### PR TITLE
fix: handle null synced_modules in sync progress response

### DIFF
--- a/tinytorch/tito/core/submission.py
+++ b/tinytorch/tito/core/submission.py
@@ -192,7 +192,14 @@ class SubmissionHandler:
                 if 200 <= response.status < 300:
                     resp_body = json.loads(response.read().decode('utf-8'))
                     self.console.print("✅ [bold green]Sync Successful![/bold green]")
-                    self.console.print(f"   Modules Synced: {resp_body.get('synced_modules', 'N/A')}")
+                    # Handle synced_modules - show count of modules that were synced
+                    synced = resp_body.get('synced_modules')
+                    if synced is not None:
+                        self.console.print(f"   Modules Synced: {synced}")
+                    else:
+                        # If null, show the count of completed modules that were sent
+                        completed_count = payload['module_progress']['completed_count']
+                        self.console.print(f"   Modules Synced: {completed_count} completed module(s)")                    
                     return True
                 else:
                     self.console.print(f"⚠️ Server returned status: {response.status}")


### PR DESCRIPTION
Desc:
Handle null synced_modules in sync progress response.
Fall back to showing completed module count when API returns null.

Before:
<img width="459" height="72" alt="image" src="https://github.com/user-attachments/assets/717f3be5-e4db-4c2a-9dcb-ea7357b9f454" />

After:
<img width="419" height="76" alt="image" src="https://github.com/user-attachments/assets/073bee96-f53b-4a30-bf1d-e1c82c87f0d4" />

