### PR TITLE
Fix dark mode stylings for callout examples

### DIFF
--- a/quarto/_extensions/mlsysbook-ext/custom-numbered-blocks/style/foldbox.css
+++ b/quarto/_extensions/mlsysbook-ext/custom-numbered-blocks/style/foldbox.css
@@ -261,6 +261,14 @@ details.fbx-question > div {
     --title-background-color: rgba(60, 72, 88, 0.12);
   }
 
+  details.callout-example summary {
+    color: #454d55; /* Darker text for better contrast */
+   }
+
+  details.callout-example code {
+    color: var(--text-color);
+  }
+
   /* Dark content backgrounds */
   details.fbx-default > div,
   details.fbx-answer > div,


### PR DESCRIPTION
# Overview

Issue: https://github.com/harvard-edge/cs249r_book/issues/990

The site seems to use a small subset of dark mode stylings in certain places. One place is in the callouts. When using dark mode, it is impossible to read the text as it is being inherited from an upstream CSS var.

| Light | Dark |
|--------|--------|
| <img width="718" height="329" alt="Screenshot 2025-10-24 at 16 43 23" src="https://github.com/user-attachments/assets/cd43de35-55fe-48d8-93c8-5b90ec8c30d5" /> | <img width="718" height="329" alt="Screenshot 2025-10-24 at 16 43 16" src="https://github.com/user-attachments/assets/52a2be93-8350-4b1c-add2-443cfdf0be51" /> |



I have updated it so that it is readable. I kept it as a very simple change as it seems dark mode isn't really properly supported in this project so it's really just a small workaround to make things readable for now.

# Testing

Build the introduction page, open it then using dev tools find the `Rendering` tab and toggle theme using `Emulate CSS media feature prefers-color-schem`.

**Light mode**

<img width="718" height="329" alt="Screenshot 2025-10-24 at 16 43 51" src="https://github.com/user-attachments/assets/aff10b59-91f1-4454-bc3a-066d549bd476" />

**Dark mode**

<img width="718" height="329" alt="Screenshot 2025-10-24 at 16 43 55" src="https://github.com/user-attachments/assets/368998f6-8b00-45f8-bcaa-cace85119aad" />

**Checklist**

- [X] The text has been proofread for grammar and spelling errors.
- [X] All images, figures, and tables render properly without any glitches.
- [X] All images have a source or they are properly linked to external sites.
- [X] The chapter's formatting is consistent with the rest of the book.
- [X] The chapter has been locally built and tested using Quarto.