### PR TITLE
fix(tinytorch): fix dark mode visibility on overview page role cards and session flow

### DIFF
--- a/tinytorch/site/_static/custom.css
+++ b/tinytorch/site/_static/custom.css
@@ -2033,3 +2033,15 @@ html[data-theme="dark"] .overview-instructor-card .overview-role-heading {
 html[data-theme="dark"] .overview-developer-card .overview-role-heading {
     color: #ce93d8 !important; /* light purple */
 }
+
+/* Typical Session Flow box */
+html[data-theme="dark"] .overview-session-box {
+    background: #1e293b !important;
+    border-color: #334155 !important;
+}
+html[data-theme="dark"] .overview-session-box,
+html[data-theme="dark"] .overview-session-box strong,
+html[data-theme="dark"] .overview-session-box p,
+html[data-theme="dark"] .overview-session-box li {
+    color: #e2e8f0 !important;
+}

--- a/tinytorch/site/_static/custom.css
+++ b/tinytorch/site/_static/custom.css
@@ -1987,3 +1987,23 @@ html[data-theme="dark"] .preface-howtolearn-card strong {
 html[data-theme="dark"] .preface-howtolearn-card p {
     color: #94a3b8 !important;
 }
+
+/* 2-column layout: cards 1 & 2 on the first row, card 3 wraps to its
+   own row at half width. Sidebars no longer push a card off-screen
+   because two 1fr columns always fit within the content area. */
+.overview-role-grid > div {
+    min-width: 0; /* prevent grid blowout from wide code blocks */
+}
+
+/* Scroll code blocks horizontally instead of expanding the card */
+.overview-role-grid pre {
+    overflow-x: auto;
+    white-space: pre;
+}
+
+/* Collapse to single column on mobile */
+@media (max-width: 600px) {
+    .overview-role-grid {
+        grid-template-columns: 1fr !important;
+    }
+}

--- a/tinytorch/site/_static/custom.css
+++ b/tinytorch/site/_static/custom.css
@@ -2007,3 +2007,29 @@ html[data-theme="dark"] .preface-howtolearn-card p {
         grid-template-columns: 1fr !important;
     }
 }
+
+
+/* Shared dark base for all three role cards */
+html[data-theme="dark"] .overview-role-card {
+    filter: none !important;
+    background: #1e1e2e !important;
+}
+html[data-theme="dark"] .overview-role-subtitle {
+    color: #94a3b8 !important;
+}
+html[data-theme="dark"] .overview-role-card p:not(.overview-role-subtitle),
+html[data-theme="dark"] .overview-role-card li,
+html[data-theme="dark"] .overview-role-card strong {
+    color: #cbd5e1 !important;
+}
+
+/* Per-card h3 accent colors — lighter versions of each brand color */
+html[data-theme="dark"] .overview-student-card .overview-role-heading {
+    color: #90caf9 !important; /* light blue */
+}
+html[data-theme="dark"] .overview-instructor-card .overview-role-heading {
+    color: #ffb74d !important; /* light amber */
+}
+html[data-theme="dark"] .overview-developer-card .overview-role-heading {
+    color: #ce93d8 !important; /* light purple */
+}

--- a/tinytorch/site/tito/overview.md
+++ b/tinytorch/site/tito/overview.md
@@ -333,7 +333,7 @@ tito milestone status
 
 Here's what a typical TinyTorch session looks like:
 
-<div style="background: #f8f9fa; padding: 1.5rem; border: 1px solid #dee2e6; border-radius: 0.5rem; margin: 1.5rem 0;">
+<div class="overview-session-box" style="background: #f8f9fa; padding: 1.5rem; border: 1px solid #dee2e6; border-radius: 0.5rem; margin: 1.5rem 0;">
 
 **1. Start Session**
 ```bash

--- a/tinytorch/site/tito/overview.md
+++ b/tinytorch/site/tito/overview.md
@@ -36,7 +36,7 @@
 
 TinyTorch serves three types of users. Choose your path:
 
-<div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 1.5rem; margin: 2rem 0;">
+<div class="overview-role-grid" style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 1.5rem; margin: 2rem 0;">
 
 <div style="background: #e3f2fd; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #2196f3;">
 <h3 style="margin: 0 0 1rem 0; color: #1976d2;"> Student / Learner</h3>

--- a/tinytorch/site/tito/overview.md
+++ b/tinytorch/site/tito/overview.md
@@ -38,9 +38,9 @@ TinyTorch serves three types of users. Choose your path:
 
 <div class="overview-role-grid" style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 1.5rem; margin: 2rem 0;">
 
-<div style="background: #e3f2fd; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #2196f3;">
-<h3 style="margin: 0 0 1rem 0; color: #1976d2;"> Student / Learner</h3>
-<p style="margin: 0 0 1rem 0; font-size: 0.9rem; color: #37474f;">You're learning ML systems by building from scratch</p>
+<div class="overview-role-card overview-student-card" style="background: #e3f2fd; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #2196f3;">
+<h3 class="overview-role-heading" style="margin: 0 0 1rem 0; color: #1976d2;"> Student / Learner</h3>
+<p class="overview-role-subtitle" style="margin: 0 0 1rem 0; font-size: 0.9rem; color: #37474f;">You're learning ML systems by building from scratch</p>
 
 **Your Workflow:**
 ```bash
@@ -64,9 +64,9 @@ tito module status
 
 </div>
 
-<div style="background: #fff3e0; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #f57c00;">
-<h3 style="margin: 0 0 1rem 0; color: #e65100;"> Instructor</h3>
-<p style="margin: 0 0 1rem 0; font-size: 0.9rem; color: #37474f;">You're teaching ML systems engineering</p>
+<div class="overview-role-card overview-instructor-card" style="background: #fff3e0; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #f57c00;">
+<h3 class="overview-role-heading" style="margin: 0 0 1rem 0; color: #e65100;"> Instructor</h3>
+<p class="overview-role-subtitle" style="margin: 0 0 1rem 0; font-size: 0.9rem; color: #37474f;">You're teaching ML systems engineering</p>
 
 **Your Workflow:**
 ```bash
@@ -99,9 +99,9 @@ tito nbgrader report
 
 </div>
 
-<div style="background: #f3e5f5; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #9c27b0;">
-<h3 style="margin: 0 0 1rem 0; color: #7b1fa2;">👩💻 Developer / Contributor</h3>
-<p style="margin: 0 0 1rem 0; font-size: 0.9rem; color: #37474f;">You're contributing to TinyTorch modules</p>
+<div class="overview-role-card overview-developer-card" style="background: #f3e5f5; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #9c27b0;">
+<h3 class="overview-role-heading" style="margin: 0 0 1rem 0; color: #7b1fa2;">👩💻 Developer / Contributor</h3>
+<p class="overview-role-subtitle" style="margin: 0 0 1rem 0; font-size: 0.9rem; color: #37474f;">You're contributing to TinyTorch modules</p>
 
 **Your Workflow:**
 ```bash


### PR DESCRIPTION
## Problem

Two sections on the overview page had invisible text in dark mode due to
hardcoded light colors in inline `style` attributes.

**"Commands by User Role" cards (×3)** — three issues per card:
1. Light pastel backgrounds (`#e3f2fd`, `#fff3e0`, `#f3e5f5`) only handled
   by the broad `filter: brightness(0.7)` rule, leaving them visibly light
2. Subtitle `color: #37474f` (dark gray) — invisible on any dark background
3. h3 brand colors (`#1976d2`, `#e65100`, `#7b1fa2`) — dark tones unreadable
   on dimmed pastel backgrounds

**"Typical Session Flow" box** — `background: #f8f9fa` and
`border: 1px solid #dee2e6` with zero dark mode CSS, making all content
inside invisible in dark mode.

## Solution

**`tito/overview.md`** — Added semantic CSS classes to each affected element:

| Element | Class added |
|---|---|
| Student card | `overview-role-card overview-student-card` |
| Instructor card | `overview-role-card overview-instructor-card` |
| Developer card | `overview-role-card overview-developer-card` |
| All h3 headings | `overview-role-heading` |
| All subtitle paragraphs | `overview-role-subtitle` |
| Session Flow box | `overview-session-box` |

**`_static/custom.css`** — Added targeted `html[data-theme="dark"]` overrides:

- `filter: none !important` on all role cards to bypass brightness dimmer,
  replaced with a proper dark background (`#1e1e2e`)
- `#37474f` subtitle text → `#94a3b8` (muted slate)
- Per-card h3 accent colors using lighter brand tones:
  Student `#1976d2` → `#90caf9` · Instructor `#e65100` → `#ffb74d` · Developer `#7b1fa2` → `#ce93d8`
- Session Flow box: `#f8f9fa` bg → `#1e293b`, border → `#334155`, text → `#e2e8f0`

## Files changed
- `tinytorch/site/tito/overview.md` — 10 lines changed (class attributes added)
- `tinytorch/site/_static/custom.css` — 38 lines added (dark mode overrides)
