### PR TITLE
[CI] fixing workflow failing on fork sync

### DIFF
--- a/.github/workflows/book-validate-dev.yml
+++ b/.github/workflows/book-validate-dev.yml
@@ -84,7 +84,8 @@ jobs:
   pre-commit:
     name: '🔍 Pre-commit Checks'
     runs-on: ubuntu-latest
-    
+    if: github.repository_owner == 'harvard-edge'
+
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Hi,

When syncing the fork with the master repo: this workflow book-validate-dev starts automatically and fails on the fork.
Added the usual if condition to block if not on master repo

Didier