### PR TITLE
fix: export DecisionLog and FailureBanner from mlsysim.labs

### DIFF
--- a/mlsysim/labs/__init__.py
+++ b/mlsysim/labs/__init__.py
@@ -24,6 +24,8 @@ from .components import (
     RooflineVisualizer,
     LatencyWaterfall,
     MathPeek,
+    DecisionLog,
+    FailureBanner,
 )
 
 __all__ = [
@@ -43,4 +45,6 @@ __all__ = [
     "RooflineVisualizer",
     "LatencyWaterfall",
     "MathPeek",
+    "DecisionLog",
+    "FailureBanner",
 ]


### PR DESCRIPTION
## Problem

`DecisionLog` and `FailureBanner` are defined in `mlsysim/labs/components.py` and imported directly by 14+ lab notebooks, but were missing from `mlsysim/labs/__init__.py`.

Any lab using the public API:
```python
from mlsysim.labs import DecisionLog
from mlsysim.labs import FailureBanner
```
raises `ImportError` at runtime.

## Fix

Add both to the import block and `__all__` in `mlsysim/labs/__init__.py`.

## Verification

```python
from mlsysim.labs import DecisionLog, FailureBanner  # ✓
```