### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/all-contributors-add.yml
+++ b/.github/workflows/all-contributors-add.yml
@@ -63,7 +63,7 @@ jobs:
       # =====================================================================
       - name: Extract trigger line and detect project
         id: extract
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           PROJECTS: ${{ env.PROJECTS }}
           PROJECT_ALIASES: ${{ env.PROJECT_ALIASES }}
@@ -233,7 +233,7 @@ jobs:
       - name: Parse LLM response and validate
         if: steps.extract.outputs.should_run == 'true'
         id: parse
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           LLM_RESPONSE: ${{ steps.llm.outputs.response }}
           TRIGGER_LINE: ${{ steps.extract.outputs.trigger_line }}
@@ -325,21 +325,21 @@ jobs:
       # =====================================================================
       - name: Checkout repository
         if: steps.extract.outputs.should_run == 'true' && steps.parse.outputs.success == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ env.TARGET_BRANCH }}
           fetch-depth: 0
 
       - name: Setup Python
         if: steps.extract.outputs.should_run == 'true' && steps.parse.outputs.success == 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
       - name: Get user info from GitHub
         if: steps.extract.outputs.should_run == 'true' && steps.parse.outputs.success == 'true'
         id: userinfo
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const username = '${{ steps.parse.outputs.username }}';
@@ -467,7 +467,7 @@ jobs:
       # =====================================================================
       - name: React to comment
         if: steps.extract.outputs.should_run == 'true' && steps.parse.outputs.success == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             // Add reaction to the comment
@@ -520,7 +520,7 @@ jobs:
       # =====================================================================
       - name: Handle parsing failure
         if: steps.extract.outputs.should_run == 'true' && steps.parse.outputs.success == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           PROJECTS: ${{ env.PROJECTS }}
         with:

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - name: Get issue/PR details
         id: get-details
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             // Determine which issue/PR to label
@@ -82,7 +82,7 @@ jobs:
 
       - name: Fetch labels from GitHub
         id: fetch-labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             // Fetch all labels from the repository
@@ -179,7 +179,7 @@ jobs:
             The "other" array should be empty [] or contain label names that apply.
 
       - name: Parse and apply labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           LLM_RESPONSE: ${{ steps.llm.outputs.response }}
           ALL_LABELS_JSON: ${{ steps.fetch-labels.outputs.all_labels_json }}

--- a/.github/workflows/book-build-baremetal.yml
+++ b/.github/workflows/book-build-baremetal.yml
@@ -238,7 +238,7 @@ jobs:
 
       - name: 📥 Checkout repository
         if: matrix.enabled
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -480,7 +480,7 @@ jobs:
       # === LINUX: Setup Python (GitHub Action) ===
       - name: 🐍 Set up Python (Linux)
         if: matrix.enabled && runner.os == 'Linux'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 
@@ -505,7 +505,7 @@ jobs:
 
       - name: 💾 Cache Python packages
         if: matrix.enabled
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache-python-packages
         with:
           path: |
@@ -587,7 +587,7 @@ jobs:
       # Cache Linux system packages without hardcoded paths
       - name: 💾 Cache APT packages
         if: matrix.enabled && runner.os == 'Linux'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache-apt
         with:
           path: ~/.apt-cache
@@ -847,7 +847,7 @@ jobs:
       # Cache R packages using standard paths
       - name: 💾 Cache R packages
         if: matrix.enabled
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache-r-packages
         with:
           path: |
@@ -1167,7 +1167,7 @@ jobs:
 
       - name: 📤 Upload build artifacts
         if: matrix.enabled
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ steps.build-declaration.outputs.artifact_name }}
           path: ${{ steps.build.outputs.output_dir }}
@@ -1250,7 +1250,7 @@ jobs:
 
       - name: 📤 Upload Build Logs (Always)
         if: matrix.enabled && always()  # Upload logs even if build fails
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: build-logs-${{ matrix.os_name }}-${{ matrix.format }}-${{ github.run_id }}
           path: logs/

--- a/.github/workflows/book-build-container.yml
+++ b/.github/workflows/book-build-container.yml
@@ -219,7 +219,7 @@ jobs:
 
       - name: 📥 Checkout repository
         if: matrix.enabled
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.target }}
           fetch-depth: 0
@@ -420,7 +420,7 @@ jobs:
           Write-Host "✅ EPUB compression completed."
 
       - name: 📤 Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: matrix.enabled
         with:
           name: ${{ matrix.artifact_name }}

