### PR TITLE
fix(ci): handle branch names with slashes in fresh install test

### DIFF
--- a/tinytorch/scripts/test-fresh-install.sh
+++ b/tinytorch/scripts/test-fresh-install.sh
@@ -139,7 +139,7 @@ OUTER_EOF
 echo "Testing TinyTorch installation from branch: $BRANCH"
 
 # Build test script with branch substituted
-TEST_SCRIPT=$(build_test_script | sed "s/__BRANCH__/$BRANCH/g")
+TEST_SCRIPT=$(build_test_script | sed "s|__BRANCH__|$BRANCH|g")
 
 if [ "$CI_MODE" = true ]; then
     print_step "Running in CI mode (no Docker)"


### PR DESCRIPTION
## Summary
- Fixes `sed` delimiter in `test-fresh-install.sh` from `/` to `|` so branch names containing `/` (e.g. `feature/foo`, `1156/merge`) don't break the substitution

## Test plan
- [x] Verified `sed "s|__BRANCH__|feature/tinytorch-core|g"` works correctly