### PR TITLE
[Doc] removed all remaining 'teeths'

### DIFF
--- a/quarto/contents/core/data_engineering/data_engineering.qmd
+++ b/quarto/contents/core/data_engineering/data_engineering.qmd
@@ -2171,7 +2171,7 @@ Our KWS system exemplifies governance challenges that arise when sophisticated s
 \resizebox{.8\textwidth}{!}{
 \begin{tikzpicture}[line join=round,font=\usefont{T1}{phv}{m}{n}]
 %Gear style
-% #1 number of teeths
+% #1 number of teeth
 % #2 radius intern
 % #3 radius extern
 % #4 angle from start to end of the first arc

--- a/quarto/contents/core/frontiers/frontiers.qmd
+++ b/quarto/contents/core/frontiers/frontiers.qmd
@@ -1545,7 +1545,7 @@ pics/stit/.style = {
   }
 }
 %gear
-% #1 number of teeths
+% #1 number of teeth
 % #2 radius intern
 % #3 radius extern
 % #4 angle from start to end of the first arc

--- a/quarto/contents/core/ops/ops.qmd
+++ b/quarto/contents/core/ops/ops.qmd
@@ -1281,7 +1281,7 @@ The operational frameworks, infrastructure components, and governance practices 
 ```{.tikz}
 \begin{tikzpicture}[line join=round,font=\small\usefont{T1}{phv}{m}{n}]
 \definecolor{Siva}{RGB}{161,152,130}
-% #1 number of teeths
+% #1 number of teeth
 % #2 radius intern
 % #3 radius extern
 % #4 angle from start to end of the first arc

--- a/quarto/contents/core/optimizations/optimizations.qmd
+++ b/quarto/contents/core/optimizations/optimizations.qmd
@@ -1470,7 +1470,7 @@ arc[radius=0.53*\ra, start angle=245, end angle= 290];
 %%top
 \begin{scope}[local bounding box=GEAR,shift={($(90: 0.5*\ra)+(0,-0.75)$)},
 scale=1.0, every node/.append style={transform shape}]
-% #1 number of teeths
+% #1 number of teeth
 % #2 radius intern
 % #3 radius extern
 % #4 angle from start to end of the first arc

--- a/quarto/contents/core/robust_ai/robust_ai.qmd
+++ b/quarto/contents/core/robust_ai/robust_ai.qmd
@@ -1827,7 +1827,7 @@ LineA/.style={violet!80!black!50,line width=3pt,shorten <=2pt,shorten >=2pt,{{Tr
 Line/.style={violet!80!black!50,line width=2pt,shorten <=2pt,shorten >=10pt}
 }
 %Gear
-% #1 number of teeths
+% #1 number of teeth
 % #2 radius intern
 % #3 radius extern
 % #4 angle from start to end of the first arc
@@ -2092,7 +2092,7 @@ Online learning systems represent another unique attack surface. These systems c
     Line/.style={line width=1.0pt,Violet,text=black},
     DLine/.style={dashed,line width=1.0pt,Violet,text=black}
 }
-% #1 number of teeths
+% #1 number of teeth
 % #2 radius intern
 % #3 radius extern
 % #4 angle from start to end of the first arc
@@ -3287,7 +3287,7 @@ Larrow/.style={fill=orange, single arrow,  inner sep=2pt, single arrow head exte
             single arrow head indent=0pt,minimum height=6mm, minimum width=3pt}
 }
 %Gear style
-% #1 number of teeths
+% #1 number of teeth
 % #2 radius intern
 % #3 radius extern
 % #4 angle from start to end of the first arc


### PR DESCRIPTION
Hi,
As per title: searched for all remaining instances of incorrect `teeths` and fixed them
Best,
Didier