### PR TITLE
fix(tinytorch): fix dark mode visibility on preface page

### DIFF
--- a/tinytorch/site/_static/custom.css
+++ b/tinytorch/site/_static/custom.css
@@ -1925,3 +1925,65 @@ html[data-theme="dark"] .bigpicture-struggle-box p,
 html[data-theme="dark"] .bigpicture-struggle-box li {
     color: #e2e8f0 !important;
 }
+
+/* The Problem box */
+html[data-theme="dark"] .preface-problem-box {
+    background: #1e293b !important;
+    border-color: #334155 !important;
+}
+html[data-theme="dark"] .preface-problem-box,
+html[data-theme="dark"] .preface-problem-box strong,
+html[data-theme="dark"] .preface-problem-box p,
+html[data-theme="dark"] .preface-problem-box li {
+    color: #e2e8f0 !important;
+}
+
+/* AI Bricks - MLSysBook card */
+html[data-theme="dark"] .preface-mlsysbook-card {
+    filter: none !important;
+    background: #0d2137 !important;
+    border-left-color: #64b5f6 !important;
+}
+html[data-theme="dark"] .preface-mlsysbook-card .preface-card-title {
+    color: #90caf9 !important;
+}
+html[data-theme="dark"] .preface-mlsysbook-card p {
+    color: #cbd5e1 !important;
+}
+
+/* AI Bricks - TinyTorch card */
+html[data-theme="dark"] .preface-tinytorch-card {
+    filter: none !important;
+    background: #1f1100 !important;
+    border-left-color: #ff9a5a !important;
+}
+html[data-theme="dark"] .preface-tinytorch-card .preface-card-title {
+    color: #ffb74d !important;
+}
+html[data-theme="dark"] .preface-tinytorch-card p {
+    color: #cbd5e1 !important;
+}
+
+/* Who This Is For - audience cards */
+html[data-theme="dark"] .preface-audience-card {
+    filter: none !important;
+    background: #1e1e2e !important;
+}
+html[data-theme="dark"] .preface-audience-card strong {
+    color: #e2e8f0 !important;
+}
+html[data-theme="dark"] .preface-audience-card p {
+    color: #94a3b8 !important;
+}
+
+/* How to Learn cards */
+html[data-theme="dark"] .preface-howtolearn-card {
+    background: #1e1e2e !important;
+    border-color: #334155 !important;
+}
+html[data-theme="dark"] .preface-howtolearn-card strong {
+    color: #e2e8f0 !important;
+}
+html[data-theme="dark"] .preface-howtolearn-card p {
+    color: #94a3b8 !important;
+}

--- a/tinytorch/site/preface.md
+++ b/tinytorch/site/preface.md
@@ -22,7 +22,7 @@ This is the gap TinyTorch exists to fill.
 
 Most people can use PyTorch or TensorFlow. They can import libraries, call functions, train models. But very few understand how these frameworks work: how memory is managed for tensors, how autograd builds computation graphs, how optimizers update parameters. And almost no one has a guided, structured way to learn that from the ground up.
 
-<div style="background: #f8f9fa; padding: 1.5rem; border-radius: 0.5rem; margin: 1.5rem 0;">
+<div class="preface-problem-box" style="background: #f8f9fa; padding: 1.5rem; border-radius: 0.5rem; margin: 1.5rem 0;">
 
 **Why does this matter?** Because users hit walls that builders do not:
 
@@ -44,12 +44,12 @@ They also cannot learn it from toy scripts. A hundred-line neural network does n
 TinyTorch teaches you the **AI bricks**—the stable engineering foundations you can use to build any AI system. Small enough to learn from: bite-sized code that runs even on a Raspberry Pi. Big enough to matter: showing the real architecture of how frameworks are built.
 
 <div class="comparison-grid" style="display: grid; grid-template-columns: 1fr 1fr; gap: 1.5rem; margin: 2rem 0;">
-<div style="background: #e3f2fd; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #1976d2;">
-<strong style="color: #1565c0;">📖 MLSysBook</strong>
+<div class="preface-mlsysbook-card" style="background: #e3f2fd; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #1976d2;">
+<strong class="preface-card-title" style="color: #1565c0;">📖 MLSysBook</strong>
 <p style="margin: 0.5rem 0 0 0;">The <a href="https://mlsysbook.ai">Machine Learning Systems</a> textbook teaches you the <em>concepts</em> of the rocket ship: propulsion, guidance, life support.</p>
 </div>
-<div style="background: #fff3e0; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #ff8247;">
-<strong style="color: #e65100;">TinyTorch</strong>
+<div class="preface-tinytorch-card" style="background: #fff3e0; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #ff8247;">
+<strong class="preface-card-title" style="color: #e65100;">TinyTorch</strong>
 <p style="margin: 0.5rem 0 0 0;">TinyTorch is where you actually <em>build</em> a small rocket with your own hands. Not a toy—a real framework.</p>
 </div>
 </div>
@@ -60,22 +60,22 @@ This is how people move from *using* machine learning to *engineering* machine l
 
 <div class="comparison-grid" style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin: 1.5rem 0;">
 
-<div style="background: #fafafa; padding: 1.25rem; border-radius: 0.5rem; border-left: 4px solid #9c27b0;">
+<div class="preface-audience-card" style="background: #fafafa; padding: 1.25rem; border-radius: 0.5rem; border-left: 4px solid #9c27b0;">
 <strong>🎓 Students & Researchers</strong>
 <p style="margin: 0.5rem 0 0 0; font-size: 0.95rem;">Want to understand ML systems deeply, not just use them superficially. If you've wondered "how does that actually work?", this is for you.</p>
 </div>
 
