### PR TITLE
fix(tinytorch): remove extra space in "Available Now" heading

### DIFF
--- a/tinytorch/site-quarto/community.qmd
+++ b/tinytorch/site-quarto/community.qmd
@@ -16,7 +16,7 @@ title: "Community Ecosystem"
 TinyTorch is more than a course---it's a growing community of students, educators, and ML engineers learning systems engineering from first principles.
 
 ```
-## Community Dashboard (Available Now )
+## Community Dashboard (Available Now)
 
 Join the global TinyTorch community and see your progress:
 

--- a/tinytorch/site/community.md
+++ b/tinytorch/site/community.md
@@ -12,7 +12,7 @@
 
 TinyTorch is more than a course—it's a growing community of students, educators, and ML engineers learning systems engineering from first principles.
 
-## Community Dashboard (Available Now )
+## Community Dashboard (Available Now)
 
 Join the global TinyTorch community and see your progress:
 


### PR DESCRIPTION
Remove trailing space before closing parenthesis in community page heading in both site/community.md and site-quarto/community.qmd.

