### PR TITLE
fix: matmul should not allow 0D tensors

### DIFF
--- a/tinytorch/src/01_tensor/01_tensor.py
+++ b/tinytorch/src/01_tensor/01_tensor.py
@@ -454,10 +454,8 @@ class Tensor:
         ### BEGIN SOLUTION
         if not isinstance(other, Tensor):
             raise TypeError(f"Expected Tensor for matrix multiplication, got {type(other)}")
-        if self.shape == () or other.shape == ():
-            return Tensor(self.data * other.data)
         if len(self.shape) == 0 or len(other.shape) == 0:
-            return Tensor(self.data * other.data)
+            raise ValueError("Both arguments to matmul need to be at least 1D, but one is 0D")
         if len(self.shape) >= 2 and len(other.shape) >= 2:
             if self.shape[-1] != other.shape[-2]:
                 raise ValueError(
@@ -1392,7 +1390,7 @@ def analyze_memory_layout():
         row_sums.append(row_sum)
     row_time = time.time() - start
     print(f"   Time: {row_time*1000:.1f}ms")
-    print(f"   Access pattern: Sequential (follows memory layout)")
+    print("   Access pattern: Sequential (follows memory layout)")
 
     # Test 2: Column-wise access (cache-unfriendly)
     # Must jump between rows, poor spatial locality
@@ -1409,22 +1407,22 @@ def analyze_memory_layout():
     # Calculate slowdown
     slowdown = col_time / row_time
     print("\n" + "=" * 60)
-    print(f"📊 PERFORMANCE IMPACT:")
+    print("📊 PERFORMANCE IMPACT:")
     print(f"   Slowdown factor: {slowdown:.2f}× ({col_time/row_time:.1f}× slower)")
     print(f"   Cache misses cause {(slowdown-1)*100:.0f}% performance loss")
 
     # Educational insights
     print("\n💡 KEY INSIGHTS:")
-    print(f"   1. Memory layout matters: Row-major (C-style) storage is sequential")
-    print(f"   2. Cache lines are ~64 bytes: Row access loads nearby elements \"for free\"")
-    print(f"   3. Column access misses cache: Must reload from DRAM every time")
+    print("   1. Memory layout matters: Row-major (C-style) storage is sequential")
+    print("   2. Cache lines are ~64 bytes: Row access loads nearby elements \"for free\"")
+    print("   3. Column access misses cache: Must reload from DRAM every time")
     print(f"   4. This is O(n) algorithm but {slowdown:.1f}× different wall-clock time!")
 
     print("\n🚀 REAL-WORLD IMPLICATIONS:")
-    print(f"   • CNNs use NCHW format (channels sequential) for cache efficiency")
-    print(f"   • Matrix multiplication optimized with blocking (tile into cache-sized chunks)")
+    print("   • CNNs use NCHW format (channels sequential) for cache efficiency")
+    print("   • Matrix multiplication optimized with blocking (tile into cache-sized chunks)")
     print(f"   • Transpose is expensive ({slowdown:.1f}×) because it changes memory layout")
-    print(f"   • This is why GPU frameworks obsess over memory coalescing")
+    print("   • This is why GPU frameworks obsess over memory coalescing")
 
     print("\n" + "=" * 60)
 


### PR DESCRIPTION
Both NumPy and PyTorch do not allow operands of the matmul operation to be 0D tensors. To make TinyTorch achieve the same functionality as PyTorch, the method matmul should raise error when it receives a 0D tensor. For 0D tensor multiplication, users should use element-wise multiplication `*`.

All Tensor module tests pass and there is no regression.