### PR TITLE
Fixes a typo in Figure 2.1 node label

### DIFF
--- a/quarto/contents/core/ml_systems/ml_systems.qmd
+++ b/quarto/contents/core/ml_systems/ml_systems.qmd
@@ -207,7 +207,7 @@ pics/mobile/.style = {
 \node[above=0 of CP,align=center]{Ultra Low Powered\\Devices and Sensors};
 \node[draw=none,fill=green!70,,circle,minimum size=20mm](MO)at(T1){};
  \pic[shift={(0,0)}] at (T1) {mobile};
- \node[above=0 of MO,align=center]{Intellignet\\Device};
+ \node[above=0 of MO,align=center]{Intelligent\\Device};
 \node[draw=none,fill=cyan,circle,minimum size=20mm](SE)at(T3){};
 \pic[shift={(-0.03,0.1)}] at (T3) {server};
  \node[above=0 of SE,align=center]{On Premise\\Servers};


### PR DESCRIPTION
Corrects the spelling of "Intelligent" in the "Intelligent Device" node label within the TikZ diagram.

Closes #1024

Co-authored-by: jianqingdu <jianqing.du@live.cn>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects the "Intelligent Device" node label spelling in `quarto/contents/core/ml_systems/ml_systems.qmd` TikZ figure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b76522077710e8ee3c96885a60651414c10530c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->