### PR TITLE
fix(epub): ensure XHTML compliance in index.qmd

### DIFF
--- a/quarto/index.qmd
+++ b/quarto/index.qmd
@@ -14,7 +14,7 @@ format:
 
 # Abstract {.unnumbered}
 
-::: {.content-visible when-format="html"}
+::: {.content-visible when-format="html:js"}
 ```{=html}
 <div class="abstract-section">
   <div class="abstract-content">
@@ -23,7 +23,7 @@ format:
   
   <a href="assets/downloads/Machine-Learning-Systems.pdf" target="_blank" class="book-card-link" title="Download PDF version">
     <div class="book-card">
-      <img src="assets/images/covers/cover-hardcover-book.png" alt="Machine Learning Systems Book Cover" class="book-image">
+      <img src="assets/images/covers/cover-hardcover-book.png" alt="Machine Learning Systems Book Cover" class="book-image" />
       <p class="book-title">Early Access Preview</p>
       <p class="book-subtitle">Publisher: The MIT Press (2026)</p>
       <p style="font-size: 0.8em; color: #6c757d; margin-top: 6px; margin-bottom: 0;">📖 Click here to download PDF</p>
@@ -124,8 +124,8 @@ Want the full story? Read our [Author's Note](contents/frontmatter/foreword.qmd)
   <p>
     This short podcast, created with Google's Notebook LM and inspired by insights from our <a href="https://web.eng.fiu.edu/gaquan/Papers/ESWEEK24Papers/CPS-Proceedings/pdfs/CODES-ISSS/563900a043/563900a043.pdf" target="_blank" rel="noopener">IEEE education viewpoint paper</a>, offers an accessible overview of the book's key ideas and themes.
   </p>
-  <audio controls>
-    <source src="assets/media/notebooklm_podcast_mlsysbookai.mp3" type="audio/mpeg">
+  <audio controls="controls">
+    <source src="assets/media/notebooklm_podcast_mlsysbookai.mp3" type="audio/mpeg" />
     Your browser does not support the audio element.
   </audio>
 </div>


### PR DESCRIPTION
## Summary
Fixes EPUB rendering errors caused by non-XHTML compliant HTML tags in index.qmd.

## Changes
- Self-closed img tag for XHTML compliance
- Added explicit value for controls attribute on audio element  
- Self-closed source tag for XHTML compliance
- Changed content-visible condition from html to html:js to prevent HTML-specific interactive content from appearing in EPUB output

## Testing
- ✅ EPUB builds successfully without XHTML parsing errors
- ✅ Pre-commit hooks pass

Closes #1014

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `quarto/index.qmd` for EPUB-safe XHTML (self-closing tags, explicit audio controls) and restricts interactive HTML to `html:js`.
> 
> - **EPUB/XHTML compliance**
>   - Self-close `img` and `source` tags in `quarto/index.qmd`.
>   - Use explicit `controls="controls"` on `<audio>`.
> - **Rendering/visibility**
>   - Change `content-visible` condition from `when-format="html"` to `when-format="html:js"` for the abstract block to prevent interactive HTML from appearing in non-HTML outputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4dd4e136a35e577cdefad0618d1fea043b015ca3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->