### PR TITLE
fix: deterministic file-path rules for PR area labels

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,16 +1,16 @@
 # =============================================================================
-# AUTO-LABEL WORKFLOW (LLM-Powered)
+# AUTO-LABEL WORKFLOW (Hybrid: Rule-Based Areas + LLM Types)
 # =============================================================================
-# Automatically labels issues and PRs using Ollama LLM analysis.
+# Automatically labels issues and PRs.
 #
-# When an issue or PR is created:
-#   1. Fetches all labels from the repository dynamically
-#   2. Groups them by prefix (area:, type:, format:, etc.)
-#   3. Sends to LLM to analyze and pick appropriate labels
-#   4. Applies the selected labels
+# AREA labels (area: book, area: tinytorch, etc.):
+#   - PRs: Deterministic file-path matching (no LLM needed)
+#   - Issues: LLM-based analysis (no file paths available)
 #
-# NO STATIC LABEL LISTS - everything is fetched from GitHub at runtime.
-# Just add/remove labels in GitHub and this workflow adapts automatically.
+# TYPE labels (type: bug, type: improvement, etc.):
+#   - Always LLM-based (requires understanding intent)
+#
+# NO STATIC LABEL LISTS for type/other - fetched from GitHub at runtime.
 # =============================================================================
 
 name: '🏷️ Auto Label'
@@ -20,7 +20,6 @@ on:
     types: [opened]
   pull_request_target:
     types: [opened]
-  # Manual trigger for testing on existing issues/PRs
   workflow_dispatch:
     inputs:
       issue_number:
@@ -30,7 +29,7 @@ on:
 
 jobs:
   auto-label:
-    name: Auto Label with LLM
+    name: Auto Label
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -42,17 +41,14 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            // Determine which issue/PR to label
-            let number, title, body;
+            let number, title, body, isPR = false;
 
             if (context.eventName === 'workflow_dispatch') {
-              // Manual trigger - fetch the specified issue/PR
               number = ${{ inputs.issue_number || 0 }};
               if (!number) {
                 core.setFailed('No issue_number provided for manual trigger');
                 return;
               }
-
               try {
                 const { data: issue } = await github.rest.issues.get({
                   owner: context.repo.owner,
@@ -61,7 +57,8 @@ jobs:
                 });
                 title = issue.title;
                 body = issue.body || '';
-                console.log(`Manual trigger for #${number}: ${title}`);
+                isPR = !!issue.pull_request;
+                console.log(`Manual trigger for #${number}: ${title} (isPR: ${isPR})`);
               } catch (e) {
                 core.setFailed(`Could not fetch issue/PR #${number}: ${e.message}`);
                 return;
@@ -70,22 +67,97 @@ jobs:
               number = context.payload.issue.number;
               title = context.payload.issue.title;
               body = context.payload.issue.body || '';
+              isPR = false;
             } else {
               number = context.payload.pull_request.number;
               title = context.payload.pull_request.title;
               body = context.payload.pull_request.body || '';
+              isPR = true;
             }
 
             core.setOutput('number', number);
             core.setOutput('title', title);
             core.setOutput('body', body);
+            core.setOutput('is_pr', isPR.toString());
 
+      # =====================================================================
+      # AREA LABEL — Deterministic for PRs (file-path rules)
+      # =====================================================================
+      - name: Determine area label from changed files (PRs only)
+        if: steps.get-details.outputs.is_pr == 'true'
+        id: area-from-files
+        uses: actions/github-script@v8
+        env:
+          ISSUE_NUMBER: ${{ steps.get-details.outputs.number }}
+        with:
+          script: |
+            const number = parseInt(process.env.ISSUE_NUMBER, 10);
+
+            // Fetch changed files
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: number,
+              per_page: 100
+            });
+
+            const paths = files.map(f => f.filename);
+            console.log(`Changed files (${paths.length}):`);
+            paths.forEach(p => console.log(`  ${p}`));
+
+            // ── Path-prefix → area label mapping ──
+            // Order matters: more specific prefixes first
+            const rules = [
+              { prefix: 'book/tools/',     label: 'area: tools' },
+              { prefix: '.github/',        label: 'area: tools' },
+              { prefix: 'book/',           label: 'area: book' },
+              { prefix: 'tinytorch/',      label: 'area: tinytorch' },
+              { prefix: 'kits/',           label: 'area: kits' },
+              { prefix: 'labs/',           label: 'area: labs' },
+              { prefix: 'socratiq/',       label: 'area: socratiq' },
+              { prefix: 'website/',        label: 'area: website' },
+              { prefix: 'mlsysim/',        label: 'area: tools' },
+              { prefix: 'interviews/',     label: 'area: tools' },
+            ];
+
+            // Count hits per area
+            const areaCounts = {};
+            for (const filePath of paths) {
+              for (const rule of rules) {
+                if (filePath.startsWith(rule.prefix)) {
+                  areaCounts[rule.label] = (areaCounts[rule.label] || 0) + 1;
+                  break; // first matching rule wins per file
+                }
+              }
+            }
+
+            // Pick area with most file hits (majority wins)
+            let areaLabel = '';
+            let maxCount = 0;
+            for (const [label, count] of Object.entries(areaCounts)) {
+              if (count > maxCount) {
+                maxCount = count;
+                areaLabel = label;
+              }
+            }
+
+            if (areaLabel) {
+              console.log(`Deterministic area: "${areaLabel}" (${maxCount}/${paths.length} files)`);
+            } else {
+              console.log('No area matched from file paths — LLM will decide');
+            }
+
+            core.setOutput('area_label', areaLabel);
+            core.setOutput('matched', areaLabel ? 'true' : 'false');
+
+      # =====================================================================
+      # FETCH LABELS — For LLM-based type classification
+      # =====================================================================
       - name: Fetch labels from GitHub
         id: fetch-labels
         uses: actions/github-script@v8
         with:
           script: |
