### PR TITLE
fix: miscellaneous fix for Tokenizer

### DIFF
--- a/tinytorch/src/10_tokenization/10_tokenization.py
+++ b/tinytorch/src/10_tokenization/10_tokenization.py
@@ -15,11 +15,10 @@
 #| default_exp core.tokenization
 #| export
 
+from collections import Counter
+from typing import Dict, List, Optional, Set, Tuple
+
 import numpy as np
-from typing import List, Dict, Tuple, Optional, Set
-import json
-import re
-from collections import defaultdict, Counter
 
 # %% [markdown]
 """
@@ -87,7 +86,6 @@ from tinytorch.core.tokenization import Tokenizer, CharTokenizer, BPETokenizer
 #| export
 # Import from TinyTorch package (Module 01 must be completed before Module 10)
 # Note: Tokenization primarily works with Python lists, but Tensor is available for advanced features
-from tinytorch.core.tensor import Tensor
 
 # Constants for memory calculations
 KB_TO_BYTES = 1024  # Kilobytes to bytes conversion
@@ -448,7 +446,7 @@ class CharTokenizer(Tokenizer):
             all_chars.update(text)
 
         # Sort for consistent ordering
-        unique_chars = sorted(list(all_chars))
+        unique_chars = sorted(all_chars)
 
         # Rebuild vocabulary with <UNK> token first
         self.vocab = ['<UNK>'] + unique_chars
@@ -730,7 +728,7 @@ class BPETokenizer(Tokenizer):
         return pairs
         ### END SOLUTION
 
-    def train(self, corpus: List[str], vocab_size: int = None) -> None:
+    def train(self, corpus: List[str], vocab_size: int) -> None:
         """
         Train BPE on corpus to learn merge rules.
 
@@ -772,10 +770,10 @@ class BPETokenizer(Tokenizer):
             vocab.update(tokens)
 
         # Convert to sorted list for consistency
-        self.vocab = sorted(list(vocab))
+        self.vocab = sorted(vocab)
 
         # Add special tokens
-        if '<UNK>' not in self.vocab:
+        if '<UNK>' not in vocab:
             self.vocab = ['<UNK>'] + self.vocab
 
         # Learn merges


### PR DESCRIPTION
The Pull Request contains several miscellaneous fix for the Tokenizer module implementation:
- When checking whether "<UNK>" exists in the vocab list that the user passes in, we should use `vocab` (which is a set) instead of `self.vocab` (which is a list) for O(1) lookup.
- `sorted(...)` function accept an iterable and returns a list, so we don't need to convert a Python set to a Python list before passing it to `sorted`.