### PR TITLE
Updated dnn_architectures.qmd to fix typo in 4.1

### DIFF
--- a/contents/core/dnn_architectures/dnn_architectures.qmd
+++ b/contents/core/dnn_architectures/dnn_architectures.qmd
@@ -45,7 +45,7 @@ Most often the architectures are discussed in terms of their algorithmic structu
 3. Data movement: Requirements for on-chip and off-chip data transfer
 4. Resource utilization: How computational and memory resources are allocated
 
-For example, dense connectivity patterns generate different memory bandwidth demands than localized processing structures. Similarly, stateful processing creates distinct requirements for on-chip memory organization compared to stateless operations. Getting a firm grasph on these mappings is important for modern computer architects and system designers who must implement these algorithms efficiently in hardware.
+For example, dense connectivity patterns generate different memory bandwidth demands than localized processing structures. Similarly, stateful processing creates distinct requirements for on-chip memory organization compared to stateless operations. Getting a firm grasp on these mappings is important for modern computer architects and system designers who must implement these algorithms efficiently in hardware.
 
 ## Multi-Layer Perceptrons: Dense Pattern Processing
 


### PR DESCRIPTION
In reference to Issue #630, this pull request fixes the typo in 4.1 - "grasph" has been changed to "grasp".
