### PR TITLE
Update Broken PDF Link in README.md #1100

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   <!-- Reader Navigation -->
   **[📖 Read Online](https://mlsysbook.ai)** •
   **[Tiny🔥Torch](https://mlsysbook.ai/tinytorch)** •
-  **[📄 Download PDF](https://mlsysbook.ai/pdf)** •
+  **[📄 Download PDF](https://mlsysbook.ai/assets/downloads/Machine-Learning-Systems.pdf)** •
   **[📓 Download EPUB](https://mlsysbook.ai/epub)** •
   **[🌐 Explore Ecosystem](https://mlsysbook.org)**
 


### PR DESCRIPTION
# Fix broken PDF download link _(Fixes #1100)_.

## Problem:
When I click on Download PDF version on `README.md` the content returned is that of *ePUB* from the canonical PDF URL https://mlsysbook.ai/pdf

## Solution(s)

1. Update current broken link to actual resource location - https://mlsysbook.ai/assets/downloads/Machine-Learning-Systems.pdf
2. Fix canonical download location to actually download *PDF* _(https://mlsysbook.ai/pdf)_ document in lieu of *epub* _(https://mlsysbook.ai/epub)_ 

###References
- PDF Download - https://mlsysbook.ai/assets/downloads/Machine-Learning-Systems.pdf