### PR TITLE
Fix example equation by adding transpose and clarify note on vector orientation (issue #974)

### DIFF
--- a/quarto/contents/core/dnn_architectures/dnn_architectures.qmd
+++ b/quarto/contents/core/dnn_architectures/dnn_architectures.qmd
@@ -245,7 +245,7 @@ local bounding box=D1,shift={($(cell-1-3A)+(-4.5,-2.6)$)}]
 
 The dimensions of these operations reveal the computational scale of dense pattern processing:
 
-* Input vector: $\mathbf{h}^{(0)} \in \mathbb{R}^{d_{\text{in}}}$ represents all potential input features
+* Input vector: $\mathbf{h}^{(0)} \in \mathbb{R}^{d_{\text{in}}}$ (treated as a row vector in this formulation) represents all potential input features
 * Weight matrices: $\mathbf{W}^{(l)} \in \mathbb{R}^{d_{\text{out}} \times d_{\text{in}}}$ capture all possible input-output relationships
 * Output vector: $\mathbf{h}^{(l)} \in \mathbb{R}^{d_{\text{out}}}$ produces transformed representations
 
@@ -258,7 +258,7 @@ Consider a simplified 4-pixel image processed by a 3-neuron hidden layer:
 
 **Computation**:
 \begin{gather*}
-\mathbf{z}^{(1)} = \mathbf{W}^{(1)}\mathbf{h}^{(0)} = \begin{bmatrix} 0.5×0.8 + (-0.3)×0.2 + 0.2×0.9 + 0.7×0.1 \\ 0.1×0.8 + 0.8×0.2 + (-0.4)×0.9 + 0.3×0.1 \\ (-0.2)×0.8 + 0.4×0.2 + 0.6×0.9 + (-0.1)×0.1 \end{bmatrix}
+\mathbf{z}^{(1)} = \mathbf{h}^{(0)T}\mathbf{W}^{(1)} = \begin{bmatrix} 0.5×0.8 + (-0.3)×0.2 + 0.2×0.9 + 0.7×0.1 \\ 0.1×0.8 + 0.8×0.2 + (-0.4)×0.9 + 0.3×0.1 \\ (-0.2)×0.8 + 0.4×0.2 + 0.6×0.9 + (-0.1)×0.1 \end{bmatrix}
 \\
 = \begin{bmatrix} 0.65 \\ -0.17 \\ 0.47 \end{bmatrix}
 \end{gather*}


### PR DESCRIPTION
This PR fixes a minor inconsistency between the layer equation and the worked example in the DNN Architectures chapter.

- Added missing transpose ^T in the example computation
- Added clarification note on input vector orientation

These updates improve notation consistency without changing mathematical meaning.

Resolves #974
