### PR TITLE
fix(mlsysim): convert all dict accesses in distributed tutorial

### DIFF
--- a/mlsysim/docs/tutorials/distributed.qmd
+++ b/mlsysim/docs/tutorials/distributed.qmd
@@ -202,8 +202,8 @@ for fab_name, fabric in fabrics:
     print(
         f"{fab_name:>10}  "
         f"{fabric.bandwidth.to('GB/s'):>10.0f~}  "
-        f"{r['dp_communication_latency'].to('ms'):>14.2f~}  "
-        f"{r['scaling_efficiency']:>11.1%}"
+        f"{r.dp_communication_latency.to('ms'):>14.2f~}  "
+        f"{r.scaling_efficiency:>11.1%}"
     )
 ```
 
@@ -251,13 +251,13 @@ for pp_size in [1, 2, 4, 8]:
             pp_size=pp_size,
             microbatch_count=m
         )
-        bubble_pct = r["bubble_fraction"] * 100
+        bubble_pct = r.bubble_fraction * 100
         print(
             f"{pp_size:>10}  "
             f"{m:>13}  "
             f"{bubble_pct:>9.1f}%  "
-            f"{r['pipeline_bubble_latency'].to('ms'):>10.1f~}  "
-            f"{r['scaling_efficiency']:>11.1%}"
+            f"{r.pipeline_bubble_latency.to('ms'):>10.1f~}  "
+            f"{r.scaling_efficiency:>11.1%}"
         )
 ```
 
@@ -307,11 +307,11 @@ for desc, tp, pp, m in configs:
         )
         print(
             f"{desc:<26}  "
-            f"{r['parallelism']['dp']:>4}  "
-            f"{r['parallelism']['tp']:>4}  "
-            f"{r['parallelism']['pp']:>4}  "
-            f"{r['scaling_efficiency']:>11.1%}  "
-            f"{r['effective_throughput'].magnitude:>14.1f}"
+            f"{r.parallelism['dp']:>4}  "
+            f"{r.parallelism['tp']:>4}  "
+            f"{r.parallelism['pp']:>4}  "
+            f"{r.scaling_efficiency:>11.1%}  "
+            f"{r.effective_throughput.magnitude:>14.1f}"
         )
     except ValueError as e:
         print(f"{desc:<26}  {'INFEASIBLE':>44}  ({e})")


### PR DESCRIPTION
## Summary
Follow-up to #1303 — more `r["key"]` → `r.key` conversions in the distributed tutorial (cells 4-6: fabric comparison, pipeline sweep, 3D parallelism tables).

🤖 Generated with [Claude Code](https://claude.com/claude-code)