### PR TITLE
fix(tinytorch): fix role-cards layout overflow and mobile collapse on overview page

### DIFF
--- a/tinytorch/site/_static/custom.css
+++ b/tinytorch/site/_static/custom.css
@@ -1987,3 +1987,23 @@ html[data-theme="dark"] .preface-howtolearn-card strong {
 html[data-theme="dark"] .preface-howtolearn-card p {
     color: #94a3b8 !important;
 }
+
+/* 2-column layout: cards 1 & 2 on the first row, card 3 wraps to its
+   own row at half width. Sidebars no longer push a card off-screen
+   because two 1fr columns always fit within the content area. */
+.overview-role-grid > div {
+    min-width: 0; /* prevent grid blowout from wide code blocks */
+}
+
+/* Scroll code blocks horizontally instead of expanding the card */
+.overview-role-grid pre {
+    overflow-x: auto;
+    white-space: pre;
+}
+
+/* Collapse to single column on mobile */
+@media (max-width: 600px) {
+    .overview-role-grid {
+        grid-template-columns: 1fr !important;
+    }
+}

--- a/tinytorch/site/tito/overview.md
+++ b/tinytorch/site/tito/overview.md
@@ -36,7 +36,7 @@
 
 TinyTorch serves three types of users. Choose your path:
 
-<div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 1.5rem; margin: 2rem 0;">
+<div class="overview-role-grid" style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 1.5rem; margin: 2rem 0;">
 
 <div style="background: #e3f2fd; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #2196f3;">
 <h3 style="margin: 0 0 1rem 0; color: #1976d2;"> Student / Learner</h3>


### PR DESCRIPTION
## Problem

The "Commands by User Role" section had two layout bugs:

1. **Sidebar overflow** — `grid-template-columns: repeat(3, 1fr)` forced
   exactly three equal columns regardless of content area width. When the
   right TOC sidebar was visible, the content area was too narrow and the
   third card overflowed into / below the sidebar.

2. **Mobile horizontal scroll** — code blocks inside the grid cards contain
   long `tito` command strings that cannot wrap. Without `min-width: 0` on
   the grid children, those blocks blew out the column widths and caused
   the entire page to scroll horizontally on mobile devices.

## Solution

**Commit 1 — `tito/overview.md`**
Switched `grid-template-columns` from `repeat(3, 1fr)` to `repeat(2, 1fr)`.
Cards 1 (Student) and 2 (Instructor) sit side by side; card 3 (Developer)
wraps naturally to the next row. Two columns always fit within the content
area regardless of sidebar state.

**Commit 2 — `_static/custom.css`**
Added `.overview-role-grid` rules:
- `min-width: 0` on grid children stops code block content from expanding
  cells beyond their `1fr` track width.
- `overflow-x: auto` + `white-space: pre` on `pre` elements lets long
  command strings scroll within their card.
- `@media (max-width: 600px)` hard-overrides to a single column as a
  final fallback for very small viewports.

## Files changed
- `tinytorch/site/tito/overview.md` — 1 line changed
- `tinytorch/site/_static/custom.css` — 20 lines added
