### PR TITLE
Improve dataset extraction robustness

### DIFF
--- a/tinytorch/milestones/data_manager.py
+++ b/tinytorch/milestones/data_manager.py
@@ -210,7 +210,20 @@ class DatasetManager:
             # Extract
             print("📦 Extracting CIFAR-10...")
             with tarfile.open(data_file, 'r:gz') as tar:
-                tar.extractall(cifar_dir)
+                def is_within_directory(directory, target):
+                    abs_directory = os.path.abspath(directory)
+                    abs_target = os.path.abspath(target)
+                    prefix = os.path.commonprefix([abs_directory, abs_target])
+                    return prefix == abs_directory
+                
+                def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
+                    for member in tar.getmembers():
+                        member_path = os.path.join(path, member.name)
+                        if not is_within_directory(path, member_path):
+                            raise Exception("Attempted Path Traversal in Tar File")
+                    tar.extractall(path, members, numeric_owner=numeric_owner)
+                
+                safe_extract(tar, cifar_dir)
             print("✅ Extraction complete!")
         else:
             print(f"✅ CIFAR-10 already downloaded at {cifar_dir}")


### PR DESCRIPTION
Updated the dataset extraction logic in `data_manager.py` to include path validation. This ensures that when extracting the CIFAR-10 dataset, all members are strictly contained within the target directory, preventing potential file system issues or unintended overwrites. I noticed the current implementation uses `extractall()` directly, so adding this check makes the process much more robust for students working with the framework.