### PR TITLE
Fix Windows install issues

### DIFF
--- a/tinytorch/site/extra/install.sh
+++ b/tinytorch/site/extra/install.sh
@@ -205,9 +205,17 @@ check_python_version() {
 
 # Find the best Python command (prioritize newer versions)
 get_python_cmd() {
+    local platform
+    platform=$(get_platform)
+
     # Check specific versions first, prioritizing newer versions
-    local candidates=("python3.13" "python3.12" "python3.11" "python3.10" "python3.9" "python3.8" "python3" "python")
-    
+    # FIX: windows to fix microsoft store alis stuf
+    if [ "$platform" = "windows" ]; then
+        local candidates=("python")
+    else
+        local candidates=("python3.13" "python3.12" "python3.11" "python3.10" "python3.9" "python3.8" "python3" "python")
+    fi
+
     for cmd in "${candidates[@]}"; do
         if command_exists "$cmd"; then
             # Verify this specific candidate actually meets the version requirement

--- a/tinytorch/tito/commands/setup.py
+++ b/tinytorch/tito/commands/setup.py
@@ -128,6 +128,10 @@ class SetupCommand(BaseCommand):
 
     def install_packages(self) -> bool:
         """Install required packages for Tiny🔥Torch development."""
+        
+        # FIX: Windows Specific flags
+        is_windows = platform.system() == "Windows"
+
         # Essential packages for TinyTorch
         packages = [
             ("numpy", "numpy>=1.21.0"),
@@ -196,29 +200,35 @@ class SetupCommand(BaseCommand):
                         return False
 
         # Install Tiny🔥Torch in development mode
-        with Progress(
-            SpinnerColumn(),
-            TextColumn("[progress.description]{task.description}"),
-            console=self.console
-        ) as progress:
-            task = progress.add_task("Installing Tiny🔥Torch in development mode...", total=None)
+        # FIX: Skip installation on windows
+        if is_windows and self._check_package_installed("tinytorch"):
+            self.console.print(
+                "[green]✅ Tiny🔥Torch already installed (skipping reinstall on Windows)[/green]"
+            )
+        else:
+            with Progress(
+                SpinnerColumn(),
+                TextColumn("[progress.description]{task.description}"),
+                console=self.console
+            ) as progress:
+                task = progress.add_task("Installing Tiny🔥Torch in development mode...", total=None)
 
-            try:
-                result = subprocess.run([
-                    sys.executable, "-m", "pip", "install", "-q", "-e", "."
-                ], cwd=self.config.project_root, capture_output=True, text=True, timeout=120)
+                try:
+                    result = subprocess.run([
+                        sys.executable, "-m", "pip", "install", "-q", "-e", "."
+                    ], cwd=self.config.project_root, capture_output=True, text=True, timeout=120)
 
-                if result.returncode == 0:
-                    progress.update(task, description="[green]✅ Tiny🔥Torch installed[/green]")
-                else:
-                    progress.update(task, description="[red]❌ Tiny🔥Torch install failed[/red]")
-                    self.console.print(f"[red]Failed to install Tiny🔥Torch: {result.stderr}[/red]")
+                    if result.returncode == 0:
+                        progress.update(task, description="[green]✅ Tiny🔥Torch installed[/green]")
+                    else:
+                        progress.update(task, description="[red]❌ Tiny🔥Torch install failed[/red]")
+                        self.console.print(f"[red]Failed to install Tiny🔥Torch: {result.stderr}[/red]")
+                        return False
+
+                except Exception as e:
+                    progress.update(task, description="[red]❌ Tiny🔥Torch error[/red]")
+                    self.console.print(f"[red]Error installing Tiny🔥Torch: {e}[/red]")
                     return False
-
-            except Exception as e:
-                progress.update(task, description="[red]❌ Tiny🔥Torch error[/red]")
-                self.console.print(f"[red]Error installing Tiny🔥Torch: {e}[/red]")
-                return False
 
         # Register Jupyter kernel so notebooks use this Python environment
         self.console.print()


### PR DESCRIPTION
Related to #1165

This PR fixes two Windows-specific installation issues when using Git Bash:

1. Prefers `python` over `python3` on Windows to avoid Microsoft Store alias resolution and incorrect Unix-style virtual environment paths.

2. Prevents WinError 32 during `tito setup` by skipping self-reinstall on Windows when TinyTorch is already installed, using `_check_package_installed()` as disussed in issue .

Tested on:
- Windows 10
- Git Bash (Git for Windows)
- Python 3.13 (Windows-native)

Installation now completes successfully without file-lock errors.
