### PR TITLE
Remove unused next_functions from Function class

### DIFF
--- a/tinytorch/src/06_autograd/06_autograd.py
+++ b/tinytorch/src/06_autograd/06_autograd.py
@@ -240,7 +240,6 @@ class Function:
     **Key Concepts:**
     - **saved_tensors**: Store inputs needed for backward pass
     - **apply()**: Compute gradients using chain rule
-    - **next_functions**: Track computation graph connections
 
     **Example Usage:**
     ```python
@@ -259,15 +258,6 @@ class Function:
             *tensors: Input tensors that will be saved for backward pass
         """
         self.saved_tensors = tensors
-        self.next_functions = []
-
-        # Build computation graph connections
-        for t in tensors:
-            if isinstance(t, Tensor) and t.requires_grad:
-                # Check if this tensor was created by another operation
-                # _grad_fn is only present if autograd is enabled and tensor came from an operation
-                if getattr(t, '_grad_fn', None) is not None:
-                    self.next_functions.append(t._grad_fn)
 
     def apply(self, grad_output):
         """


### PR DESCRIPTION
## Summary

Removes the unused next_functions attribute from the Function class in the autograd module. This attribute was declared and populated but never actually used in the backward pass.

## Context

This addresses the question raised in #1122 by @AmirAlasady, who correctly identified that self.next_functions is declared but never used. The backward() method uses saved_tensors directly to propagate gradients, making next_functions dead code.

## Why remove it

1. Reduces confusion for students trying to understand the code
2. The recursive backward approach using saved_tensors is simpler to follow
3. The docstring incorrectly listed next_functions as a key concept

## Testing

- All 9 tests in tests/06_autograd/test_autograd_core.py pass
- Integration test passes