### PR TITLE
refactor(labs/lab_06): migrate fault-tolerance lab to Pattern C (proof lab)

### DIFF
--- a/labs/vol2/lab_06_fault_tolerance.py
+++ b/labs/vol2/lab_06_fault_tolerance.py
@@ -213,9 +213,7 @@ def _(mo):
 
 # ─── CELL 5: PART A REFLECTION + PART B PREDICTION WIDGETS ──────────────────
 @app.cell(hide_code=True)
-def _(mo, partA_prediction):
-    mo.stop(partA_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partA_reflection = mo.ui.radio(
         options={
             "A) Double the checkpoint frequency to protect against failures": "A",
@@ -240,9 +238,7 @@ def _(mo, partA_prediction):
 
 # ─── CELL 6: PART B CONTROLS + SYNTHESIS WIDGETS ────────────────────────────
 @app.cell(hide_code=True)
-def _(mo, partB_prediction):
-    mo.stop(partB_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     a2_model_b = mo.ui.slider(start=1, stop=175, value=175, step=1, label="Model size (B params)")
     a2_cluster_gpus = mo.ui.slider(start=100, stop=25000, value=1000, step=100, label="Cluster GPUs")
     a2_storage = mo.ui.dropdown(
@@ -265,9 +261,7 @@ def _(mo, partB_prediction):
 
 # ─── CELL 6b: PART C WIDGETS ─────────────────────────────────────────────────
 @app.cell(hide_code=True)
-def _(mo, partB_reflection):
-    mo.stop(partB_reflection.value is None, mo.md("**Complete Part B reflection to unlock Part C.**"))
-
+def _(mo):
     partC_prediction = mo.ui.radio(
         options={
             "A) 10 seconds -- NVMe is fast": "A",
@@ -294,9 +288,7 @@ def _(mo, partB_reflection):
 
 # ─── CELL 6c: PART D WIDGETS ─────────────────────────────────────────────────
 @app.cell(hide_code=True)
-def _(mo, partC_reflection):
-    mo.stop(partC_reflection.value is None, mo.md("**Complete Part C reflection to unlock Part D.**"))
-
+def _(mo):
     partD_prediction = mo.ui.radio(
         options={
             "A) 1 replica -- just restart the failed one": "A",
@@ -1467,8 +1459,6 @@ def _(
 # ─── CELL 9: LEDGER_HUD ─────────────────────────────────────────────────────
 @app.cell(hide_code=True)
 def _(COLORS, partA_prediction, partB_prediction, mo):
-    mo.stop(partA_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
     _a1_ok = partA_prediction.value == "C"
     _a2_ok = partB_prediction.value == "C"
     _tier = "Optimal" if (_a1_ok and _a2_ok) else ("Partial" if (_a1_ok or _a2_ok) else "Developing")


### PR DESCRIPTION
first of 14 labs to migrate per #1347. this is the proof-of-pattern PR; once CI validates and you sign off, the remaining 13 can follow the same template (or be batched).

## bug fixed

two experts independently flagged a dangling `mo.stop(partA_prediction.value is None, ...)` in the LEDGER_HUD cell at the bottom of this lab. the message "Make your prediction above to unlock this part" has no sensible referent at the bottom of the page, and the HUD's own logic (`_a1_ok = partA_prediction.value == "C"`) already handles None-value correctly. this PR removes it.

## the pattern

applies the canonical pattern from `vol2/lab_05_dist_train` (the only lab that currently XPASSes the widget-gated-cell check). widget cells become pure widget definitions; gating lives inside `build_part_X()` functions via `if partX_prediction.value is None: items.append(mo.callout(...)); return`. the internal gates were already written in lab_06 (lines 413, 652, etc.) — the cell-level `mo.stop` calls were redundant gating on top.

## what changes for the student

before: tabs don't render until student answers predictions A → B → C → D in sequence (cell-level gates cascade).

after: all 5 tabs (A, B, C, D, Synthesis) render immediately on load. each tab still shows its own unlock message until that part's prediction is answered. synthesis tab is accessible at any time as an advance organizer, matching the TEMPLATE intent.

## 5 mo.stop calls removed

- cell at line 215 (was gated on partA_prediction)
- cell at line 242 (was gated on partB_prediction)
- cell at line 267 (was gated on partB_reflection)
- cell at line 296 (was gated on partC_reflection)
- cell at line 1468 (LEDGER_HUD, the expert-flagged dangling gate)

cell signatures simplified where the gate dep was only used in the removed `mo.stop`.

## verification

- `marimo check` — clean
- `pytest labs/tests/test_engine.py -k lab_06_fault` — 2/2 passed (cells execute, produce outputs)
- `pytest labs/tests/test_static.py -k lab_06_fault` — 20 passed; `test_no_widget_defined_in_gated_cell` XPASSED (lab no longer has the pattern)
- programmatic `app.run()` — 12 cell outputs, 49 definitions, all 18 expected widgets + tabs cell defined
- `marimo export html-wasm` — valid HTML produced

## net diff

`4 insertions(+), 14 deletions(-)` — small and mechanical.

## related

- #1347 tracks the 14-lab refactor effort
- #1350 updated the test check to use the multi-widget-leak threshold (less strict than the original test in #1346)
- if this lands cleanly, vol2/lab_07 through vol2/lab_16 + vol2/lab_01 + vol1/lab_00 follow the same template