-<div style="background: #fafafa; padding: 1.25rem; border-radius: 0.5rem; border-left: 4px solid #4caf50;">
+<div class="preface-audience-card" style="background: #fafafa; padding: 1.25rem; border-radius: 0.5rem; border-left: 4px solid #4caf50;">
 <strong>⚙ ML Engineers</strong>
 <p style="margin: 0.5rem 0 0 0; font-size: 0.95rem;">Need to debug, optimize, and deploy models in production. Understanding the systems underneath makes you more effective.</p>
 </div>
 
-<div style="background: #fafafa; padding: 1.25rem; border-radius: 0.5rem; border-left: 4px solid #2196f3;">
+<div class="preface-audience-card" style="background: #fafafa; padding: 1.25rem; border-radius: 0.5rem; border-left: 4px solid #2196f3;">
 <strong>💻 Systems Programmers</strong>
 <p style="margin: 0.5rem 0 0 0; font-size: 0.95rem;">You understand memory hierarchies, computational complexity, performance optimization. You want to apply it to ML.</p>
 </div>
 
-<div style="background: #fafafa; padding: 1.25rem; border-radius: 0.5rem; border-left: 4px solid #ffc107;">
+<div class="preface-audience-card" style="background: #fafafa; padding: 1.25rem; border-radius: 0.5rem; border-left: 4px solid #ffc107;">
 <strong>🛠 Self-taught Engineers</strong>
 <p style="margin: 0.5rem 0 0 0; font-size: 0.95rem;">Can use frameworks but want to know how they work. Preparing for ML infrastructure roles and need systems-level understanding.</p>
 </div>
@@ -108,22 +108,22 @@ Each module follows a **Build-Use-Reflect** cycle: implement from scratch, apply
 
 <div class="comparison-grid" style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin: 1.5rem 0;">
 
-<div style="border: 1px solid #e0e0e0; padding: 1rem; border-radius: 0.5rem;">
+<div class="preface-howtolearn-card" style="border: 1px solid #e0e0e0; padding: 1rem; border-radius: 0.5rem;">
 <strong>Type every line yourself</strong>
 <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem; color: #666;">Do not copy-paste. The learning happens in the struggle of implementation.</p>
 </div>
 
-<div style="border: 1px solid #e0e0e0; padding: 1rem; border-radius: 0.5rem;">
+<div class="preface-howtolearn-card" style="border: 1px solid #e0e0e0; padding: 1rem; border-radius: 0.5rem;">
 <strong>Profile your code</strong>
 <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem; color: #666;">Use built-in profiling tools. Measure first, optimize second.</p>
 </div>
 
-<div style="border: 1px solid #e0e0e0; padding: 1rem; border-radius: 0.5rem;">
+<div class="preface-howtolearn-card" style="border: 1px solid #e0e0e0; padding: 1rem; border-radius: 0.5rem;">
 <strong>Run the tests</strong>
 <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem; color: #666;">Every module includes comprehensive tests. When they pass, you have built something real.</p>
 </div>
 
-<div style="border: 1px solid #e0e0e0; padding: 1rem; border-radius: 0.5rem;">
+<div class="preface-howtolearn-card" style="border: 1px solid #e0e0e0; padding: 1rem; border-radius: 0.5rem;">
 <strong>Compare with PyTorch</strong>
 <p style="margin: 0.5rem 0 0 0; font-size: 0.9rem; color: #666;">Once your implementation works, compare with PyTorch's equivalent.</p>
 </div>


### PR DESCRIPTION
## Problem

Four sections on the preface page were unreadable in dark mode because
they rely entirely on hardcoded light colors in inline `style` attributes.
The existing broad `filter: brightness(0.7)` rule in `custom.css` only
dimmed these elements — it still left light backgrounds behind dark text,
making content invisible or very hard to read.

Affected sections:
- **"The Problem" box** — `background: #f8f9fa` with no dark mode CSS at all
- **AI Bricks cards** — MLSysBook (`#e3f2fd`, `color: #1565c0`) and TinyTorch
  (`#fff3e0`, `color: #e65100`) still rendered as light cards after dimming
- **"Who This Is For" cards** — `background: #fafafa`, light gray in dark mode
- **"How to Learn" cards** — `color: #666` body text (invisible on dark bg)

## Solution

**`tinytorch/site/preface.md`** — Added semantic CSS classes to each affected
element while keeping existing inline styles intact for light mode:

| Element | Class added |
|---|---|
| "The Problem" highlight box | `preface-problem-box` |
| MLSysBook AI Brick card | `preface-mlsysbook-card` + `preface-card-title` |
| TinyTorch AI Brick card | `preface-tinytorch-card` + `preface-card-title` |
| Audience cards (×4) | `preface-audience-card` |
| How to Learn cards (×4) | `preface-howtolearn-card` |

**`tinytorch/site/_static/custom.css`** — Added targeted `html[data-theme="dark"]`
overrides for each class. Key decisions:

- `filter: none !important` on the AI Brick and audience cards to bypass the
  existing brightness dimmer, then set a proper dark background instead
- Colors follow the existing dark mode palette already used across the site
  (`#1e293b`, `#1e1e2e`, `#e2e8f0`, `#94a3b8`, `#cbd5e1`)
- MLSysBook card uses navy (`#0d2137`) + blue accent (`#90caf9`) to preserve
  its blue brand identity in dark mode
- TinyTorch card uses deep amber (`#1f1100`) + warm accent (`#ffb74d`) to
  preserve its fire/amber brand identity in dark mode

## Testing

- Built locally with `jupyter-book build .`
- Verified all four sections are readable in both light and dark mode
- No regressions on other pages (changes are scoped to `.preface-*` classes)

## Files changed

- `tinytorch/site/preface.md` — 13 lines changed (class attributes added)
- `tinytorch/site/_static/custom.css` — 64 lines added (dark mode overrides)
