### PR TITLE
Patch tinytorch installer script for Windows-Unix Support

### DIFF
--- a/tinytorch/.gitattributes
+++ b/tinytorch/.gitattributes
@@ -7,3 +7,5 @@ tinytorch/core/*.py -diff
 *.zip filter=lfs diff=lfs merge=lfs -text
 *.pkl filter=lfs diff=lfs merge=lfs -text
 *.bin filter=lfs diff=lfs merge=lfs -text
+# Set default line termination behavior for all text files
+* text=auto


### PR DESCRIPTION
This pull request proposes an enhancement to the installer Bash script, thus, in a way addresses #1078 as well as follows up on #1083 .

First of all the enhancement to this script assumes the user will run it on a UNIX environment, thus, for Windows users in particular, running using Git Bash or WSL should work just fine. As I have noticed, the painpoint in the original `install.sh` script emanates from the differences in setting up virtual environments between UNIX and Windows. 

The proposed modification checks the platform before use to dynamically determine how the virtual environment must be setup, on the other hand, it forces the setup to use the Python executable defined within the scope of the virtual environment.