### PR TITLE
Fix typo in SocratiQ introduction

### DIFF
--- a/book/quarto/contents/frontmatter/socratiq/socratiq.qmd
+++ b/book/quarto/contents/frontmatter/socratiq/socratiq.qmd
@@ -25,7 +25,7 @@ Learn more about SocratiQ's design and pedagogy in our research paper: [SocratiQ
 ::: {.content-visible when-format="html:js"}
 ## AI Learning Companion {#sec-socratiq-ai-ai-learning-companion-bc63}
 
-Welcome to SocratiQ (pronounced ``Socratic''), an AI learning assistant seamlessly integrated throughout this resource. Inspired by the Socratic method of teaching—emphasizing thoughtful questions and answers to stimulate critical thinking—SocratiQ is part of our experiment with what we call as _Generative Learning._ By combining interactive quizzes, personalized assistance, and real-time feedback, SocratiQ is meant to reinforce your understanding and help you create new connections. _SocratiQ is still a work in progress, and we welcome your feedback._
+Welcome to SocratiQ (pronounced ``Socratic''), an AI learning assistant seamlessly integrated throughout this resource. Inspired by the Socratic method of teaching—emphasizing thoughtful questions and answers to stimulate critical thinking—SocratiQ is part of our experiment with what we call _Generative Learning._ By combining interactive quizzes, personalized assistance, and real-time feedback, SocratiQ is meant to reinforce your understanding and help you create new connections. _SocratiQ is still a work in progress, and we welcome your feedback._
 
 Learn more: Read our research paper [SocratiQ: A Generative AI-Powered Learning Companion for Personalized Education and Broader Accessibility](https://arxiv.org/abs/2502.00341).
 


### PR DESCRIPTION
Superfluous "as" word.