### PR TITLE
[Doc] Hyperlink to non-existing file removed

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -536,7 +536,6 @@ If you're still having issues:
 3. **Consult documentation**:
    - [BINDER.md](BINDER.md) - Binder CLI guide
    - [DEVELOPMENT.md](DEVELOPMENT.md) - Development setup
-   - [MAINTENANCE_GUIDE.md](MAINTENANCE_GUIDE.md) - Maintenance tasks
 4. **Ask for help**:
    - GitHub Discussions: https://github.com/harvard-edge/cs249r_book/discussions
    - GitHub Issues: https://github.com/harvard-edge/cs249r_book/issues


### PR DESCRIPTION
Hi,
Removed link to MAINTENANCE_GUIDE.md which seems to have been removed.
Let me if I should replace it by something else: didn't find anything close.
Didier