-            // Fetch all labels from the repository
             const { data: labels } = await github.rest.issues.listLabelsForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -94,90 +166,64 @@ jobs:
 
             console.log(`Found ${labels.length} labels in repository`);
 
-            // Group labels by prefix
-            const grouped = {
-              area: [],
-              type: [],
-              format: [],
-              other: []
-            };
+            const grouped = { area: [], type: [], other: [] };
 
             for (const label of labels) {
               const name = label.name;
               const desc = label.description || '';
-
-              if (name.startsWith('area:')) {
-                grouped.area.push({ name, description: desc });
-              } else if (name.startsWith('type:')) {
-                grouped.type.push({ name, description: desc });
-              } else if (name.startsWith('format:')) {
-                grouped.format.push({ name, description: desc });
-              } else {
-                grouped.other.push({ name, description: desc });
-              }
+              if (name.startsWith('area:')) grouped.area.push({ name, description: desc });
+              else if (name.startsWith('type:')) grouped.type.push({ name, description: desc });
+              else if (!name.startsWith('format:')) grouped.other.push({ name, description: desc });
             }
 
-            // Format for LLM prompt
-            const formatGroup = (items) => items
-              .map(l => `${l.name} - ${l.description}`)
-              .join('\n');
+            const formatGroup = (items) => items.map(l => `${l.name} — ${l.description}`).join('\n');
 
-            const areaLabels = formatGroup(grouped.area);
-            const typeLabels = formatGroup(grouped.type);
-            const otherLabels = formatGroup(grouped.other);
+            core.setOutput('area_labels', formatGroup(grouped.area));
+            core.setOutput('type_labels', formatGroup(grouped.type));
+            core.setOutput('other_labels', formatGroup(grouped.other));
+            core.setOutput('all_labels_json', JSON.stringify(labels.map(l => l.name)));
+            core.setOutput('default_area', grouped.area[0]?.name || '');
+            core.setOutput('default_type', grouped.type[0]?.name || '');
 
