### PR TITLE
Add TinyTorch-specific contributor recognition

### DIFF
--- a/tinytorch/.all-contributorsrc
+++ b/tinytorch/.all-contributorsrc
@@ -1,0 +1,24 @@
+{
+    "projectName": "TinyTorch",
+    "projectOwner": "harvard-edge",
+    "files": [
+        "README.md"
+    ],
+    "imageSize": 80,
+    "commit": false,
+    "commitConvention": "angular",
+    "contributors": [
+        {
+            "login": "AmirAlasady",
+            "name": "Amir Alasady",
+            "avatar_url": "https://avatars.githubusercontent.com/AmirAlasady",
+            "profile": "https://github.com/AmirAlasady",
+            "contributions": ["bug"]
+        }
+    ],
+    "contributorsPerLine": 7,
+    "linkToUsage": false,
+    "repoType": "github",
+    "repoHost": "https://github.com",
+    "skipCi": true
+}

--- a/tinytorch/README.md
+++ b/tinytorch/README.md
@@ -255,11 +255,33 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ---
 
+## Community Contributors
+
+Thanks to these amazing people who helped improve TinyTorch! ([emoji key](https://allcontributors.org/docs/en/emoji-key))
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/AmirAlasady"><img src="https://avatars.githubusercontent.com/AmirAlasady?v=4?s=80" width="80px;" alt="Amir Alasady"/><br /><sub><b>Amir Alasady</b></sub></a><br /><a href="https://github.com/harvard-edge/cs249r_book/issues?q=author%3AAmirAlasady" title="Bug reports">🐛</a></td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+Want to contribute? Check out our [Contributing Guide](CONTRIBUTING.md) or [open a discussion](https://github.com/harvard-edge/cs249r_book/discussions)!
+
+---
+
 ## Acknowledgments
 
 Created by [Prof. Vijay Janapa Reddi](https://vijay.seas.harvard.edu) at Harvard University.
-
-Special thanks to students and contributors who helped build this framework.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a dedicated contributor recognition system for TinyTorch, separate from the main book.

## Changes

- Created `tinytorch/.all-contributorsrc` for TinyTorch-specific tracking
- Added "Community Contributors" section to TinyTorch README with All Contributors format
- Added @AmirAlasady as the first community contributor for identifying dead code in #1122

## Why separate from the book?

TinyTorch has different contribution types relevant to a framework:
- Bug reports (like #1122)
- Code contributions
- Ideas and suggestions
- Documentation

This allows more granular recognition for TinyTorch contributors while keeping the main book contributors list focused on book content.

## How to add new contributors

Comment on any issue/PR:
```
@all-contributors please add @username for bug
```

Or manually edit `tinytorch/.all-contributorsrc` and regenerate the table.