### PR TITLE
fix(mlsysim): update distributed tutorial to attribute access API

### DIFF
--- a/mlsysim/docs/tutorials/distributed.qmd
+++ b/mlsysim/docs/tutorials/distributed.qmd
@@ -137,15 +137,15 @@ result_dp = solver.solve(
     pp_size=1,   # no pipeline parallelism
 )
 
-node_perf = result_dp["node_performance"]
+node_perf = result_dp.node_profile
 print(f"Single-GPU compute time:     {node_perf.latency.to('ms'):~.1f}/step")
-print(f"DP all-reduce overhead:      {result_dp['dp_communication_latency'].to('ms'):~.2f}")
-print(f"Pipeline bubble:             {result_dp['pipeline_bubble_latency'].to('ms'):~.2f}")
+print(f"DP all-reduce overhead:      {result_dp.dp_communication_latency.to('ms'):~.2f}")
+print(f"Pipeline bubble:             {result_dp.pipeline_bubble_latency.to('ms'):~.2f}")
 print(f"")
-print(f"Total step latency:          {result_dp['step_latency_total'].to('ms'):~.1f}")
-print(f"Scaling efficiency:          {result_dp['scaling_efficiency']:.1%}")
-print(f"Effective throughput:        {result_dp['effective_throughput'].magnitude:.0f} samples/s")
-print(f"Parallelism:                 DP={result_dp['parallelism']['dp']}  TP={result_dp['parallelism']['tp']}  PP={result_dp['parallelism']['pp']}")
+print(f"Total step latency:          {result_dp.step_latency_total.to('ms'):~.1f}")
+print(f"Scaling efficiency:          {result_dp.scaling_efficiency:.1%}")
+print(f"Effective throughput:        {result_dp.effective_throughput.magnitude:.0f} samples/s")
+print(f"Parallelism:                 DP={result_dp.parallelism['dp']}  TP={result_dp.parallelism['tp']}  PP={result_dp.parallelism['pp']}")
 ```
 
 ::: {.callout-note}


### PR DESCRIPTION
## Summary
- Follow-up to #1302 — the distributed tutorial still used dict-style `result["key"]` access but the restored solver returns Pydantic result objects (attribute access `result.key`)
- Also fixes `node_performance` → `node_profile` field name

## Test plan
- [x] Verified locally with Python 3.14
- [ ] CI: MLSysim Validate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)