### PR TITLE
fix: no need to clip input value of Sigmoid

### DIFF
--- a/tinytorch/src/02_activations/02_activations.py
+++ b/tinytorch/src/02_activations/02_activations.py
@@ -240,23 +240,21 @@ class Sigmoid:
         """
         ### BEGIN SOLUTION
         # Apply sigmoid: 1 / (1 + exp(-x))
-        # Clip extreme values to prevent overflow (sigmoid(-500) ≈ 0, sigmoid(500) ≈ 1)
-        # Clipping at ±500 ensures exp() stays within float64 range
-        z = np.clip(x.data, -500, 500)
+        x_data = x.data
 
         # Use numerically stable sigmoid
         # For positive values: 1 / (1 + exp(-x))
         # For negative values: exp(x) / (1 + exp(x)) = 1 / (1 + exp(-x)) after clipping
-        result_data = np.zeros_like(z)
+        result_data = np.zeros_like(x_data)
 
         # Positive values (including zero)
-        pos_mask = z >= 0
-        result_data[pos_mask] = 1.0 / (1.0 + np.exp(-z[pos_mask]))
+        pos_mask = x_data >= 0
+        result_data[pos_mask] = 1.0 / (1.0 + np.exp(-x_data[pos_mask]))
 
         # Negative values
-        neg_mask = z < 0
-        exp_z = np.exp(z[neg_mask])
-        result_data[neg_mask] = exp_z / (1.0 + exp_z)
+        neg_mask = x_data < 0
+        exp_x = np.exp(x_data[neg_mask])
+        result_data[neg_mask] = exp_x / (1.0 + exp_x)
 
         return Tensor(result_data)
         ### END SOLUTION


### PR DESCRIPTION
The code already handles overflow by splitting the input into positive and negative branches:
- For x >= 0, computing e^(-x) will not result in overflow even though x is very large.
- For x < 0, computing e^(x) will comfortably range between 0 and 1.