### PR TITLE
Security: mitigate shell injection in build-baremetal

### DIFF
--- a/.github/workflows/book-build-baremetal.yml
+++ b/.github/workflows/book-build-baremetal.yml
@@ -1159,10 +1159,11 @@ jobs:
         if: matrix.enabled
         id: build-declaration
         shell: bash
+        env:
+          ARTIFACT_NAME_RAW: ${{ inputs.artifact_name != '' && format('{0}-{1}-{2}', inputs.artifact_name, matrix.os_name, matrix.format) || format('build-{0}-{1}-{2}', inputs.target, matrix.os_name, matrix.format) }}
         run: |
-          ARTIFACT_NAME="${{ inputs.artifact_name != '' && format('{0}-{1}-{2}', inputs.artifact_name, matrix.os_name, matrix.format) || format('build-{0}-{1}-{2}', inputs.target, matrix.os_name, matrix.format) }}"
-          echo "📦 Build Declaration: Successfully created artifact '$ARTIFACT_NAME'"
-          echo "artifact_name=$ARTIFACT_NAME" >> $GITHUB_OUTPUT
+          echo "📦 Build Declaration: Successfully created artifact '$ARTIFACT_NAME_RAW'"
+          echo "artifact_name=$ARTIFACT_NAME_RAW" >> $GITHUB_OUTPUT
 
       - name: 📤 Upload build artifacts
         if: matrix.enabled


### PR DESCRIPTION
Move artifact name evaluation to `env` context.

Interpolating `inputs.artifact_name` directly into the shell script is unsafe as it allows for potential command injection. By using an intermediate environment variable, the value is handled as data rather than executable code during shell expansion.