### PR TITLE
[Doc] fixing incorrect sample code

### DIFF
--- a/quarto/contents/labs/shared/dsp_spectral_features_block/dsp_spectral_features_block.qmd
+++ b/quarto/contents/labs/shared/dsp_spectral_features_block/dsp_spectral_features_block.qmd
@@ -379,9 +379,9 @@ def welch_max_hold(fx, sampling_freq, nfft, n_overlap):
 Applying the above function to 3 signals:
 
 ``` python
-fax,Pax = welch_max_hold(accX, fs, FFT_Lenght, 0)
-fay,Pay = welch_max_hold(accY, fs, FFT_Lenght, 0)
-faz,Paz = welch_max_hold(accZ, fs, FFT_Lenght, 0)
+fax,Pax = welch_max_hold(accX, fs, FFT_Length, 0)
+fay,Pay = welch_max_hold(accY, fs, FFT_Length, 0)
+faz,Paz = welch_max_hold(accZ, fs, FFT_Length, 0)
 specs = [Pax, Pay, Paz ]
 ```
 


### PR DESCRIPTION
Hi,
Fixing some incorrect sample code: FFT_Length (without fixed typo) is defined in previous code section at line #125.
Didier