### PR TITLE
Fix #1268 installscript fails on ubuntu LTS 20.04

### DIFF
--- a/tinytorch/site/extra/install.sh
+++ b/tinytorch/site/extra/install.sh
@@ -157,7 +157,7 @@ fetch_latest_version() {
             local tag_name
             tag_name=$(echo "$response" | grep -o "\"name\": *\"${TAG_PREFIX}[^\"]*\"" | head -1 | sed 's/.*"name": *"\([^"]*\)".*/\1/')
             if [ -n "$tag_name" ]; then
-                TINYTORCH_VERSION="${tag_name#$TAG_PREFIX}"
+                TINYTORCH_VERSION="${tag_name#"$TAG_PREFIX"}"
                 return 0
             fi
         fi
@@ -191,7 +191,7 @@ check_python_version() {
     minor=$($python_cmd -c "import sys; print(sys.version_info.minor)" 2>/dev/null)
 
     # Check for Python 3.8+ (Required for TinyTorch)
-    if [ "$major" -eq 3 ] && [ "$minor" -ge 8 ]; then
+    if [ "$major" -eq 3 ] && [ "$minor" -ge 9 ]; then
         echo "$version"
         return 0
     elif [ "$major" -gt 3 ]; then
@@ -215,7 +215,7 @@ get_python_cmd() {
     if [ "$platform" = "windows" ]; then
         local candidates=("python")
     else
-        local candidates=("python3.13" "python3.12" "python3.11" "python3.10" "python3.9" "python3.8" "python3" "python")
+        local candidates=("python3.13" "python3.12" "python3.11" "python3.10" "python3.9" "python3" "python")
     fi
 
     for cmd in "${candidates[@]}"; do
@@ -274,13 +274,37 @@ check_internet() {
     print_success "GitHub reachable"
 }
 
+# Check if git version > 2.25.1
+check_git_version() {
+    local major minor rev
+    major="$(echo "$1" | cut -d '.' -f 1)" 2>/dev/null
+    minor="$(echo "$1" | cut -d '.' -f 2)" 2>/dev/null
+    rev="$(echo "$1" | cut -d '.' -f 3)" 2>/dev/null
+
+    # Check for git >= 2.25.2 (sparse url bug fixed)
+    if [ "$major" -eq 2 ] && [ "$minor" -ge 26 ]; then
+        return 0
+    elif [ "$major" -gt 3 ]; then
+        return 0
+    elif [ "$major" -eq 2 ] && [ "$minor" -eq 25 ] &&  [ "$rev" -ge 2 ] ; then
+        return 0
+    else
+        return 1
+    fi
+}
+
 check_prerequisites() {
     local errors=0
 
     # Check for git
     if command_exists git; then
-        GIT_VERSION=$(git --version | cut -d' ' -f3)
-        print_success "Git $GIT_VERSION"
+        GIT_VERSION="$(git --version | cut -d ' ' -f3)"
+        if check_git_version "$GIT_VERSION"; then
+            print_success "Git $GIT_VERSION"
+        else
+            print_error "git version > 2.25.1 required. If you are using ubuntu LTS 20.04, please upgrade to ubuntu LTS 22.04 or clone project and extract tinytorch subdirectory manually."
+            errors=$((errors + 1))
+        fi
     else
         print_error "Git not found"
         echo "  Install: https://git-scm.com/downloads"
@@ -302,7 +326,7 @@ check_prerequisites() {
         else
              print_error "Python 3.8+ not found"
         fi
-        echo "  Install: https://python.org/downloads or 'brew install python'"
+        echo "  Install: https://python.org/downloads or 'brew install python' or 'apt install python3.9' or python 3.12"
         errors=$((errors + 1))
     fi
 
@@ -485,7 +509,7 @@ do_install() {
     # -------------------------------------------------------------------------
     echo -e "${BLUE}[2/4]${NC} Creating Python environment..."
     cd "$INSTALL_DIR"
-    
+
     # Use the detected 3.10+ command explicitly
     $PYTHON_CMD -m venv .venv
 

--- a/tinytorch/site/extra/install.sh
+++ b/tinytorch/site/extra/install.sh
@@ -182,7 +182,7 @@ fetch_latest_version() {
     TINYTORCH_VERSION="latest"
 }
 
-# Check if Python version is 3.8+
+# Check if Python version is 3.9+
 check_python_version() {
     local python_cmd="$1"
     local version major minor
@@ -190,7 +190,7 @@ check_python_version() {
     major=$($python_cmd -c "import sys; print(sys.version_info.major)" 2>/dev/null)
     minor=$($python_cmd -c "import sys; print(sys.version_info.minor)" 2>/dev/null)
 
-    # Check for Python 3.8+ (Required for TinyTorch)
+    # Check for Python 3.9+ (Required for TinyTorch)
     if [ "$major" -eq 3 ] && [ "$minor" -ge 9 ]; then
         echo "$version"
         return 0
@@ -322,9 +322,9 @@ check_prerequisites() {
         # Diagnostic: Check if they have ANY python, just too old
         if command_exists python3; then
              CURRENT_VER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>/dev/null)
-             print_error "Found Python $CURRENT_VER, but 3.8+ is required"
+             print_error "Found Python $CURRENT_VER, but 3.9+ is required"
         else
-             print_error "Python 3.8+ not found"
+             print_error "Python 3.9+ not found"
         fi
         echo "  Install: https://python.org/downloads or 'brew install python' or 'apt install python3.9' or python 3.12"
         errors=$((errors + 1))

--- a/tinytorch/site/extra/install.sh
+++ b/tinytorch/site/extra/install.sh
@@ -191,7 +191,7 @@ check_python_version() {
     minor=$($python_cmd -c "import sys; print(sys.version_info.minor)" 2>/dev/null)
 
     # Check for Python 3.8+ (Required for TinyTorch)
-    if [ "$major" -eq 3 ] && [ "$minor" -ge 8 ]; then
+    if [ "$major" -eq 3 ] && [ "$minor" -ge 9 ]; then
         echo "$version"
         return 0
     elif [ "$major" -gt 3 ]; then
@@ -215,7 +215,7 @@ get_python_cmd() {
     if [ "$platform" = "windows" ]; then
         local candidates=("python")
     else
-        local candidates=("python3.13" "python3.12" "python3.11" "python3.10" "python3.9" "python3.8" "python3" "python")
+        local candidates=("python3.13" "python3.12" "python3.11" "python3.10" "python3.9" "python3" "python")
     fi
 
     for cmd in "${candidates[@]}"; do
@@ -274,13 +274,38 @@ check_internet() {
     print_success "GitHub reachable"
 }
 
+# Check if git version > 2.25.1
+check_git_version() {
+    local major minor rev
+    major="$(echo "$1" | cut -d '.' -f 1)" 2>/dev/null
+    minor="$(echo "$1" | cut -d '.' -f 2)" 2>/dev/null
+    rev="$(echo "$1" | cut -d '.' -f 3)" 2>/dev/null
+    echo "$1 - $major - $minor - $rev"
+
+    # Check for git >= 2.25.2 (sparse url bug fixed)
+    if [ "$major" -eq 2 ] && [ "$minor" -ge 26 ]; then
+        return 0
+    elif [ "$major" -gt 3 ]; then
+        return 0
+    elif [ "$major" -eq 2 ] && [ "$minor" -eq 25 ] &&  [ "$rev" -ge 2 ] ; then
+        return 0
+    else
+        return 1
+    fi
+}
+
 check_prerequisites() {
     local errors=0
 
     # Check for git
     if command_exists git; then
-        GIT_VERSION=$(git --version | cut -d' ' -f3)
-        print_success "Git $GIT_VERSION"
+        GIT_VERSION="$(git --version | cut -d ' ' -f3)"
+        if check_git_version "$GIT_VERSION"; then
+            print_success "Git $GIT_VERSION"
+        else
+            print_error "git version > 2.25.1 required. If you are using ubuntu LTS 20.04, please upgrade to ubuntu LTS 22.04 or clone project and extract tinytorch subdirectory manually."
+            errors=$((errors + 1))
+        fi
     else
         print_error "Git not found"
         echo "  Install: https://git-scm.com/downloads"
@@ -302,7 +327,7 @@ check_prerequisites() {
         else
              print_error "Python 3.8+ not found"
         fi
-        echo "  Install: https://python.org/downloads or 'brew install python'"
+        echo "  Install: https://python.org/downloads or 'brew install python' or 'apt install python3.9' or python 3.12"
         errors=$((errors + 1))
     fi
 
@@ -485,7 +510,7 @@ do_install() {
     # -------------------------------------------------------------------------
     echo -e "${BLUE}[2/4]${NC} Creating Python environment..."
     cd "$INSTALL_DIR"
-    
+
     # Use the detected 3.10+ command explicitly
     $PYTHON_CMD -m venv .venv
 


### PR DESCRIPTION
See discussion #1087 

Made the following changes:

- removed python3.8 support because of dependency problems. It apparently no longer works without complicating requirements.txt, and probably not even then.
- checking for git > 2.25.1 to avoid --sparse command line args bug.

The problem should affect only very ancient distributions, but since it happened only three months ago it probably will happen again. From my experience, many people have difficulties upgrading their linux distribution after a couple of years. I have observed that they often just reinstall the system from scratch and avoid that for data loss issues. 

I have tested the install script with ubuntu 20.04 installed in a docker container and on a current Mac Book Pro with the following results:

ubuntu 20.04:
```
tinytorch@d8f93717750f:~/projects$ ./install.sh

  Tiny?Torch v0.1.9
  Don't import it. Build it.

Checking prerequisites...
? git version > 2.25.1 required. If you are using ubuntu LTS 20.04, please upgrade to ubuntu LTS 22.04 or clone project and extract tinytorch subdirectory manually.
? Found Python 3.8, but 3.9+ is required
  Install: https://python.org/downloads or 'brew install python' or 'apt install python3.9' or python 3.12

? Missing prerequisites. Please fix the issues above.
```

The "?" show up because of restricted terminal support in the docker container terminal output, nothing to do with the changes.

OSX 26.3.1:
```
La-Bestia:~/projects/test[1016]> /Users/peter/PycharmProjects/cs249r_book/tinytorch/site/extra/install.sh

  Tiny🔥Torch v0.1.9
  Don't import it. Build it.

Checking prerequisites...
✓ Git 2.50.1
✓ Python 3.13 (python3.13)
✓ Python venv module
✓ GitHub reachable

Where would you like to install Tiny🔥Torch?
  Press Enter for default: /Users/peter/projects/test/tinytorch

Install directory [tinytorch]: 

This will create a tinytorch folder here:
  /Users/peter/projects/test/tinytorch

What will be installed:
  - Tiny🔥Torch learning modules
  - Python virtual environment (.venv/)
  - tito CLI tool

Source: harvard-edge/cs249r_book (main branch)

Continue? [Y/n] 

[1/4] Downloading from GitHub...
✓ Downloaded TinyTorch (f00520c)                        
[2/4] Creating Python environment...
✓ Created virtual environment using python3.13
[3/4] Installing dependencies...
✓ Installed dependencies                                
[4/4] Verifying installation...
✓ Verified tito CLI

✓ Tiny🔥Torch installed successfully!

Next steps:

  cd /Users/peter/projects/test/tinytorch
  source .venv/bin/activate
  tito setup

Then start building:

  tito module start 01

Documentation: https://tinytorch.ai
```