### PR TITLE
fix(tinytorch): fix dark mode visibility on big-picture page

### DIFF
--- a/tinytorch/site/_static/custom.css
+++ b/tinytorch/site/_static/custom.css
@@ -1898,3 +1898,30 @@ html[data-theme="dark"] .tinytorch-announcement-bar {
         margin-top: 0.25rem;
     }
 }
+
+/* Choose Your Learning Path cards (Sequential Builder, Vision, Language, Instructor) */
+html[data-theme="dark"] .bigpicture-path-card {
+    filter: none !important;
+    background: #1e1e2e !important;
+}
+html[data-theme="dark"] .bigpicture-path-card strong {
+    color: #e2e8f0 !important;
+}
+html[data-theme="dark"] .bigpicture-path-card .bigpicture-path-subtitle {
+    color: #94a3b8 !important;
+}
+html[data-theme="dark"] .bigpicture-path-card p {
+    color: #cbd5e1 !important;
+}
+
+/* Expect to Struggle box */
+html[data-theme="dark"] .bigpicture-struggle-box {
+    background: #1c1500 !important;
+    border-left-color: #ffa726 !important;
+}
+html[data-theme="dark"] .bigpicture-struggle-box,
+html[data-theme="dark"] .bigpicture-struggle-box strong,
+html[data-theme="dark"] .bigpicture-struggle-box p,
+html[data-theme="dark"] .bigpicture-struggle-box li {
+    color: #e2e8f0 !important;
+}

--- a/tinytorch/site/big-picture.md
+++ b/tinytorch/site/big-picture.md
@@ -523,9 +523,9 @@ Pick the route that matches your goals and available time:
 
 <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1.25rem; margin: 1.5rem 0;">
 
-<div style="background: #e3f2fd; padding: 1.25rem; border-radius: 0.5rem; border-left: 4px solid #1976d2;">
+<div class="bigpicture-path-card" style="background: #e3f2fd; padding: 1.25rem; border-radius: 0.5rem; border-left: 4px solid #1976d2;">
 <strong>Sequential Builder</strong><br/>
-<span style="font-size: 0.9rem; color: #555;">Complete all 20 modules in order</span>
+<span class="bigpicture-path-subtitle" style="font-size: 0.9rem; color: #555;">Complete all 20 modules in order</span>
 <p style="margin: 0.75rem 0 0 0; font-size: 0.95rem;">
 <strong>Best for:</strong> Students, career transitioners, deep understanding<br/>
 <strong>Time:</strong> 60-80 hours (8-12 weeks part-time)<br/>
@@ -533,9 +533,9 @@ Pick the route that matches your goals and available time:
 </p>
 </div>
 
-<div style="background: #f3e5f5; padding: 1.25rem; border-radius: 0.5rem; border-left: 4px solid #7b1fa2;">
+<div class="bigpicture-path-card" style="background: #f3e5f5; padding: 1.25rem; border-radius: 0.5rem; border-left: 4px solid #7b1fa2;">
 <strong>Vision Track</strong><br/>
-<span style="font-size: 0.9rem; color: #555;">01-09 → 14-19 (CNNs + optimization)</span>
+<span class="bigpicture-path-subtitle" style="font-size: 0.9rem; color: #555;">01-09 → 14-19 (CNNs + optimization)</span>
 <p style="margin: 0.75rem 0 0 0; font-size: 0.95rem;">
 <strong>Best for:</strong> Computer vision focus, MLOps practitioners<br/>
 <strong>Time:</strong> 40-50 hours<br/>
@@ -543,9 +543,9 @@ Pick the route that matches your goals and available time:
 </p>
 </div>
 
-<div style="background: #fff3e0; padding: 1.25rem; border-radius: 0.5rem; border-left: 4px solid #f57c00;">
+<div class="bigpicture-path-card" style="background: #fff3e0; padding: 1.25rem; border-radius: 0.5rem; border-left: 4px solid #f57c00;">
 <strong>Language Track</strong><br/>
