### PR TITLE
feat(ci): tooling to catch fork-PR variable leaks and marimo dataflow bugs

### DIFF
--- a/.github/scripts/check_workflow_fork_safety.py
+++ b/.github/scripts/check_workflow_fork_safety.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""
+Check that workflows triggered by pull_request events do not reference
+repository variables that won't be available on fork PRs.
+
+Why this exists
+---------------
+GitHub does not expose repository variables to workflows triggered by
+``pull_request`` events from forks. This is a security default. When a
+workflow references ``${{ vars.* }}`` and runs on a fork PR, the
+reference resolves to an empty string, which almost always leads to
+silent build failures that look like "file missing" errors instead of
+the real configuration problem.
+
+Secrets are an even stronger case: ``${{ secrets.* }}`` is stripped for
+fork PRs with the sole exception of ``secrets.GITHUB_TOKEN``, which is
+always available (GitHub provides it automatically). Workflows that
+need real secrets on PR should use ``pull_request_target`` (which runs
+with target-branch context) and understand the security implications.
+
+Incident: PR #1344. Three validate workflows used
+``${{ vars.LABS_ROOT }}`` / ``${{ vars.KITS_ROOT }}`` /
+``${{ vars.MLSYSIM_DOCS }}``. Every fork PR that touched those
+directories silently failed its CI for a week before the pattern was
+identified. The fix was to move the constants into workflow-level
+``env:`` blocks, which ARE available in all contexts.
+
+What this script does
+---------------------
+1. Parse every workflow file under ``.github/workflows/`` as YAML.
+2. If its ``on:`` section declares a ``pull_request`` trigger (not
+   ``pull_request_target``, which has target-branch context), scan the
+   raw file text for ``${{ vars.* }}`` and for ``${{ secrets.* }}``
+   references other than ``secrets.GITHUB_TOKEN``.
+3. Skip comment lines and YAML block-scalar comments.
+4. Fail with file:line:token pointers.
+
+How to fix a violation
+----------------------
+Replace the ``vars.*`` reference with a workflow-level ``env:`` block::
+
+    env:
+      LABS_ROOT: labs
+
+    jobs:
+      ...
+        steps:
+          - working-directory: ${{ env.LABS_ROOT }}
+
+Workflow-level env vars ARE exposed to fork PRs.
+
+Exit codes
+----------
+0   All clean.
+1   At least one violation found.
+2   Script error (could not parse a workflow, missing directory, etc).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print(
+        "error: PyYAML is required. install with: pip install pyyaml",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+WORKFLOW_DIR = Path(".github/workflows")
+
+# Match ${{ vars.NAME }} or ${{ secrets.NAME }} with optional whitespace.
+UNSAFE_PATTERN = re.compile(r"\$\{\{\s*(vars|secrets)\.(\w+)\s*\}\}")
+
+# GITHUB_TOKEN is the one secret that IS available on fork PRs.
+ALWAYS_AVAILABLE_SECRETS = {"GITHUB_TOKEN"}
+
+
+def triggers_on_pull_request(workflow_yaml: dict) -> bool:
+    """True if the workflow's on: section declares a pull_request trigger.
+
+    We treat pull_request_target as safe because it runs with
+    target-branch context and DOES have access to repo vars/secrets.
+    Only plain pull_request is fork-unsafe.
+    """
+    on_section = workflow_yaml.get("on", workflow_yaml.get(True))
+    # PyYAML parses the bare keyword `on` as the Python boolean True
+    # in some YAML contexts, so we also check the True key.
+
+    if on_section is None:
+        return False
+    if isinstance(on_section, str):
+        return on_section == "pull_request"
+    if isinstance(on_section, list):
+        return "pull_request" in on_section
+    if isinstance(on_section, dict):
+        return "pull_request" in on_section
+    return False
+
+
+def strip_comment(line: str) -> str:
+    """Remove YAML inline comment. Preserves # inside quoted strings.
+
+    Good enough for our purposes - we're scanning for ${{ ... }}
+    patterns and any # inside a ${{ }} would be unusual.
+    """
+    in_single_quote = False
+    in_double_quote = False
+    for i, ch in enumerate(line):
+        if ch == "'" and not in_double_quote:
+            in_single_quote = not in_single_quote
+        elif ch == '"' and not in_single_quote:
+            in_double_quote = not in_double_quote
+        elif ch == "#" and not in_single_quote and not in_double_quote:
+            return line[:i]
+    return line
+
+
+def find_violations(path: Path) -> list[tuple[int, str, str]]:
+    """Return [(line_number, token, context), ...] for fork-unsafe refs.
+
+    Returns empty list if the workflow does not trigger on pull_request.
+    """
+    text = path.read_text()
+    try:
+        parsed = yaml.safe_load(text)
+    except yaml.YAMLError as e:
+        raise RuntimeError(f"could not parse {path} as YAML: {e}")
+
+    if not isinstance(parsed, dict):
+        return []
+    if not triggers_on_pull_request(parsed):
+        return []
+
+    violations: list[tuple[int, str, str]] = []
+    for lineno, raw_line in enumerate(text.splitlines(), start=1):
+        # Skip lines that are entirely comment. Inline comments after
+        # the match still get scanned (but strip_comment removes the
+        # comment portion first).
+        stripped_leading = raw_line.lstrip()
+        if stripped_leading.startswith("#"):
+            continue
+        code_part = strip_comment(raw_line)
+        for match in UNSAFE_PATTERN.finditer(code_part):
+            kind = match.group(1)  # "vars" or "secrets"
+            name = match.group(2)
+            if kind == "secrets" and name in ALWAYS_AVAILABLE_SECRETS:
+                continue
+            token = f"{kind}.{name}"
+            violations.append((lineno, token, raw_line.strip()))
+    return violations
+
+
+def format_violation(path: Path, lineno: int, token: str, context: str) -> str:
+    kind = token.split(".", 1)[0]
+    return (
+        f"  {path}:{lineno}\n"
+        f"    token:   ${{{{ {token} }}}}\n"
+        f"    context: {context}\n"
+        f"    fix:     replace {kind}.* with a workflow-level env: block.\n"
+        f"             see .github/scripts/check_workflow_fork_safety.py for why.\n"
+    )
+
+
+def main() -> int:
+    if not WORKFLOW_DIR.is_dir():
+        print(f"error: {WORKFLOW_DIR} not found", file=sys.stderr)
+        return 2
+
+    total_violations = 0
+    exposed_workflows = 0
+    scanned = 0
+
+    workflow_paths = sorted(
+        list(WORKFLOW_DIR.glob("*.yml")) + list(WORKFLOW_DIR.glob("*.yaml"))
+    )
+
+    for workflow_path in workflow_paths:
+        scanned += 1
+        try:
+            violations = find_violations(workflow_path)
+        except RuntimeError as e:
+            print(f"error: {e}", file=sys.stderr)
+            return 2
+        except OSError as e:
+            print(f"error: could not read {workflow_path}: {e}", file=sys.stderr)
+            return 2
+
+        try:
+            parsed = yaml.safe_load(workflow_path.read_text())
+            if isinstance(parsed, dict) and triggers_on_pull_request(parsed):
+                exposed_workflows += 1
+        except yaml.YAMLError:
+            continue
+
+        if violations:
+            print(f"\nfork-unsafe references in {workflow_path}:")
+            for lineno, token, context in violations:
+                print(format_violation(workflow_path, lineno, token, context))
+                total_violations += 1
+
+    if total_violations == 0:
+        print(
+            f"ok: scanned {scanned} workflows; "
+            f"{exposed_workflows} trigger on pull_request; "
+            f"none reference vars.* or (non-GITHUB_TOKEN) secrets.*"
+        )
+        return 0
+
+    print(
+        f"\nfound {total_violations} fork-unsafe reference(s) across "
+        f"{exposed_workflows} pull_request-exposed workflow(s).",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci-sanity.yml
+++ b/.github/workflows/ci-sanity.yml
@@ -1,0 +1,57 @@
+name: '🧪 CI Sanity'
+
+# =============================================================================
+# Cross-cutting CI hygiene checks
+# =============================================================================
+#
+# Small, fast checks that catch bug classes affecting the CI system itself
+# rather than any single subsystem's content.
+#
+# Current checks:
+#   - workflow-fork-safety: ensure no pull_request-triggered workflow
+#     references vars.* or (non-GITHUB_TOKEN) secrets.*, since those
+#     are not exposed to fork PRs and cause silent build failures.
+#
+# Triggers:
+#   - pull_request on changes to .github/
+#   - push to dev on changes to .github/
+#   - workflow_dispatch for manual runs
+# =============================================================================
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/**'
+  push:
+    branches: [dev]
+    paths:
+      - '.github/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-sanity-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  workflow-fork-safety:
+    name: '🔐 Workflow fork-safety'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v6
+
+      - name: 🐍 Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: 📦 Install PyYAML
+        run: pip install pyyaml
+
+      - name: 🔐 Check workflows are safe for fork PRs
+        run: python3 .github/scripts/check_workflow_fork_safety.py

--- a/.github/workflows/kits-validate-dev.yml
+++ b/.github/workflows/kits-validate-dev.yml
@@ -119,12 +119,21 @@ jobs:
 
       - name: 🔍 Validate build output
         run: |
-          if [ ! -f "${{ env.KITS_ROOT }}/_build/index.html" ]; then
-            echo "❌ CRITICAL: index.html missing from build output."
+          KITS_ROOT="${{ env.KITS_ROOT }}"
+          echo "🔎 Resolved KITS_ROOT: '${KITS_ROOT}'"
+          if [ -z "${KITS_ROOT}" ]; then
+            echo "❌ FATAL: KITS_ROOT resolved to empty string."
+            echo "   If this is a fork PR, check that KITS_ROOT is declared in the workflow-level env: block."
+            echo "   Repository variables are not available on fork PR triggers."
+            exit 1
+          fi
+          if [ ! -f "${KITS_ROOT}/_build/index.html" ]; then
+            echo "❌ CRITICAL: ${KITS_ROOT}/_build/index.html missing from build output."
+            echo "   Quarto render may have exited nonzero. Check the build step above."
             exit 1
           fi
           echo "✅ Site built successfully"
-          echo "📊 Build size: $(du -sh ${{ env.KITS_ROOT }}/_build | cut -f1)"
+          echo "📊 Build size: $(du -sh ${KITS_ROOT}/_build | cut -f1)"
 
   # ===========================================================================
   # Stage 3: PDF build validation (reuse existing workflow)

--- a/.github/workflows/labs-validate-dev.yml
+++ b/.github/workflows/labs-validate-dev.yml
@@ -130,12 +130,21 @@ jobs:
 
       - name: 🔍 Validate build output
         run: |
-          if [ ! -f "${{ env.LABS_ROOT }}/_build/index.html" ]; then
-            echo "❌ CRITICAL: index.html missing from build output."
+          LABS_ROOT="${{ env.LABS_ROOT }}"
+          echo "🔎 Resolved LABS_ROOT: '${LABS_ROOT}'"
+          if [ -z "${LABS_ROOT}" ]; then
+            echo "❌ FATAL: LABS_ROOT resolved to empty string."
+            echo "   If this is a fork PR, check that LABS_ROOT is declared in the workflow-level env: block."
+            echo "   Repository variables are not available on fork PR triggers."
+            exit 1
+          fi
+          if [ ! -f "${LABS_ROOT}/_build/index.html" ]; then
+            echo "❌ CRITICAL: ${LABS_ROOT}/_build/index.html missing from build output."
+            echo "   Quarto render may have exited nonzero. Check the build step above."
             exit 1
           fi
           echo "✅ Site built successfully"
-          echo "📊 Build size: $(du -sh ${{ env.LABS_ROOT }}/_build | cut -f1)"
+          echo "📊 Build size: $(du -sh ${LABS_ROOT}/_build | cut -f1)"
 
   # ===========================================================================
   # Stage 3: WASM export smoke test

--- a/.github/workflows/mlsysim-validate-dev.yml
+++ b/.github/workflows/mlsysim-validate-dev.yml
@@ -98,9 +98,18 @@ jobs:
 
       - name: 🔍 Validate build output
         run: |
-          if [ ! -f "${{ env.MLSYSIM_DOCS }}/_build/index.html" ]; then
-            echo "❌ CRITICAL: index.html missing from build output."
+          MLSYSIM_DOCS="${{ env.MLSYSIM_DOCS }}"
+          echo "🔎 Resolved MLSYSIM_DOCS: '${MLSYSIM_DOCS}'"
+          if [ -z "${MLSYSIM_DOCS}" ]; then
+            echo "❌ FATAL: MLSYSIM_DOCS resolved to empty string."
+            echo "   If this is a fork PR, check that MLSYSIM_DOCS is declared in the workflow-level env: block."
+            echo "   Repository variables are not available on fork PR triggers."
+            exit 1
+          fi
+          if [ ! -f "${MLSYSIM_DOCS}/_build/index.html" ]; then
+            echo "❌ CRITICAL: ${MLSYSIM_DOCS}/_build/index.html missing from build output."
+            echo "   Quarto render may have exited nonzero. Check the build step above."
             exit 1
           fi
           echo "✅ Site built successfully"
-          echo "📊 Build size: $(du -sh ${{ env.MLSYSIM_DOCS }}/_build | cut -f1)"
+          echo "📊 Build size: $(du -sh ${MLSYSIM_DOCS}/_build | cut -f1)"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -418,6 +418,20 @@ repos:
   # Removed: TinyTorch has its own CLI validation system
 
   # ===========================================================================
+  # SECTION 3.5: CI SANITY (workflow hygiene)
+  # Files: .github/workflows/*.yml
+  # ===========================================================================
+
+  - repo: local
+    hooks:
+      - id: ci-check-workflow-fork-safety
+        name: "CI: Check workflows are safe for fork PRs"
+        entry: python3 .github/scripts/check_workflow_fork_safety.py
+        language: system
+        pass_filenames: false
+        files: ^\.github/workflows/.*\.(yml|yaml)$
+
+  # ===========================================================================
   # SECTION 4: STAFFML HOOKS (Vault data validation)
   # Files: interviews/staffml/src/data/*.json, interviews/vault/*.json
   # ===========================================================================

--- a/labs/tests/test_static.py
+++ b/labs/tests/test_static.py
@@ -265,3 +265,127 @@ class TestWASMCompatibility:
                         f"WASM-incompatible import 'from {node.module}' at line {node.lineno}. "
                         f"This package is not available in Pyodide."
                     )
+
+
+# ── Test: Marimo Dataflow ────────────────────────────────────────────────────
+
+def _has_app_cell_decorator(func):
+    """True if the function is decorated with @app.cell or @app.cell(...)."""
+    for dec in func.decorator_list:
+        if isinstance(dec, ast.Attribute) and isinstance(dec.value, ast.Name):
+            if dec.value.id == "app" and dec.attr == "cell":
+                return True
+        if isinstance(dec, ast.Call) and isinstance(dec.func, ast.Attribute):
+            if (
+                isinstance(dec.func.value, ast.Name)
+                and dec.func.value.id == "app"
+                and dec.func.attr == "cell"
+            ):
+                return True
+    return False
+
+
+def _is_mo_stop_call(stmt):
+    """True if stmt is an expression statement calling mo.stop(...)."""
+    if not isinstance(stmt, ast.Expr) or not isinstance(stmt.value, ast.Call):
+        return False
+    func = stmt.value.func
+    return (
+        isinstance(func, ast.Attribute)
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "mo"
+        and func.attr == "stop"
+    )
+
+
+def _is_mo_ui_assign(stmt):
+    """If stmt is `<name> = mo.ui.<widget>(...)`, return the name. Else None."""
+    if not isinstance(stmt, ast.Assign) or len(stmt.targets) != 1:
+        return None
+    target = stmt.targets[0]
+    if not isinstance(target, ast.Name) or not isinstance(stmt.value, ast.Call):
+        return None
+    func = stmt.value.func
+    while isinstance(func, ast.Attribute):
+        if (
+            isinstance(func.value, ast.Attribute)
+            and isinstance(func.value.value, ast.Name)
+            and func.value.value.id == "mo"
+            and func.value.attr == "ui"
+        ):
+            return target.id
+        func = func.value if isinstance(func.value, ast.Attribute) else None
+        if func is None:
+            break
+    return None
+
+
+def _returned_names(func):
+    """Names listed in the cell's return statement."""
+    for node in ast.walk(func):
+        if isinstance(node, ast.Return) and node.value is not None:
+            if isinstance(node.value, ast.Tuple):
+                return {elt.id for elt in node.value.elts if isinstance(elt, ast.Name)}
+            if isinstance(node.value, ast.Name):
+                return {node.value.id}
+    return set()
+
+
+class TestMarimoDataflow:
+    """Detect the widget-in-gated-cell anti-pattern.
+
+    When a @app.cell has mo.stop() AND defines mo.ui.* widgets that
+    appear in the cell's return tuple, those widgets will not exist
+    until the gate unblocks. Any cell that depends on them cannot run,
+    which produces a "dependency undefined" cascade manifesting as
+    widgets invisibly failing to render.
+
+    Proper pattern (see lab_02's prediction cells): define widgets in
+    their own un-gated cell. Gate cells should be pure `mo.stop()`
+    statements with no side-effect widget definitions.
+
+    This bug class is tracked as an open cleanup effort. The test is
+    xfail-marked until a systematic refactor lands across all labs.
+    Once that tracking issue is closed, remove the xfail.
+    """
+
+    @pytest.mark.xfail(
+        reason=(
+            "widget-in-gated-cell pattern exists in most labs today. the "
+            "systematic refactor is a separate tracking effort. once labs are "
+            "converted to the proper pattern (widget in its own cell, gate cell "
+            "is pure mo.stop), remove this xfail."
+        ),
+        strict=False,
+    )
+    def test_no_widget_defined_in_gated_cell(self, lab_path):
+        tree = parse_tree(lab_path)
+        violations = []
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if not _has_app_cell_decorator(node):
+                continue
+            if not any(_is_mo_stop_call(s) for s in node.body):
+                continue
+            widgets_defined = {}
+            for s in node.body:
+                name = _is_mo_ui_assign(s)
+                if name is not None:
+                    widgets_defined[name] = s.lineno
+            leaked = widgets_defined.keys() & _returned_names(node)
+            if leaked:
+                violations.append((node.lineno, sorted(leaked)))
+
+        if violations:
+            summary = "\n".join(
+                f"  cell at line {line}: gated AND returns widgets {names}"
+                for line, names in violations
+            )
+            pytest.fail(
+                "widget defined in gated cell (will not render until gate unblocks):\n"
+                + summary
+                + "\n\nfix: move widget definitions to their own un-gated cell. "
+                "gate cells should be pure mo.stop(). see lab_02's prediction "
+                "cells for the canonical pattern."
+            )


### PR DESCRIPTION
adds static checks for two bug classes we hit in the last week, each of which produced silent, long-lived failures:

## bug classes

**1. workflow fork-safety (the #1344 incident).** any `pull_request`-triggered workflow that references `${{ vars.* }}` or non-`GITHUB_TOKEN` `${{ secrets.* }}` breaks silently on fork PRs, because repository variables and secrets are not exposed in that context by GitHub's security default. the token resolves to empty string, the working directory is wrong, and the final validation step looks for a file at the wrong path. one week of broken fork CI on #1306, #1331, #1339 before anyone noticed.

**2. marimo widget-in-gated-cell (the lab_01 incident, fixed by #1339).** when an `@app.cell` function contains `mo.stop()` AND defines `mo.ui.*` widgets that appear in its return tuple, those widgets don't exist until the gate unblocks. every cell that depends on them cascades to undefined state.

## what's in this PR

| file | purpose |
|------|---------|
| `.github/scripts/check_workflow_fork_safety.py` | standalone python + PyYAML. parses each workflow, identifies pull_request triggers, flags unsafe vars/secrets references with file:line:token pointers and fix hints. exempts `secrets.GITHUB_TOKEN` which is always available. |
| `.github/workflows/ci-sanity.yml` | new workflow on `.github/**` changes. runs the fork-safety check so contributors without pre-commit still get caught. |
| `.pre-commit-config.yaml` | new hook under a SECTION 3.5: CI SANITY for local fast feedback. |
| `labs/tests/test_static.py` | new `TestMarimoDataflow` class with `test_no_widget_defined_in_gated_cell`. AST-based. marked `xfail` because 32 of 33 labs currently have the pattern; a systematic refactor is separate scope. once labs are converted (see `vol2/lab_05_dist_train` for the proper pattern), remove the xfail. |
| `labs-validate-dev.yml`, `kits-validate-dev.yml`, `mlsysim-validate-dev.yml` | "Validate build output" step now echoes the resolved env var and fails loudly if empty, with a message explaining the fork-PR var issue. would have diagnosed #1344 in 30 seconds instead of a week. |

## verification

- `python3 .github/scripts/check_workflow_fork_safety.py` — ok, scanned 47 workflows, 8 trigger on pull_request, 0 violations
- `marimo check labs/vol{1,2}/*.py` — clean across all 33 labs (after #1345)
- `pytest labs/tests/test_static.py` — 656 passed, 4 skipped, 33 xfailed, 1 xpassed
- the xpassed lab is `vol2/lab_05_dist_train` — it's the canonical reference for the proper pattern

## not in this PR

- full refactor of the 33 labs to remove the widget-in-gated-cell pattern. that's a separate tracking issue; the xfail in the new test will enforce strict checking once the refactor lands.