--- a/.github/workflows/book-preview-dev.yml
+++ b/.github/workflows/book-preview-dev.yml
@@ -76,7 +76,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 📥 Download HTML Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ env.ARTIFACT_NAME }}
           run-id: ${{ steps.run_info.outputs.run_id }}
@@ -84,7 +84,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 📥 Download PDF Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           name: dev-pdf-linux
@@ -93,7 +93,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 📥 Download EPUB Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           name: dev-epub-linux
@@ -144,7 +144,7 @@ jobs:
           echo "::endgroup::"
 
       - name: ⬇️ Checkout repository (for scripts)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ./repo-scripts
           sparse-checkout: |

--- a/.github/workflows/book-publish-live.yml
+++ b/.github/workflows/book-publish-live.yml
@@ -157,7 +157,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -309,7 +309,7 @@ jobs:
           echo "✅ Branch check passed - running from ${{ github.ref_name }}"
 
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -412,7 +412,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -550,7 +550,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -595,7 +595,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -728,7 +728,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -766,7 +766,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -829,7 +829,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -867,19 +867,19 @@ jobs:
           echo "✅ API contract validated - all artifact names provided"
 
       - name: 📦 Download HTML Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ needs.call-production-build.outputs.linux_html_artifact }}
           path: ./html-temp
 
       - name: 📦 Download PDF Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ needs.call-production-build.outputs.linux_pdf_artifact }}
           path: ./pdf-temp
 
       - name: 📦 Download EPUB Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ needs.call-production-build.outputs.linux_epub_artifact }}
           path: ./epub-temp
@@ -1166,7 +1166,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 📤 Upload PDF Artifact for GitHub Release
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: pdf-artifact
           path: Machine-Learning-Systems.pdf
@@ -1182,7 +1182,7 @@ jobs:
           fi
 
       - name: 📤 Upload EPUB Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: epub-artifact
           path: Machine-Learning-Systems.epub
@@ -1197,12 +1197,12 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 📄 Download PDF from previous job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: pdf-artifact
           path: ./
@@ -1455,13 +1455,13 @@ jobs:
           fi
 
       - name: 📤 Upload Release Notes Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: release-notes
           path: release_notes_${{ needs.validate-inputs.outputs.new_version }}.md
 
       - name: 📤 Upload Git Log Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: git-changes
           path: |
@@ -1478,24 +1478,24 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 📄 Download PDF from previous job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: pdf-artifact
           path: ./
 
       - name: 📚 Download EPUB from previous job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: epub-artifact
           path: ./
 
       - name: 📝 Download release notes
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: release-notes
           path: ./
@@ -1719,7 +1719,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -1819,7 +1819,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/book-validate-dev.yml
+++ b/.github/workflows/book-validate-dev.yml
@@ -87,13 +87,13 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.test_branch || github.ref }}
           fetch-depth: 0
 
       - name: 🐍 Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/infra-cleanup-caches.yml
+++ b/.github/workflows/infra-cleanup-caches.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: '📥 Checkout repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: '🐍 Setup Python'
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/infra-container-linux.yml
+++ b/.github/workflows/infra-container-linux.yml
@@ -155,7 +155,7 @@ jobs:
           echo "✅ Environment check completed"
 
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🧹 Free up disk space
         run: |

--- a/.github/workflows/infra-container-windows.yml
+++ b/.github/workflows/infra-container-windows.yml
@@ -118,7 +118,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Skip Docker Buildx for Windows containers - use native Docker engine
       # Buildx doesn't properly support Windows containers on GitHub Actions

--- a/.github/workflows/infra-health-check.yml
+++ b/.github/workflows/infra-health-check.yml
@@ -101,7 +101,7 @@ jobs:
         if: |
           (matrix.platform == 'linux' && inputs.test_linux != false) ||
           (matrix.platform == 'windows' && inputs.test_windows != false)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -766,7 +766,7 @@ jobs:
 
       - name: 📤 Upload Test Artifacts
         if: always() && ((matrix.platform == 'linux' && inputs.test_linux != false) || (matrix.platform == 'windows' && inputs.test_windows != false))
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.platform }}-container-test-results
           path: |

