### PR TITLE
Add the hyperlink to the blog post name

### DIFF
--- a/tinytorch/src/04_losses/ABOUT.md
+++ b/tinytorch/src/04_losses/ABOUT.md
@@ -899,7 +899,7 @@ For students who want to understand the academic foundations and explore deeper:
 ### Additional Resources
 
 - **Tutorial**: [Understanding Cross-Entropy Loss](https://pytorch.org/docs/stable/generated/torch.nn.CrossEntropyLoss.html) - PyTorch documentation with mathematical details
-- **Blog post**: "The Softmax Function and Its Derivative" - Excellent explanation of log-sum-exp trick and numerical stability
+- **Blog post**: ["The Softmax Function and Its Derivative"](https://eli.thegreenplace.net/2016/the-softmax-function-and-its-derivative/) - Excellent explanation of log-sum-exp trick and numerical stability
 - **Textbook**: "Deep Learning" by Goodfellow, Bengio, and Courville - Chapter 5 covers loss functions and maximum likelihood
 
 ## What's Next


### PR DESCRIPTION
The Additional Resources section mentions a blog post without a link to it. This can cause ambiguity since there may be many blog posts with similar name. This commit adds a hyperlink to the blog post name.