### PR TITLE
fix(tinytorch): rename misspelled "commununity" image file

### DIFF
--- a/tinytorch/site-quarto/community.qmd
+++ b/tinytorch/site-quarto/community.qmd
@@ -8,7 +8,7 @@ title: "Community Ecosystem"
 **See yourself on the TinyTorch Globe!** Create an account and join the global community to track your progress and connect with other builders.
 
 <p align="center">
-<img src="assets/images/diagram_tiny-commununity.png" alt="TinyTorch Community Ecosystem" width="100%">
+<img src="assets/images/diagram_tiny-community.png" alt="TinyTorch Community Ecosystem" width="100%">
 </p>
 
 **Learn together, build together, grow together.**

--- a/tinytorch/site/community.md
+++ b/tinytorch/site/community.md
@@ -5,7 +5,7 @@
 **See yourself on the TinyTorch Globe!** Create an account and join the global community to track your progress and connect with other builders.
 
 <p align="center">
-<img src="_static/images/diagram_tiny-commununity.png" alt="TinyTorch Community Ecosystem" width="100%">
+<img src="_static/images/diagram_tiny-community.png" alt="TinyTorch Community Ecosystem" width="100%">
 </p>
 
 **Learn together, build together, grow together.**

--- a/tinytorch/site/extra/community/about.html
+++ b/tinytorch/site/extra/community/about.html
@@ -153,7 +153,7 @@
             This is a vibrant community-based site for the TinyTorch learning project. Here, you can check your TinyTorch status, submit your module results, and connect with other community members. You can track your progress and challenges, and coming soon, you'll be able to accept new challenges and compete with other learners for performance or accuracy in your AI models. Join us to build, learn, and grow together!
 
             <div style="margin-top: 30px; text-align: center;">
-                <img src="../_static/images/diagram_tiny-commununity.png" alt="TinyTorch Community Structure" style="width: 100%;">
+                <img src="../_static/images/diagram_tiny-community.png" alt="TinyTorch Community Structure" style="width: 100%;">
             </div>
         </div>
 


### PR DESCRIPTION
Rename diagram_tiny-commununity.png to diagram_tiny-community.png and update all 3 references (site/community.md, site-quarto/community.qmd, site/extra/community/about.html).

