### PR TITLE
docs(activations): expand GELU explanation with both approximation forms

### DIFF
--- a/tinytorch/src/02_activations/02_activations.py
+++ b/tinytorch/src/02_activations/02_activations.py
@@ -553,10 +553,21 @@ if __name__ == "__main__":
 GELU (Gaussian Error Linear Unit) is a smooth approximation to ReLU that's become popular in modern architectures like transformers. Unlike ReLU's sharp corner, GELU is smooth everywhere.
 
 ### Mathematical Definition
+
+The exact GELU multiplies x by Φ(x), the probability that a standard
+normal random variable is ≤ x (an S-curve from 0 to 1):
 ```
-f(x) = x * Φ(x) ≈ x * Sigmoid(1.702 * x)
+GELU(x) = x · Φ(x)
 ```
-Where Φ(x) is the cumulative distribution function of standard normal distribution.
+
+Two common approximations exist (Hendrycks & Gimpel, 2016):
+```
+Tanh:    0.5x(1 + tanh[√(2/π)(x + 0.044715x³)])   ← more accurate
+Sigmoid: x · σ(1.702x)                              ← faster, used here
+```
+
+We use the sigmoid form because it reuses sigmoid (which you just built!)
+and the single constant 1.702 is empirically fitted so that σ(1.702x) ≈ Φ(x).
 
 ### Visual Behavior
 ```


### PR DESCRIPTION
## Summary
- Expands the GELU mathematical definition to show all three forms: exact (Φ), tanh approximation, and sigmoid approximation
- Explains *why* we use the sigmoid form (reuses sigmoid from earlier in the module, simpler)
- Describes Φ(x) in plain language ("probability that a standard normal variable is ≤ x") rather than using erf notation — appropriate for Module 2 students

Follow-up to #1156 / Related to #1154

## Test plan
- [x] Verified markdown renders correctly in the notebook cell
- [x] No code logic changes — documentation only