--- a/.github/workflows/infra-link-check.yml
+++ b/.github/workflows/infra-link-check.yml
@@ -49,7 +49,7 @@ jobs:
       broken-count: ${{ steps.link-summary.outputs.broken-count }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: 🔗 Check Links
         id: lychee

--- a/.github/workflows/kits-build-pdfs.yml
+++ b/.github/workflows/kits-build-pdfs.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.ref }}
 
@@ -72,7 +72,7 @@ jobs:
           mv _build/pdf/Hardware-Kits-compressed.pdf _build/pdf/Hardware-Kits.pdf
 
       - name: 📤 Upload PDF Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Kits-PDF
           path: kits/_build/pdf/Hardware-Kits.pdf

--- a/.github/workflows/kits-preview-dev.yml
+++ b/.github/workflows/kits-preview-dev.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔧 Setup Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -44,7 +44,7 @@ jobs:
           touch _build/.nojekyll
 
       - name: 📥 Download PDF Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           name: Kits-PDF

--- a/.github/workflows/kits-publish-live.yml
+++ b/.github/workflows/kits-publish-live.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔧 Setup Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -40,7 +40,7 @@ jobs:
           touch _build/.nojekyll
 
       - name: 📥 Download PDF Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: Kits-PDF
           path: kits/_build/assets/downloads/

--- a/.github/workflows/labs-preview-dev.yml
+++ b/.github/workflows/labs-preview-dev.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔧 Setup Quarto
         uses: quarto-dev/quarto-actions/setup@v2

--- a/.github/workflows/labs-publish-live.yml
+++ b/.github/workflows/labs-publish-live.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔧 Setup Quarto
         uses: quarto-dev/quarto-actions/setup@v2

--- a/.github/workflows/publish-all-live.yml
+++ b/.github/workflows/publish-all-live.yml
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -146,7 +146,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Quarto
         uses: quarto-dev/quarto-actions/setup@v2

--- a/.github/workflows/tinytorch-build-pdfs.yml
+++ b/.github/workflows/tinytorch-build-pdfs.yml
@@ -37,19 +37,19 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.ref }}
 
       - name: 🐍 Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'
           cache-dependency-path: 'tinytorch/site/requirements.txt'
 
       - name: 🟢 Setup Node.js (for Mermaid)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -80,7 +80,7 @@ jobs:
           latexmk_use_xelatex: true
 
       - name: 📤 Upload PDF Guide
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: TinyTorch-Guide
           path: tinytorch/site/_build/latex/tinytorch-course.pdf
@@ -92,7 +92,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.ref }}
 
@@ -104,7 +104,7 @@ jobs:
           latexmk_use_lualatex: true
 
       - name: 📤 Upload PDF Paper
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: TinyTorch-Paper
           path: tinytorch/paper/paper.pdf

--- a/.github/workflows/tinytorch-preview-dev.yml
+++ b/.github/workflows/tinytorch-preview-dev.yml
@@ -35,10 +35,10 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🐍 Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -66,14 +66,14 @@ jobs:
           echo "✅ Build complete"
 
       - name: 📥 Download PDF Guide
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           name: TinyTorch-Guide
           path: ./pdf-artifacts/guide
 
       - name: 📥 Download PDF Paper
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           name: TinyTorch-Paper

--- a/.github/workflows/tinytorch-publish-live.yml
+++ b/.github/workflows/tinytorch-publish-live.yml
@@ -108,7 +108,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -201,7 +201,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout dev branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: dev
           fetch-depth: 0
@@ -318,7 +318,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0
@@ -366,12 +366,12 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main  # Use freshly synced main
 
       - name: 🐍 Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -397,14 +397,14 @@ jobs:
           touch _build/html/.nojekyll
 
       - name: 📥 Download PDF Guide
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           name: TinyTorch-Guide
           path: ./pdf-artifacts/guide
 
       - name: 📥 Download PDF Paper
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           name: TinyTorch-Paper
@@ -470,7 +470,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/tinytorch-update-pdfs.yml
+++ b/.github/workflows/tinytorch-update-pdfs.yml
@@ -29,7 +29,7 @@ jobs:
     if: inputs.update_paper
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
 
@@ -41,7 +41,7 @@ jobs:
           latexmk_use_lualatex: true
 
       - name: 📤 Upload PDF Paper
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: TinyTorch-Paper
           path: tinytorch/paper/paper.pdf
