### PR TITLE
changed word "algorithms" to "models"

### DIFF
--- a/contents/ml_systems/ml_systems.qmd
+++ b/contents/ml_systems/ml_systems.qmd
@@ -30,7 +30,7 @@ As we journey further into this chapter, we will demystify the intricate yet cap
 
 ## Machine Learning Systems
 
-ML is rapidly evolving, with new paradigms emerging that are reshaping how these algorithms are developed, trained, and deployed. In particular, the area of embedded machine learning is experiencing significant innovation, driven by the proliferation of smart sensors, edge devices, and microcontrollers. This chapter explores the landscape of embedded machine learning, covering the key approaches of Cloud ML, Edge ML, and TinyML (@fig-cloud-edge-tinyml-comparison).
+ML is rapidly evolving, with new paradigms emerging that are reshaping how models are developed, trained, and deployed. In particular, the area of embedded machine learning is experiencing significant innovation, driven by the proliferation of smart sensors, edge devices, and microcontrollers. This chapter explores the landscape of embedded machine learning, covering the key approaches of Cloud ML, Edge ML, and TinyML (@fig-cloud-edge-tinyml-comparison).
 
 ![Cloud vs. Edge vs. TinyML: The Spectrum of Distributed Intelligence](images/png/cloud-edge-tiny.png){#fig-cloud-edge-tinyml-comparison}
 


### PR DESCRIPTION
Although models are technically algorithms, in the field of ML the word "algorithm" generally refers to the learning algorithm that spits the model as output.

I think using algorithms as a synonym for models can confuse the reader.