-<span style="font-size: 0.9rem; color: #555;">01-08 → 10-13 (transformers + GPT)</span>
+<span class="bigpicture-path-subtitle" style="font-size: 0.9rem; color: #555;">01-08 → 10-13 (transformers + GPT)</span>
 <p style="margin: 0.75rem 0 0 0; font-size: 0.95rem;">
 <strong>Best for:</strong> NLP focus, research engineers<br/>
 <strong>Time:</strong> 35-45 hours<br/>
@@ -553,9 +553,9 @@ Pick the route that matches your goals and available time:
 </p>
 </div>
 
-<div style="background: #e8f5e9; padding: 1.25rem; border-radius: 0.5rem; border-left: 4px solid #388e3c;">
+<div class="bigpicture-path-card" style="background: #e8f5e9; padding: 1.25rem; border-radius: 0.5rem; border-left: 4px solid #388e3c;">
 <strong>Instructor Sampler</strong><br/>
-<span style="font-size: 0.9rem; color: #555;">Read: 01, 03, 05, 07, 12 (key concepts)</span>
+<span class="bigpicture-path-subtitle" style="font-size: 0.9rem; color: #555;">Read: 01, 03, 05, 07, 12 (key concepts)</span>
 <p style="margin: 0.75rem 0 0 0; font-size: 0.95rem;">
 <strong>Best for:</strong> Evaluating for course adoption<br/>
 <strong>Time:</strong> 8-12 hours (reading, not building)<br/>
@@ -573,7 +573,7 @@ Pick the route that matches your goals and available time:
 
 ## Expect to Struggle (That's the Design)
 
-<div style="background: #fff8e1; border-left: 4px solid #ffa726; padding: 1.5rem; margin: 1.5rem 0;">
+<div class="bigpicture-struggle-box" style="background: #fff8e1; border-left: 4px solid #ffa726; padding: 1.5rem; margin: 1.5rem 0;">
 
 **Getting stuck is not a bug—it's a feature.**
 


### PR DESCRIPTION
## Problem

Two sections on the `big-picture` page were unreadable in dark mode due to
hardcoded light colors in inline `style` attributes.

**"Choose Your Learning Path"** — four track cards (Sequential Builder, Vision,
Language, Instructor Sampler) each use light pastel backgrounds (`#e3f2fd`,
`#f3e5f5`, `#fff3e0`, `#e8f5e9`) and a subtitle with `color: #555`. The
existing broad `filter: brightness(0.7)` rule in `custom.css` only dimmed
these cards — it still left light backgrounds with illegible text in dark mode.

**"Expect to Struggle (That's the Design)"** — standalone highlight box with
`background: #fff8e1` (pale yellow) had zero dark mode CSS at all.

## Solution

**`tinytorch/site/big-picture.md`** — Added semantic CSS classes to each
affected element while keeping existing inline styles intact for light mode:

| Element | Class added |
|---|---|
| Sequential Builder card | `bigpicture-path-card` + `bigpicture-path-subtitle` |
| Vision Track card | `bigpicture-path-card` + `bigpicture-path-subtitle` |
| Language Track card | `bigpicture-path-card` + `bigpicture-path-subtitle` |
| Instructor Sampler card | `bigpicture-path-card` + `bigpicture-path-subtitle` |
| Expect to Struggle box | `bigpicture-struggle-box` |

**`tinytorch/site/_static/custom.css`** — Added targeted `html[data-theme="dark"]`
overrides at the end of the file. Key decisions:

- `filter: none !important` on path cards to bypass the existing brightness
  dimmer, then set a proper dark background (`#1e1e2e`) instead
- All four path cards share one dark background — they stay differentiated
  by their brand-colored `border-left` (blue, purple, orange, green)
- Subtitle `color: #555` → `#94a3b8` (muted slate, consistent with site palette)
- Struggle box gets `#1c1500` (deep amber-tinted dark) to preserve its
  warning identity while remaining legible

## Testing

- Built locally with `jupyter-book build .`
- Verified all five affected elements are fully readable in both light and dark mode
- No regressions on other pages (all changes scoped to `.bigpicture-*` classes)

## Files changed

- `tinytorch/site/big-picture.md` — 9 lines changed (class attributes added)
- `tinytorch/site/_static/custom.css` — 33 lines added (dark mode overrides)
