### PR TITLE
fix(ci): move path vars to workflow-level env so fork PRs can build

### DIFF
--- a/.github/workflows/kits-validate-dev.yml
+++ b/.github/workflows/kits-validate-dev.yml
@@ -47,6 +47,13 @@ concurrency:
   group: kits-validate-${{ github.ref }}
   cancel-in-progress: true
 
+# Workflow-level environment. Defined here rather than as a repository variable
+# because repository variables are not exposed to workflows triggered by
+# pull_request events from forks (GitHub security default). Workflow-level
+# env vars are available in all contexts.
+env:
+  KITS_ROOT: kits
+
 jobs:
   # ===========================================================================
   # Stage 1: Content validation (image refs, cross-refs)
@@ -107,17 +114,17 @@ jobs:
         uses: quarto-dev/quarto-actions/setup@v2
 
       - name: 🔨 Build Kits Site (HTML)
-        working-directory: ${{ vars.KITS_ROOT }}
+        working-directory: ${{ env.KITS_ROOT }}
         run: quarto render
 
       - name: 🔍 Validate build output
         run: |
-          if [ ! -f "${{ vars.KITS_ROOT }}/_build/index.html" ]; then
+          if [ ! -f "${{ env.KITS_ROOT }}/_build/index.html" ]; then
             echo "❌ CRITICAL: index.html missing from build output."
             exit 1
           fi
           echo "✅ Site built successfully"
-          echo "📊 Build size: $(du -sh ${{ vars.KITS_ROOT }}/_build | cut -f1)"
+          echo "📊 Build size: $(du -sh ${{ env.KITS_ROOT }}/_build | cut -f1)"
 
   # ===========================================================================
   # Stage 3: PDF build validation (reuse existing workflow)

--- a/.github/workflows/labs-validate-dev.yml
+++ b/.github/workflows/labs-validate-dev.yml
@@ -49,6 +49,13 @@ concurrency:
   group: labs-validate-${{ github.ref }}
   cancel-in-progress: true
 
+# Workflow-level environment. Defined here rather than as a repository variable
+# because repository variables are not exposed to workflows triggered by
+# pull_request events from forks (GitHub security default). Workflow-level
+# env vars are available in all contexts.
+env:
+  LABS_ROOT: labs
+
 jobs:
   # ===========================================================================
   # Stage 1: Python syntax + import validation
@@ -118,17 +125,17 @@ jobs:
         uses: quarto-dev/quarto-actions/setup@v2
 
       - name: 🔨 Build Labs Site
-        working-directory: ${{ vars.LABS_ROOT }}
+        working-directory: ${{ env.LABS_ROOT }}
         run: quarto render
 
       - name: 🔍 Validate build output
         run: |
-          if [ ! -f "${{ vars.LABS_ROOT }}/_build/index.html" ]; then
+          if [ ! -f "${{ env.LABS_ROOT }}/_build/index.html" ]; then
             echo "❌ CRITICAL: index.html missing from build output."
             exit 1
           fi
           echo "✅ Site built successfully"
-          echo "📊 Build size: $(du -sh ${{ vars.LABS_ROOT }}/_build | cut -f1)"
+          echo "📊 Build size: $(du -sh ${{ env.LABS_ROOT }}/_build | cut -f1)"
 
   # ===========================================================================
   # Stage 3: WASM export smoke test

--- a/.github/workflows/mlsysim-validate-dev.yml
+++ b/.github/workflows/mlsysim-validate-dev.yml
@@ -43,6 +43,13 @@ concurrency:
   group: mlsysim-validate-${{ github.ref }}
   cancel-in-progress: true
 
+# Workflow-level environment. Defined here rather than as a repository variable
+# because repository variables are not exposed to workflows triggered by
+# pull_request events from forks (GitHub security default). Workflow-level
+# env vars are available in all contexts.
+env:
+  MLSYSIM_DOCS: mlsysim/docs
+
 jobs:
   test:
     name: '🧪 Run Tests'
@@ -86,14 +93,14 @@ jobs:
         run: pip install ".[docs]"
 
       - name: 🔨 Build MLSYSIM Site
-        working-directory: ${{ vars.MLSYSIM_DOCS }}
+        working-directory: ${{ env.MLSYSIM_DOCS }}
         run: quarto render
 
       - name: 🔍 Validate build output
         run: |
-          if [ ! -f "${{ vars.MLSYSIM_DOCS }}/_build/index.html" ]; then
+          if [ ! -f "${{ env.MLSYSIM_DOCS }}/_build/index.html" ]; then
             echo "❌ CRITICAL: index.html missing from build output."
             exit 1
           fi
           echo "✅ Site built successfully"
-          echo "📊 Build size: $(du -sh ${{ vars.MLSYSIM_DOCS }}/_build | cut -f1)"
+          echo "📊 Build size: $(du -sh ${{ env.MLSYSIM_DOCS }}/_build | cut -f1)"


### PR DESCRIPTION
## problem

repository variables (`vars.LABS_ROOT`, `vars.KITS_ROOT`, `vars.MLSYSIM_DOCS`) are not exposed to workflows triggered by `pull_request` events from forks. this is a github security default, not a misconfiguration.

when a fork PR modifies files under `labs/`, `kits/`, or `mlsysim/`, the validate-dev workflow runs and `vars.*` resolves to empty string. this causes:

- `working-directory: ${{ vars.LABS_ROOT }}` becomes empty, so `quarto render` runs from the repo root instead of `labs/`
- the validation step looks for `/_build/index.html` (absolute root with leading slash) instead of `labs/_build/index.html`
- quarto exits quickly with nothing to render and the index.html check fails

evidence: on #1306, #1331, #1339 the CI log shows `if [ ! -f "/_build/index.html" ]`. on dev it shows `if [ ! -f "labs/_build/index.html" ]`. same workflow, different resolution depending on fork vs non-fork context.

## fix

declare the path at workflow level via `env:`, not `vars:`. workflow env is available in all contexts including fork PRs. the abstraction (named variable) is preserved, storage just moves from repo-level to file-level. the value is effectively a constant anyway.

changed files:
- `.github/workflows/labs-validate-dev.yml` — `LABS_ROOT: labs`
- `.github/workflows/kits-validate-dev.yml` — `KITS_ROOT: kits`
- `.github/workflows/mlsysim-validate-dev.yml` — `MLSYSIM_DOCS: mlsysim/docs`

## scope

only the three validate-dev workflows that trigger on `pull_request` events. other workflows using `vars.*` run on `push`, `workflow_run`, or `workflow_dispatch` where repo vars are available, so they are correct as written.

## impact

once merged, re-running CI on open fork PRs (#1306, #1331, #1339) will use this fixed workflow file and produce real build signal for the first time. the three fork PRs have been stuck on this CI failure for days through no fault of their authors.