### PR TITLE
Update upload-artifact version to 4

### DIFF
--- a/.github/workflows/build_pages.yml
+++ b/.github/workflows/build_pages.yml
@@ -19,7 +19,7 @@ jobs:
         run: quarto render
       - name: Upload artifact from Ubuntu
         if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: _book-ubuntu
           path: _book

--- a/.github/workflows/build_pages_windows.yml
+++ b/.github/workflows/build_pages_windows.yml
@@ -19,7 +19,7 @@ jobs:
         run: quarto render
       - name: Upload artifact from Windows
         if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: _book-windows
           path: _book


### PR DESCRIPTION
Hotfix to update upload-artifact version from 3 to 4. 
For more details see: https://github.com/marketplace/actions/upload-a-build-artifact 
