### PR TITLE
fix(activations): correct GELU hint about 1.702 constant

### DIFF
--- a/tinytorch/src/02_activations/02_activations.py
+++ b/tinytorch/src/02_activations/02_activations.py
@@ -615,7 +615,7 @@ class GELU:
         >>> print(result.data)
         [-0.159, 0.0, 0.841]  # Smooth, like ReLU but differentiable everywhere
 
-        HINT: The 1.702 constant comes from √(2/π) approximation
+        HINT: The 1.702 constant is empirically fitted so that sigmoid(1.702x) ≈ Φ(x)
         """
         ### BEGIN SOLUTION
         # GELU approximation: x * sigmoid(1.702 * x)


### PR DESCRIPTION
## Summary
- Fixes misleading hint in Module 2 GELU implementation that claimed the 1.702 constant comes from √(2/π) ≈ 0.798
- The 1.702 is actually an empirically fitted constant so that `sigmoid(1.702x) ≈ Φ(x)` (the Gaussian CDF)
- The √(2/π) constant appears in the separate **tanh-based** GELU approximation, not the sigmoid approximation used here

Fixes #1154

## Test plan
- [x] Verified the hint now accurately describes the origin of the 1.702 constant
- [x] Confirmed no other references to this incorrect claim exist in the module