### PR TITLE
fix(ci): auto-label permissions for fork PRs

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -18,7 +18,7 @@ name: '🏷️ Auto Label'
 on:
   issues:
     types: [opened]
-  pull_request:
+  pull_request_target:
     types: [opened]
   # Manual trigger for testing on existing issues/PRs
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Switch `pull_request` → `pull_request_target` in auto-label workflow
- Fixes 403 "Resource not accessible by integration" when labeling fork PRs ([failed run](https://github.com/harvard-edge/cs249r_book/actions/runs/21643621058))

## Root cause
GitHub downgrades `GITHUB_TOKEN` to read-only for `pull_request` events from forks. `pull_request_target` runs in the base repo context, granting the declared `issues: write` and `pull-requests: write` permissions.