### PR TITLE
Fix link to ML kits

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Thank you for being a part of the story 🙏
 
 1. Read [Chapter 1](https://www.mlsysbook.ai/contents/core/introduction/introduction.html) and the overview.
 2. Skim the [Benchmarking chapter](https://mlsysbook.ai/contents/core/benchmarking/benchmarking.html) to know what to measure.
-3. Pick a [TinyML kit](https://www.mlsysbook.ai/contents/labs/shared/kits.html) and run a lab.
+3. Pick a [TinyML kit](https://www.mlsysbook.ai/contents/labs/kits.html) and run a lab.
 4. Say hello in [Introduce Yourself](https://github.com/harvard-edge/cs249r_book/discussions). I will do my best to reply.
 
 ## 📚 What You Will Learn


### PR DESCRIPTION
The README contains a non-existent link to the hardware kits. I have updated it to point to the appropriate page. It also fixes a link to TinyTorch.

Issue: https://github.com/harvard-edge/cs249r_book/issues/998

Before submitting your Pull Request, please review and complete the items on this checklist.

- [x] The text has been proofread for grammar and spelling errors.
- [x] All images, figures, and tables render properly without any glitches.
- [x] All images have a source or they are properly linked to external sites.
- [x] The chapter's formatting is consistent with the rest of the book.
- [x] The chapter has been locally built and tested using Quarto.
