### PR TITLE
Fix: Add requires_grad parameter to Tensor.__init__ for Linear layer compatibility

### DIFF
--- a/tinytorch/src/01_tensor/01_tensor.py
+++ b/tinytorch/src/01_tensor/01_tensor.py
@@ -267,7 +267,7 @@ class Tensor:
     All arithmetic, matrix, and shape operations are built on this foundation.
     """
 
-    def __init__(self, data):
+    def __init__(self, data, requires_grad=False):
         """Create a new tensor from data.
 
         TODO: Initialize a Tensor by wrapping data in a NumPy array and setting attributes.
@@ -293,6 +293,7 @@ class Tensor:
         self.shape = self.data.shape
         self.size = self.data.size
         self.dtype = self.data.dtype
+        self.requires_grad = requires_grad
         ### END SOLUTION
 
     def __repr__(self):


### PR DESCRIPTION
- Added `requires_grad` parameter to `Tensor.__init__` in `tinytorch/src/01_tensor/01_tensor.py`
- Fixes TypeError caused by `Tensor(weight_data, requires_grad=True)` in Linear layer
- Ensures compatibility with autograd flag usage across activation and layer modules
- Tested locally: Linear layer unit test passes after this change