@@ -53,19 +53,19 @@ jobs:
     if: inputs.update_guide
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
 
       - name: 🐍 Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'
           cache-dependency-path: 'tinytorch/site/requirements.txt'
 
       - name: 🟢 Setup Node.js (for Mermaid)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -96,7 +96,7 @@ jobs:
           latexmk_use_xelatex: true
 
       - name: 📤 Upload PDF Guide
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: TinyTorch-Guide
           path: tinytorch/site/_build/latex/tinytorch-course.pdf
@@ -109,21 +109,21 @@ jobs:
     if: always() && (needs.build-paper.result == 'success' || needs.build-guide.result == 'success')
     steps:
       - name: 📥 Checkout gh-pages
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: gh-pages
           path: gh-pages
 
       - name: 📥 Download Paper PDF
         if: needs.build-paper.result == 'success'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: TinyTorch-Paper
           path: ./artifacts/paper
 
       - name: 📥 Download Guide PDF
         if: needs.build-guide.result == 'success'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: TinyTorch-Guide
           path: ./artifacts/guide

--- a/.github/workflows/tinytorch-validate-dev.yml
+++ b/.github/workflows/tinytorch-validate-dev.yml
@@ -217,10 +217,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -262,10 +262,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -305,10 +305,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -348,10 +348,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -393,10 +393,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -428,7 +428,7 @@ jobs:
 
     steps:
       - name: Checkout (for test script only)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             tinytorch/scripts/test-fresh-install.sh
@@ -462,10 +462,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -49,12 +49,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/cache` | [`v4`](https://github.com/actions/cache/releases/tag/v4) | [`v5`](https://github.com/actions/cache/releases/tag/v5) | [Release](https://github.com/actions/cache/releases/tag/v5) | book-build-baremetal.yml |
| `actions/checkout` | [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | all-contributors-add.yml, book-build-baremetal.yml, book-build-container.yml, book-preview-dev.yml, book-publish-live.yml, book-validate-dev.yml, infra-cleanup-caches.yml, infra-container-linux.yml, infra-container-windows.yml, infra-health-check.yml, infra-link-check.yml, kits-build-pdfs.yml, kits-preview-dev.yml, kits-publish-live.yml, labs-preview-dev.yml, labs-publish-live.yml, publish-all-live.yml, tinytorch-build-pdfs.yml, tinytorch-preview-dev.yml, tinytorch-publish-live.yml, tinytorch-update-pdfs.yml, tinytorch-validate-dev.yml, update-contributors.yml |
| `actions/download-artifact` | [`v4`](https://github.com/actions/download-artifact/releases/tag/v4) | [`v7`](https://github.com/actions/download-artifact/releases/tag/v7) | [Release](https://github.com/actions/download-artifact/releases/tag/v7) | book-preview-dev.yml, book-publish-live.yml, kits-preview-dev.yml, kits-publish-live.yml, tinytorch-preview-dev.yml, tinytorch-publish-live.yml, tinytorch-update-pdfs.yml |
| `actions/github-script` | [`v7`](https://github.com/actions/github-script/releases/tag/v7) | [`v8`](https://github.com/actions/github-script/releases/tag/v8) | [Release](https://github.com/actions/github-script/releases/tag/v8) | all-contributors-add.yml, auto-label.yml |
| `actions/setup-node` | [`v4`](https://github.com/actions/setup-node/releases/tag/v4) | [`v6`](https://github.com/actions/setup-node/releases/tag/v6) | [Release](https://github.com/actions/setup-node/releases/tag/v6) | tinytorch-build-pdfs.yml, tinytorch-update-pdfs.yml |
| `actions/setup-python` | [`v4`](https://github.com/actions/setup-python/releases/tag/v4), [`v5`](https://github.com/actions/setup-python/releases/tag/v5) | [`v6`](https://github.com/actions/setup-python/releases/tag/v6) | [Release](https://github.com/actions/setup-python/releases/tag/v6) | all-contributors-add.yml, book-build-baremetal.yml, book-validate-dev.yml, infra-cleanup-caches.yml, tinytorch-build-pdfs.yml, tinytorch-preview-dev.yml, tinytorch-publish-live.yml, tinytorch-update-pdfs.yml, tinytorch-validate-dev.yml, update-contributors.yml |
| `actions/upload-artifact` | [`v4`](https://github.com/actions/upload-artifact/releases/tag/v4) | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) | book-build-baremetal.yml, book-build-container.yml, book-publish-live.yml, infra-health-check.yml, kits-build-pdfs.yml, tinytorch-build-pdfs.yml, tinytorch-update-pdfs.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