-            // Store all valid label names for validation
-            const allLabelNames = labels.map(l => l.name);
-
-            // Set outputs
-            core.setOutput('area_labels', areaLabels);
-            core.setOutput('type_labels', typeLabels);
-            core.setOutput('other_labels', otherLabels);
-            core.setOutput('all_labels_json', JSON.stringify(allLabelNames));
-
-            // Find defaults (first of each type, or fallback)
-            const defaultArea = grouped.area[0]?.name || '';
-            const defaultType = grouped.type[0]?.name || '';
-            core.setOutput('default_area', defaultArea);
-            core.setOutput('default_type', defaultType);
-
-            console.log('Area labels:', grouped.area.length);
-            console.log('Type labels:', grouped.type.length);
-            console.log('Other labels:', grouped.other.length);
-
+      # =====================================================================
+      # LLM ANALYSIS — Type label (+ area fallback for issues)
+      # =====================================================================
       - name: Analyze with LLM
         uses: ai-action/ollama-action@v2
         id: llm
         with:
           model: llama3.1:8b
           prompt: |
-            You are a GitHub issue labeler. Analyze this issue/PR and select the most appropriate labels.
+            You are a GitHub issue/PR labeler. Analyze this and select appropriate labels.
 
             TITLE: ${{ steps.get-details.outputs.title }}
 
             BODY: ${{ steps.get-details.outputs.body }}
 
-            AVAILABLE AREA LABELS (pick exactly ONE - these indicate which part of the project):
+            AVAILABLE TYPE LABELS (pick exactly ONE — what kind of change is this):
+            ${{ steps.fetch-labels.outputs.type_labels }}
+
+            AVAILABLE AREA LABELS (pick exactly ONE — only if area is NOT already determined):
             ${{ steps.fetch-labels.outputs.area_labels }}
 
-            AVAILABLE TYPE LABELS (pick exactly ONE - these indicate what kind of issue):
-            ${{ steps.fetch-labels.outputs.type_labels }}
+            AREA ALREADY DETERMINED: ${{ steps.area-from-files.outputs.area_label || 'NOT SET — you must pick one' }}
 
             OTHER LABELS (pick any that clearly apply, or none):
             ${{ steps.fetch-labels.outputs.other_labels }}
 
             Instructions:
-            - Pick ONE area label based on which project/component this relates to
-            - Pick ONE type label based on what kind of issue this is
+            - Pick ONE type label based on intent (bug fix, new feature, question, etc.)
+            - If AREA ALREADY DETERMINED shows a label, use exactly that for area
+            - If AREA ALREADY DETERMINED says "NOT SET", pick ONE area label
             - Only add other labels if they clearly and obviously apply
-            - If unsure about area, use "${{ steps.fetch-labels.outputs.default_area }}"
             - If unsure about type, use "${{ steps.fetch-labels.outputs.default_type }}"
 
-            Return ONLY a JSON object with this exact format (no other text):
+            Return ONLY a JSON object (no other text):
             {"area": "area: book", "type": "type: bug", "other": []}
 
-            The "other" array should be empty [] or contain label names that apply.
-
+      # =====================================================================
+      # APPLY LABELS
+      # =====================================================================
       - name: Parse and apply labels
         uses: actions/github-script@v8
         env:
@@ -186,32 +232,26 @@ jobs:
           DEFAULT_AREA: ${{ steps.fetch-labels.outputs.default_area }}
           DEFAULT_TYPE: ${{ steps.fetch-labels.outputs.default_type }}
           ISSUE_NUMBER: ${{ steps.get-details.outputs.number }}
+          DETERMINISTIC_AREA: ${{ steps.area-from-files.outputs.area_label }}
         with:
           script: |
             const response = process.env.LLM_RESPONSE || '';
-            console.log('LLM response:', response);
-
-            // Get all valid labels from the fetch step
+            const deterministicArea = process.env.DETERMINISTIC_AREA || '';
             const allValidLabels = JSON.parse(process.env.ALL_LABELS_JSON || '[]');
             const defaultArea = process.env.DEFAULT_AREA || '';
             const defaultType = process.env.DEFAULT_TYPE || '';
 
