### PR TITLE
fix: fix memory calculation result

### DIFF
--- a/tinytorch/src/01_tensor/ABOUT.md
+++ b/tinytorch/src/01_tensor/ABOUT.md
@@ -542,7 +542,7 @@ A batch of 32 RGB images (224×224 pixels) stored as float32. How much memory?
 ```{admonition} Answer
 :class: dropdown
 
-32 × 3 × 224 × 224 × 4 = **77,070,336 bytes ≈ 77 MB**
+32 × 3 × 224 × 224 × 4 = **19,267,584 bytes ≈ 19.3 MB**
 
 This is why batch size matters - double the batch, double the memory!
 ```


### PR DESCRIPTION
The current result is multiplied by 4 twice since 32 × 3 × 224 × 224 × 4 x 4 = 77,070,336, which is incorrect.