### PR TITLE
Fix: correct CNN architecture question option order (issue #976)

### DIFF
--- a/quarto/contents/core/dnn_architectures/dnn_architectures_quizzes.json
+++ b/quarto/contents/core/dnn_architectures/dnn_architectures_quizzes.json
@@ -145,10 +145,10 @@
             "choices": [
               "Global connectivity",
               "Parameter sharing",
-              "Both B and C",
+              "Both B and D",
               "Local connectivity"
             ],
-            "answer": "The correct answer is C. Both B and C. CNNs use parameter sharing and local connectivity to efficiently process spatially structured data, reducing the number of parameters and focusing on local spatial relationships.",
+            "answer": "The correct answer is C. Both B and D. CNNs use parameter sharing and local connectivity to efficiently process spatially structured data, reducing the number of parameters and focusing on local spatial relationships.",
             "learning_objective": "Understand the architectural features that enable CNNs to efficiently handle spatial data."
           },
           {


### PR DESCRIPTION
### Summary
Fixed typo in the CNN architectural features question.

### Changes
- Updated answer text from “Both B and C” → “Both B and D”.
- Updated explanation accordingly.