-            console.log(`Valid labels: ${allValidLabels.length}`);
-            console.log(`Default area: ${defaultArea}`);
-            console.log(`Default type: ${defaultType}`);
+            console.log('LLM response:', response);
+            console.log('Deterministic area:', deterministicArea || '(none)');
 
-            // Helper to normalize label (add space after colon if missing)
             const normalizeLabel = (label) => {
               if (!label) return label;
-              // If label has "prefix:value" without space, add space
               return label.replace(/^(area|type|format):(?! )/, '$1: ');
             };
 
             // Parse LLM response
             let result = { area: defaultArea, type: defaultType, other: [] };
-
             try {
-              // Find JSON in response (LLM might add extra text)
               const jsonMatch = response.match(/\{[\s\S]*?\}/);
               if (jsonMatch) {
                 const parsed = JSON.parse(jsonMatch[0]);
@@ -220,29 +260,31 @@ jobs:
                 if (parsed.other) result.other = parsed.other.map(normalizeLabel);
               }
             } catch (e) {
-              console.log('Failed to parse JSON, using defaults:', e.message);
+              console.log('Failed to parse LLM JSON, using defaults:', e.message);
             }
 
-            // Validate and collect labels (only allow labels that exist in repo)
+            // ── Build final label set ──
             const labels = [];
 
-            // Validate area label
-            if (allValidLabels.includes(result.area)) {
-              labels.push(result.area);
+            // Area: deterministic wins over LLM
+            const areaLabel = deterministicArea || result.area;
+            if (allValidLabels.includes(areaLabel)) {
+              labels.push(areaLabel);
+              console.log(`Area label: "${areaLabel}" (${deterministicArea ? 'deterministic' : 'LLM'})`);
             } else if (defaultArea) {
-              console.log(`Invalid area label "${result.area}", using default "${defaultArea}"`);
               labels.push(defaultArea);
+              console.log(`Area fallback to default: "${defaultArea}"`);
             }
 
-            // Validate type label
+            // Type: always from LLM
             if (allValidLabels.includes(result.type)) {
               labels.push(result.type);
             } else if (defaultType) {
-              console.log(`Invalid type label "${result.type}", using default "${defaultType}"`);
+              console.log(`Invalid type "${result.type}", using default "${defaultType}"`);
               labels.push(defaultType);
             }
 
-            // Validate other labels
+            // Other labels
             if (Array.isArray(result.other)) {
               for (const label of result.other) {
                 if (allValidLabels.includes(label)) {
@@ -253,12 +295,10 @@ jobs:
               }
             }
 
-            // Apply labels
+            // Apply
             const number = parseInt(process.env.ISSUE_NUMBER, 10);
-
             if (labels.length > 0) {
-              console.log(`Applying labels to #${number}: ${labels.join(', ')}`);
-
+              console.log(`Applying to #${number}: ${labels.join(', ')}`);
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,


### PR DESCRIPTION
## Summary

- PR area labels now use **deterministic file-path prefix matching** instead of relying on the LLM
- The LLM (`llama3.1:8b`) was mis-tagging PRs (e.g., #1242 got `area: socratiq` instead of `area: book`) because it only saw title/body text — no file paths
- LLM is still used for **type labels** (bug, improvement, etc.) and **issue area labels** (where no file paths exist)

## How it works

New step fetches changed files via `pulls.listFiles()` and matches against prefix rules:

| File prefix | Area label |
|-------------|-----------|
| `book/tools/` | `area: tools` |
| `.github/` | `area: tools` |
| `book/` | `area: book` |
| `tinytorch/` | `area: tinytorch` |
| `kits/` | `area: kits` |
| `labs/` | `area: labs` |
| `socratiq/` | `area: socratiq` |
| `website/` | `area: website` |

Majority-wins when a PR touches multiple areas. Falls back to LLM only if no prefix matches.

## Test plan

- [ ] Run workflow manually on #1242 to verify it would pick `area: book`
- [ ] Open a test PR touching `tinytorch/` files to verify correct tagging
- [ ] Open a test issue (no files) to verify LLM fallback still works