### PR TITLE
[Doc] removing duplicate on Moore's Law in glossary

### DIFF
--- a/quarto/contents/backmatter/glossary/glossary.qmd
+++ b/quarto/contents/backmatter/glossary/glossary.qmd
@@ -1680,11 +1680,8 @@ This comprehensive glossary contains definitions of key terms used throughout th
   *Appears in: @sec-robust-ai*
 
 **moore's law**
-: The observation that the number of transistors on a microchip doubles approximately every two years while the cost of computers is halved.
+: The observation that the number of transistors on a microchip doubles approximately every two years while the cost of computers is halved. It was made by Intel co-founder Gordon Moore in 1965. Hardware improvements follow this trend while AI algorithmic efficiency improved 44× in 7 years.
   *Appears in: @sec-sustainable-ai*
-
-**moores law**
-: Intel co-founder Gordon Moore's 1965 observation that transistor density doubles every 2 years, with hardware improvements following this trend while AI algorithmic efficiency improved 44× in 7 years.
   *Appears in: @sec-efficient-ai*
 
 **multi-agent approach**


### PR DESCRIPTION
Hi,
Tried to fix manually a duplicate in Glossary. 
It may be generated automatically but I couldn't find the code generating the issue.

The root cause seems to be the initial different spellings of moore's law

Let me know if you want me to fix the proposed text.

Cheers
Didier