### PR TITLE
Fix navbar overflow by adjusting collapse breakpoint

### DIFF
--- a/book/quarto/config/_quarto-html.yml
+++ b/book/quarto/config/_quarto-html.yml
@@ -75,7 +75,7 @@ website:
     search: true
     pinned: true
     collapse: true
-    collapse-below: "md"
+    collapse-below: "lg"
     title: "Machine Learning Systems"
     left:
       - text: "Textbook"


### PR DESCRIPTION
### What this PR does
Fixes an issue where navbar items overflow and are partially hidden on medium-width screens by adjusting the collapse breakpoint.

### Changes
- Collapse navbar earlier to prevent clipping
- Fix minor target attribute typo

### Screenshots
Before / After (optional but recommended)

### Related issue
Fixes #1095
