### PR TITLE
fix(tinytorch): ensure model params have requires_grad=True in trainer_init

### DIFF
--- a/tinytorch/src/08_training/08_training.py
+++ b/tinytorch/src/08_training/08_training.py
@@ -632,8 +632,10 @@ def trainer_init(self, model, optimizer, loss_fn, scheduler=None, grad_clip_norm
     # Enable gradient tracking for all model parameters.
     # Layers (e.g. Linear) may be created without requires_grad=True,
     # so we set it explicitly here to ensure backward() populates param.grad.
+    # Guard against raw numpy arrays passed by test stubs or non-Tensor params.
     for param in model.parameters():
-        param.requires_grad = True
+        if isinstance(param, Tensor):
+            param.requires_grad = True
 
     # Training state
     self.epoch = 0

--- a/tinytorch/src/08_training/08_training.py
+++ b/tinytorch/src/08_training/08_training.py
@@ -608,8 +608,9 @@ def trainer_init(self, model, optimizer, loss_fn, scheduler=None, grad_clip_norm
 
     APPROACH:
     1. Store model, optimizer, loss_fn, scheduler, and grad_clip_norm as attributes
-    2. Initialize epoch=0, step=0, training_mode=True
-    3. Create history dict with keys: 'train_loss', 'eval_loss', 'learning_rates'
+    2. Enable gradient tracking: set requires_grad=True on all model.parameters()
+    3. Initialize epoch=0, step=0, training_mode=True
+    4. Create history dict with keys: 'train_loss', 'eval_loss', 'learning_rates'
        (each mapping to an empty list)
 
     EXAMPLE:
@@ -627,6 +628,12 @@ def trainer_init(self, model, optimizer, loss_fn, scheduler=None, grad_clip_norm
     self.loss_fn = loss_fn
     self.scheduler = scheduler
     self.grad_clip_norm = grad_clip_norm
+
+    # Enable gradient tracking for all model parameters.
+    # Layers (e.g. Linear) may be created without requires_grad=True,
+    # so we set it explicitly here to ensure backward() populates param.grad.
+    for param in model.parameters():
+        param.requires_grad = True
 
     # Training state
     self.epoch = 0


### PR DESCRIPTION
Fixes #1334 — `test_unit_trainer_optimizer_update` fails with "Parameters should change after optimizer update" because `param.grad` is never populated.

**Root cause:** `Linear.__init__` creates weights with `requires_grad=False`. `tracked_mse_forward` only attaches a backward graph `if predictions.requires_grad` — so `loss.backward()` returns immediately and no gradients flow. `Optimizer.__init__` does set the flag but only on construction; any ordering edge case silently breaks the chain.

**Fix:** iterate `model.parameters()` in `trainer_init` and set `requires_grad = True`, making the Trainer the authoritative owner of gradient tracking.

| File | Change |
|------|--------|
| `tinytorch/src/08_training/08_training.py` | `requires_grad = True` loop in solution block; APPROACH docstring updated |