### PR TITLE
fix(tinytorch): typo "Tokentic" → "Tokenization" in site-quarto diagram

### DIFF
--- a/tinytorch/site-quarto/big-picture.qmd
+++ b/tinytorch/site-quarto/big-picture.qmd
@@ -425,7 +425,7 @@ graph LR
         direction TB
         Data["DataLoader"]
         Data --> Conv["CNNs"]
-        Data --> Tok["Tokentic"]
+        Data --> Tok["Tokenization"]
         Tok --> Emb["Embed"]
         Emb --> Att["Attention"]
         Att --> Trans["Transform"]


### PR DESCRIPTION
Mermaid diagram in site-quarto/big-picture.qmd had "Tokentic" instead of "Tokenization" for Module 10 node label.

## Summary

Fix typo in mermaid diagram node label in site-quarto/big-picture.qmd
