### PR TITLE
Adding Star History chart at bottom of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,3 +365,7 @@ Thanks goes to these wonderful people who have contributed to making this resour
 
 Our goal is to educate 1 million AI systems engineers for the future at the edge of AI.
 </div>
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=harvard-edge/cs249r_book&type=date&legend=top-left)](https://www.star-history.com/#harvard-edge/cs249r_book&type=date&legend=top-left)


### PR DESCRIPTION
Hi,

Adding star-history chart at bottom of README. It should look like picture below

For all details, see https://www.star-history.com/#harvard-edge/cs249r_book&type=date&legend=top-left

<img width="935" height="706" alt="image" src="https://github.com/user-attachments/assets/fb6d92dd-7b90-40af-b218-476d5c7f65e1" />

Cheers,
Didier
