### PR TITLE
Fix colors in code listing

### DIFF
--- a/config/tex/header-includes.tex
+++ b/config/tex/header-includes.tex
@@ -89,7 +89,6 @@ labelformat=mylabel,justification=centering,singlelinecheck=false,font={ninept}}
 \@ifpackageloaded{fancyvrb}{}{\usepackage{fancyvrb}}
 \makeatother 
 
-
 %New float "codelisting" has been updated
 \AtBeginDocument{%
 \floatstyle{ruled}
@@ -97,12 +96,44 @@ labelformat=mylabel,justification=centering,singlelinecheck=false,font={ninept}}
 \floatname{codelisting}{Listing}
 \floatplacement{codelisting}{!htb}
 \captionsetup[codelisting]{labelfont=bf,skip=-2pt,labelfont={bf,ninept},labelformat=mylabel,
-singlelinecheck=false,width=\linewidth,labelsep=none,font={ninept}}
+  singlelinecheck=false,width=\linewidth,labelsep=none,font={ninept}}%
 \renewenvironment{snugshade}{%
    \def\FrameCommand{\fboxsep=5pt\colorbox{shadecolor}}%
    \MakeFramed{\advance\hsize-\width\FrameRestore}%
-   \leftskip 0.5em \rightskip 0.5em}%
-   {\endMakeFramed}%
+   \leftskip 0.5em \rightskip 0.5em%
+   \small% decrease font size
+   }{\endMakeFramed}%
+% --- Markdown-style syntax coloring ---
+% Keywords: def, return, for, in, etc.
+\renewcommand{\KeywordTok}[1]{\textcolor[rgb]{0.73,0.48,0.84}{\textbf{#1}}}
+% Control flow: return, break, continue
+\renewcommand{\ControlFlowTok}[1]{\textcolor[rgb]{0.863,0.196,0.184}{#1}}
+% Built-in functions: range, len, zip
+\renewcommand{\BuiltInTok}[1]{\textcolor[rgb]{0.95, 0.49, 0.05}{#1}}
+% Comments
+\renewcommand{\CommentTok}[1]{\textcolor[rgb]{0.41,0.45,0.49}{#1}}
+% Strings
+\renewcommand{\StringTok}[1]{\textcolor[rgb]{0.12,0.55,0.30}{#1}}
+\renewcommand{\VerbatimStringTok}[1]{\StringTok{#1}}
+% Function names
+\renewcommand{\FunctionTok}[1]{\textcolor[rgb]{0.42,0.369,0.78}{#1}}
+% Variables
+\renewcommand{\VariableTok}[1]{\textcolor[rgb]{0.00,0.00,0.00}{#1}}
+% Numbers (constants, floats)
+\renewcommand{\FloatTok}[1]{\textcolor[rgb]{0.82,0.1,0.26}{#1}}
+\renewcommand{\DecValTok}[1]{\textcolor[rgb]{0.58, 0.00, 0.30}{#1}}
+\renewcommand{\ConstantTok}[1]{\DecValTok{#1}}
+% Operators
+\renewcommand{\OperatorTok}[1]{\textcolor[rgb]{0.10,0.10,0.10}{#1}}
+% Imports
+\renewcommand{\ImportTok}[1]{\textcolor[rgb]{0.00,0.45,0.70}{#1}}
+% Attributes (obj.attr)
+\renewcommand{\AttributeTok}[1]{\textcolor[rgb]{0.82,0.1,0.26}{#1}}
+% Errors/alerts (unused, but just in case)
+\renewcommand{\AlertTok}[1]{\textcolor[rgb]{0.75,0.00,0.00}{#1}}
+\renewcommand{\ErrorTok}[1]{\AlertTok{#1}}
+% Default
+\renewcommand{\NormalTok}[1]{\textcolor[rgb]{0.00,0.00,0.00}{#1}}
 }
 
 %The space before and after the verbatim environment "Highlighting" has been reduced
@@ -683,4 +714,4 @@ align=right,font={\fontsize{40pt}{40}\selectfont}]
 
 
 \AtBeginEnvironment{longtable}{\scriptsize} % Adjust to \footnotesize or \scriptsize if needed
-\setcounter{chapter}{0}
+\setcounter{chapter}{5}

--- a/quarto/assets/styles/style.scss
+++ b/quarto/assets/styles/style.scss
@@ -1428,68 +1428,12 @@ figcaption.quarto-float-caption-top {
 }
 
 
-
-/* Ensure code syntax highlighting works well with light background */
-.listing .sourceCode .kw,
-.listing .sourceCode .keyword {
-  color: #A51C30 !important; /* Harvard Crimson for keywords on light background */
-}
-
-.listing .sourceCode .nb,
-.listing .sourceCode .number {
-  color: #3A70B0 !important; /* Muted blue for numbers on light background */
-}
-
-.listing .sourceCode .s1,
-.listing .sourceCode .string {
-  color: #3A70B0 !important; /* Muted blue for strings on light background */
-}
-
-.listing .sourceCode .n,
-.listing .sourceCode .name {
-  color: #333333 !important; /* Neutral dark for names/variables on light background */
-}
-
-/* Additional syntax elements using the complete callout palette */
-.listing .sourceCode .o,
-.listing .sourceCode .operator {
-  color: #333333 !important; /* Neutral dark for operators on light background */
-}
-
-.listing .sourceCode .c1,
-.listing .sourceCode .comment {
-  color: #7A8899 !important; /* Cool gray for comments on light background */
-}
-
-.listing .sourceCode .k,
-.listing .sourceCode .keyword {
-  color: #A51C30 !important; /* Harvard Crimson for keywords on light background */
-}
-
-.listing .sourceCode .kt,
-.listing .sourceCode .keyword-type {
-  color: #4f7396 !important; /* Steel blue for type keywords - from callout-info */
-}
-
-.listing .sourceCode .p,
-.listing .sourceCode .punctuation {
-  color: #b8860b !important; /* Golden amber for punctuation - from callout-caution */
-}
-
-
-
 /* Override slimcontent layout to match regular floating layout */
 @media (min-width: 992px) {
   body.floating.slimcontent .page-columns {
     grid-template-columns: [screen-start] 1.5em [screen-start-inset] 5fr [page-start] minmax(25px, 50px) [page-start-inset] minmax(50px, 150px) [body-start-outset] minmax(25px, 50px) [body-start] 1.5em [body-content-start] minmax(500px, calc(800px - 3em)) [body-content-end] 1.5em [body-end] minmax(25px, 50px) [body-end-outset] minmax(50px, 150px) [page-end-inset] minmax(25px, 50px) [page-end] 5fr [screen-end-inset] 1.5em [screen-end] !important;
   }
 }
-
-
-
-
-
-
 
 /* Minimal Video Styling */
 .video-container {
@@ -1524,4 +1468,88 @@ body {
 
 .margin-video + p em::before {
   content: "Video " counter(margin-video) ": ";
+}
+
+
+/* --- Match HTML code coloring with PDF colors --- */
+
+:root {
+  --quarto-hl-kw-color: rgb(187, 124, 215) !important; /* Keywords: def, class, return, if, else, for, while, try, except */
+  --quarto-hl-cf-color: rgb(220, 50, 47) !important;   /* Control flow: return, break, continue, pass */
+  --quarto-hl-fu-color: rgb(108, 94, 200) !important;  /* Function names: __init__, forward, custom_func */
+  --quarto-hl-fl-color: rgb(209, 26, 66) !important;   /* Floating-point numbers: 3.14, 2e10 */
+  --quarto-hl-im-color: rgb(0, 115, 178) !important;   /* Imports: import, from, as */
+  --quarto-hl-bu-color: rgb(224, 102, 25) !important;  /* Built-in functions: print, len, zip, range, super, compile */
+  --quarto-hl-va-color: rgb(0, 0, 0) !important;       /* Variables: self, x, y – neutral identifiers */
+  --quarto-hl-op-color: rgb(26, 26, 26) !important;    /* Operators: =, +, -, (), :, ., [] */
+  --quarto-hl-dv-color: rgb(148, 0, 76) !important;    /* Decimal values: 42, 3.14 */
+  --quarto-hl-st-color: rgb(31, 140, 77) !important;   /* Strings: "text", 'text' */
+  --quarto-hl-co-color: rgb(105, 115, 125) !important; /* Comments: # ... */
+  --quarto-hl-at-color: rgb(209, 25, 66) !important;   /* Attributes: obj.attr */
+  --quarto-hl-er-color: rgb(191, 0, 0) !important;     /* Errors: syntax errors, exceptions */
+  --quarto-hl-nl-color: rgb(0, 0, 0)!important;        /* Normal text: default fallback */
+}
+
+.listing .sourceCode .kw,
+.listing .sourceCode .keyword {
+  color: var(--quarto-hl-kw-color) !important;
+}
+
+.listing .sourceCode .cf {
+  color: var(--quarto-hl-cf-color) !important;
+}
+
+.listing .sourceCode .fl {
+  color: var(--quarto-hl-fl-color) !important;
+}
+
+.listing .sourceCode .fu,
+.listing .sourceCode .function {
+  color: var(--quarto-hl-fu-color) !important;
+}
+
+.listing .sourceCode .im,
+.listing .sourceCode .import {
+  color: var(--quarto-hl-im-color) !important;
+}
+
+.listing .sourceCode .bu,
+.listing .sourceCode .builtin {
+  color: var(--quarto-hl-bu-color) !important;
+}
+
+.listing .sourceCode .va,
+.listing .sourceCode .variable {
+  color: var(--quarto-hl-va-color) !important;
+}
+
+.listing .sourceCode .op,
+.listing .sourceCode .operator {
+  color: var(--quarto-hl-op-color) !important;
+}
+
+.listing .sourceCode .dv {
+  color: var(--quarto-hl-dv-color) !important;
+}
+
+.listing .sourceCode .st,
+.listing .sourceCode .string {
+  color: var(--quarto-hl-st-color) !important;
+}
+
+.listing .sourceCode .co,
+.listing .sourceCode .comment {
+  color: var(--quarto-hl-co-color) !important;
+}
+
+.listing .sourceCode .at {
+  color: var(--quarto-hl-at-color) !important;
+}
+
+.listing .sourceCode .er {
+  color: var(--quarto-hl-er-color) !important;
+}
+
+.listing .sourceCode .nl {
+  color: var(--quarto-hl-nl-color) !important;
 }


### PR DESCRIPTION
Align code syntax colors with Markdown highlighting conventions and unify colors for PDF and HTML outputs.

Before submitting your Pull Request, please review and complete the items on this checklist.

- [x] The text has been proofread for grammar and spelling errors.
- [x] All images, figures, and tables render properly without any glitches.
- [x] All images have a source or they are properly linked to external sites.
- [x] The chapter's formatting is consistent with the rest of the book.
- [x] The chapter has been locally built and tested using Quarto.
