### PR TITLE
refactor(labs): migrate 30 labs to Pattern C (closes out #1347)

### DIFF
--- a/labs/tests/test_static.py
+++ b/labs/tests/test_static.py
@@ -372,21 +372,11 @@ class TestMarimoDataflow:
     # per-lab (tracked in #1347). As each lab is converted to the
     # one-widget-per-gated-cell pattern (see lab_01 post-#1339 or lab_05_dist_train),
     # remove it from this set. When the set is empty the bug class is closed.
+    # Only vol1/lab_00 remains. Its check1/check2/check3 pattern is structurally
+    # different from the partX_prediction idiom and the mechanical Pattern C
+    # transformation breaks test_engine.py. Needs manual per-cell refactor.
     _KNOWN_MULTI_LEAK_LABS = frozenset({
         "vol1/lab_00_introduction.py",
-        "vol1/lab_01_ml_intro.py",
-        "vol2/lab_01_introduction.py",
-        "vol2/lab_06_fault_tolerance.py",
-        "vol2/lab_07_fleet_orch.py",
-        "vol2/lab_08_inference.py",
-        "vol2/lab_09_perf_engineering.py",
-        "vol2/lab_10_edge_intelligence.py",
-        "vol2/lab_11_ops_scale.py",
-        "vol2/lab_12_security_privacy.py",
-        "vol2/lab_13_robust_ai.py",
-        "vol2/lab_14_sustainable_ai.py",
-        "vol2/lab_15_responsible_ai.py",
-        "vol2/lab_16_fleet_synthesis.py",
     })
 
     def test_no_multi_widget_leak_in_gated_cell(self, lab_path):

--- a/labs/vol1/lab_01_ml_intro.py
+++ b/labs/vol1/lab_01_ml_intro.py
@@ -277,9 +277,7 @@ def _(
     return (partA_prediction,)
 
 @app.cell(hide_code=True)
-def _(mo, partA_prediction):
-    mo.stop(partA_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     # Part B widgets
     partB_prediction = mo.ui.radio(
         options={
@@ -294,9 +292,7 @@ def _(mo, partA_prediction):
     return (partB_prediction,)
 
 @app.cell(hide_code=True)
-def _(mo, partB_prediction):
-    mo.stop(partB_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     # Part C widgets
     partC_prediction = mo.ui.radio(
         options={
@@ -311,9 +307,7 @@ def _(mo, partB_prediction):
     return (partC_prediction,)
 
 @app.cell(hide_code=True)
-def _(mo, partC_prediction):
-    mo.stop(partC_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     # Part D widgets
     partD_prediction = mo.ui.radio(
         options={
@@ -328,9 +322,7 @@ def _(mo, partC_prediction):
     return (partD_prediction,)
 
 @app.cell(hide_code=True)
-def _(DecisionLog, mo, partD_prediction):
-    mo.stop(partD_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(DecisionLog, mo):
     partA_scenario = mo.ui.dropdown(
         options={
             "Rec System: stale training data": "stale_data",

--- a/labs/vol1/lab_02_ml_systems.py
+++ b/labs/vol1/lab_02_ml_systems.py
@@ -286,9 +286,7 @@ def _(
     return (partA_prediction,)
 
 @app.cell(hide_code=True)
-def _(mo, partA_prediction):
-    mo.stop(partA_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partA_ai = mo.ui.slider(
         start=1, stop=400, value=5, step=1,
         label="Arithmetic Intensity (FLOPs/Byte)",
@@ -309,9 +307,7 @@ def _(mo, partA_prediction):
     return (partB_prediction,)
 
 @app.cell(hide_code=True)
-def _(mo, partB_prediction):
-    mo.stop(partB_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partB_distance = mo.ui.slider(
         start=0, stop=5000, value=1500, step=50,
         label="Datacenter distance (km)",
@@ -336,9 +332,7 @@ def _(mo, partB_prediction):
     return (partC_prediction,)
 
 @app.cell(hide_code=True)
-def _(mo, partC_prediction):
-    mo.stop(partC_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partC_target = mo.ui.dropdown(
         options={
             "Cloud (300W TDP)": "cloud",
@@ -374,8 +368,6 @@ def _(mo, partC_prediction):
 
 @app.cell(hide_code=True)
 def _(mo, partD_prediction):
-    mo.stop(partD_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
     partD_data_size = mo.ui.slider(
         start=1, stop=1024, value=16, step=1,
         label="Data size (KB)",

--- a/labs/vol1/lab_03_ml_workflow.py
+++ b/labs/vol1/lab_03_ml_workflow.py
@@ -206,9 +206,7 @@ def _(
     return (partA_prediction,)
 
 @app.cell(hide_code=True)
-def _(mo, partA_prediction):
-    mo.stop(partA_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partA_stage = mo.ui.slider(
         start=1, stop=6, value=5, step=1,
         label="Discovery stage (1=Problem Definition, 6=Monitoring)",
@@ -228,9 +226,7 @@ def _(mo, partA_prediction):
     return (partB_prediction,)
 
 @app.cell(hide_code=True)
-def _(mo, partB_prediction):
-    mo.stop(partB_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partB_cycle_a = mo.ui.slider(
         start=1, stop=336, value=168, step=1,
         label="Team A cycle time (hours)",
@@ -254,9 +250,7 @@ def _(mo, partB_prediction):
     return (partC_prediction,)
 
 @app.cell(hide_code=True)
-def _(mo, partC_prediction):
-    mo.stop(partC_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partC_sliders = {
         "data_collect": mo.ui.slider(start=0, stop=20, value=3, step=1,
                                       label="Data Collection (person-months)"),
@@ -285,8 +279,6 @@ def _(mo, partC_prediction):
 
 @app.cell(hide_code=True)
 def _(mo, partD_prediction):
-    mo.stop(partD_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
     partD_months = mo.ui.slider(
         start=0, stop=24, value=0, step=1,
         label="Months since production launch",

--- a/labs/vol1/lab_04_data_engr.py
+++ b/labs/vol1/lab_04_data_engr.py
@@ -208,9 +208,7 @@ def _(
     return (partA_prediction,)
 
 @app.cell(hide_code=True)
-def _(mo, partA_prediction):
-    mo.stop(partA_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partA_storage = mo.ui.dropdown(
         options={
             "HDD (100 MB/s)": 100, "SSD (250 MB/s)": 250,
@@ -237,9 +235,7 @@ def _(mo, partA_prediction):
     return (partB_prediction,)
 
 @app.cell(hide_code=True)
-def _(mo, partB_prediction):
-    mo.stop(partB_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partB_dataset = mo.ui.slider(
         start=1, stop=500, value=50, step=1,
         label="Dataset size (TB)",
@@ -263,9 +259,7 @@ def _(mo, partB_prediction):
     return (partC_prediction,)
 
 @app.cell(hide_code=True)
-def _(mo, partC_prediction):
-    mo.stop(partC_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partC_error_rate = mo.ui.slider(
         start=0.5, stop=10.0, value=2.0, step=0.5,
         label="Ingestion error rate (%)",
@@ -290,8 +284,6 @@ def _(mo, partC_prediction):
 
 @app.cell(hide_code=True)
 def _(mo, partD_prediction):
-    mo.stop(partD_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
     partD_tolerance = mo.ui.slider(
         start=1, stop=50, value=1, step=1,
         label="False wake-ups per month (tolerance)",

--- a/labs/vol1/lab_05_nn_compute.py
+++ b/labs/vol1/lab_05_nn_compute.py
@@ -238,9 +238,7 @@ def _(
     return (partA_prediction,)
 
 @app.cell(hide_code=True)
-def _(mo, partA_prediction):
-    mo.stop(partA_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partA_context = mo.ui.radio(
         options={"Cloud GPU (H100)": "cloud", "Mobile NPU (iPhone)": "mobile"},
         value="Cloud GPU (H100)",
@@ -278,9 +276,7 @@ def _(mo, partA_prediction):
     return (partB_prediction,)
 
 @app.cell(hide_code=True)
-def _(mo, partB_prediction):
-    mo.stop(partB_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partB_context = mo.ui.radio(
         options={"Cloud GPU (H100)": "cloud", "Mobile NPU (iPhone)": "mobile"},
         value="Mobile NPU (iPhone)",
@@ -308,9 +304,7 @@ def _(mo, partB_prediction):
     return (partC_prediction,)
 
 @app.cell(hide_code=True)
-def _(mo, partC_prediction):
-    mo.stop(partC_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partC_width = mo.ui.slider(
         start=32, stop=2048, value=128, step=32, label="Hidden layer width",
     )
@@ -330,8 +324,6 @@ def _(mo, partC_prediction):
 
 @app.cell(hide_code=True)
 def _(mo, partD_prediction):
-    mo.stop(partD_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
     partD_depth = mo.ui.slider(
         start=3, stop=50, value=20, step=1, label="Network depth (layers)",
     )

--- a/labs/vol1/lab_06_nn_arch.py
+++ b/labs/vol1/lab_06_nn_arch.py
@@ -230,9 +230,7 @@ def _(
     return (partA_prediction,)
 
 @app.cell(hide_code=True)
-def _(mo, partA_prediction):
-    mo.stop(partA_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partA_arch = mo.ui.radio(
         options={"MLP (no structure)": "mlp", "CNN 3x3": "cnn3", "CNN 5x5": "cnn5"},
         value="MLP (no structure)", label="Architecture:", inline=True,
@@ -255,9 +253,7 @@ def _(mo, partA_prediction):
     return (partB_prediction,)
 
 @app.cell(hide_code=True)
-def _(mo, partB_prediction):
-    mo.stop(partB_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partB_seq_len = mo.ui.slider(
         start=512, stop=131072, value=4096, step=512, label="Sequence length (tokens)",
     )
@@ -279,9 +275,7 @@ def _(mo, partB_prediction):
     return (partC_prediction,)
 
 @app.cell(hide_code=True)
-def _(mo, partC_prediction):
-    mo.stop(partC_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partC_depth = mo.ui.slider(
         start=2, stop=128, value=64, step=2, label="Depth (layers)",
     )
@@ -304,8 +298,6 @@ def _(mo, partC_prediction):
 
 @app.cell(hide_code=True)
 def _(mo, partD_prediction):
-    mo.stop(partD_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
     partD_batch_d = mo.ui.slider(
         start=1, stop=256, value=1, step=1, label="Batch size",
     )

--- a/labs/vol1/lab_07_ml_frameworks.py
+++ b/labs/vol1/lab_07_ml_frameworks.py
@@ -241,9 +241,7 @@ def _(
     return (partA_prediction,)
 
 @app.cell(hide_code=True)
-def _(mo, partA_prediction):
-    mo.stop(partA_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partA_kernels = mo.ui.slider(
         start=10, stop=2000, value=1000, step=10, label="Number of kernels",
     )
@@ -265,9 +263,7 @@ def _(mo, partA_prediction):
     return (partB_prediction,)
 
 @app.cell(hide_code=True)
-def _(mo, partB_prediction):
-    mo.stop(partB_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partB_num_ops = mo.ui.slider(
         start=2, stop=8, value=3, step=1, label="Operations to fuse",
     )
@@ -289,9 +285,7 @@ def _(mo, partB_prediction):
     return (partC_prediction,)
 
 @app.cell(hide_code=True)
-def _(mo, partC_prediction):
-    mo.stop(partC_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partC_compile_time = mo.ui.slider(
         start=5, stop=300, value=30, step=5, label="Compile time (seconds)",
     )
@@ -314,8 +308,6 @@ def _(mo, partC_prediction):
 
 @app.cell(hide_code=True)
 def _(mo, partD_prediction):
-    mo.stop(partD_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
     partD_framework = mo.ui.dropdown(
         options={"PyTorch": "PyTorch", "TensorFlow": "TensorFlow",
                  "ONNX Runtime": "ONNX Runtime", "TF Lite": "TF Lite",

--- a/labs/vol1/lab_08_model_train.py
+++ b/labs/vol1/lab_08_model_train.py
@@ -232,9 +232,7 @@ def _(
     return (partA_prediction,)
 
 @app.cell(hide_code=True)
-def _(mo, partA_prediction):
-    mo.stop(partA_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partA_model_size = mo.ui.slider(
         start=0.1, stop=70, value=7, step=0.1, label="Model size (billions of params)",
     )
@@ -262,9 +260,7 @@ def _(mo, partA_prediction):
     return (partB_prediction,)
 
 @app.cell(hide_code=True)
-def _(mo, partB_prediction):
-    mo.stop(partB_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partB_data_ms = mo.ui.slider(
         start=1, stop=100, value=50, step=1, label="Data loading (ms)",
     )
@@ -292,9 +288,7 @@ def _(mo, partB_prediction):
     return (partC_prediction,)
 
 @app.cell(hide_code=True)
-def _(mo, partC_prediction):
-    mo.stop(partC_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partC_model_c = mo.ui.slider(
         start=0.1, stop=13, value=1.5, step=0.1, label="Model size (billions)",
     )
@@ -318,8 +312,6 @@ def _(mo, partC_prediction):
 
 @app.cell(hide_code=True)
 def _(mo, partD_prediction):
-    mo.stop(partD_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
     partD_gpus = mo.ui.slider(
         start=1, stop=256, value=8, step=1, label="Number of GPUs",
     )

--- a/labs/vol1/lab_09_data_selection.py
+++ b/labs/vol1/lab_09_data_selection.py
@@ -228,9 +228,7 @@ def _(
     return (partA_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, partA_pred):
-    mo.stop(partA_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partA_frac = mo.ui.slider(
         start=5, stop=100, value=100, step=5,
         label="Dataset fraction (%)",
@@ -255,9 +253,7 @@ def _(mo, partA_pred):
     return (partB_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, partB_pred):
-    mo.stop(partB_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partB_coreset = mo.ui.slider(
         start=10, stop=90, value=50, step=5,
         label="Coreset fraction (%)",
@@ -293,9 +289,7 @@ def _(mo, partB_pred):
     return (partC_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, partC_pred):
-    mo.stop(partC_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partC_workers = mo.ui.slider(
         start=1, stop=16, value=8, step=1,
         label="CPU workers",
@@ -330,8 +324,6 @@ def _(mo, partC_pred):
 
 @app.cell(hide_code=True)
 def _(mo, partD_pred):
-    mo.stop(partD_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
     partD_params_b = mo.ui.slider(
         start=0.5, stop=50, value=10, step=0.5,
         label="Model size (B parameters)",

--- a/labs/vol1/lab_10_model_compress.py
+++ b/labs/vol1/lab_10_model_compress.py
@@ -236,9 +236,7 @@ def _(
     return (pA_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, pA_pred):
-    mo.stop(pA_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pA_precision = mo.ui.dropdown(
         options={"FP32": "fp32", "FP16": "fp16", "INT8": "int8", "INT4": "int4", "INT2": "int2"},
         value="FP32",
@@ -263,9 +261,7 @@ def _(mo, pA_pred):
     return (pB_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, pB_pred):
-    mo.stop(pB_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pB_sparsity = mo.ui.slider(start=0, stop=95, value=0, step=5, label="Sparsity (%)")
     pB_type = mo.ui.dropdown(
         options={"Unstructured": "unstructured", "Structured": "structured", "2:4 Structured": "2_4"},
@@ -285,9 +281,7 @@ def _(mo, pB_pred):
     return (pC_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, pC_pred):
-    mo.stop(pC_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pD_pred = mo.ui.radio(
         options={
             "A) 50/50 -- balanced": "50_50",
@@ -300,9 +294,7 @@ def _(mo, pC_pred):
     return (pD_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, pD_pred):
-    mo.stop(pD_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pD_precision_e = mo.ui.dropdown(
         options={"FP32": "fp32", "FP16": "fp16", "INT8": "int8", "INT4": "int4"},
         value="FP32",
@@ -327,8 +319,6 @@ def _(mo, pD_pred):
 
 @app.cell(hide_code=True)
 def _(mo, pE_pred):
-    mo.stop(pE_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
     pE_temp = mo.ui.slider(start=1.0, stop=20.0, value=4.0, step=0.5, label="Temperature")
 
     # ─────────────────────────────────────────────────────────────────────

--- a/labs/vol1/lab_11_hw_accel.py
+++ b/labs/vol1/lab_11_hw_accel.py
@@ -227,9 +227,7 @@ def _(
     return (pA_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, pA_pred):
-    mo.stop(pA_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pA_dim = mo.ui.slider(start=128, stop=8192, value=512, step=128, label="Matrix dimension N")
     pA_prec = mo.ui.radio(
         options={"FP32": "fp32", "FP16": "fp16", "INT8": "int8"},
@@ -248,9 +246,7 @@ def _(mo, pA_pred):
     return (pB_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, pB_pred):
-    mo.stop(pB_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pB_mode = mo.ui.radio(
         options={"Eager (separate kernels)": "eager", "Fused (single kernel)": "fused"},
         value="Eager (separate kernels)", label="Execution mode:", inline=True,
@@ -269,9 +265,7 @@ def _(mo, pB_pred):
     return (pC_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, pC_pred):
-    mo.stop(pC_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pC_hw = mo.ui.radio(
         options={"Cloud (H100)": "h100", "Edge (Jetson Orin NX)": "jetson", "Mobile (A17 Pro)": "iphone"},
         value="Cloud (H100)", label="Hardware:", inline=True,
@@ -289,9 +283,7 @@ def _(mo, pC_pred):
     return (pD_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, pD_pred):
-    mo.stop(pD_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pE_pred = mo.ui.radio(
         options={
             "A) ~1.2x (minor)": "1_2",
@@ -305,8 +297,6 @@ def _(mo, pD_pred):
 
 @app.cell(hide_code=True)
 def _(mo, pE_pred):
-    mo.stop(pE_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
     pE_tile = mo.ui.slider(start=32, stop=2048, value=256, step=32, label="Tile size (elements)")
     pE_seq = mo.ui.slider(start=512, stop=16384, value=4096, step=512, label="Sequence length")
 

--- a/labs/vol1/lab_12_perf_bench.py
+++ b/labs/vol1/lab_12_perf_bench.py
@@ -224,9 +224,7 @@ def _(
     return (pA_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, pA_pred):
-    mo.stop(pA_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pA_speedup = mo.ui.slider(start=1, stop=100, value=10, step=1, label="Inference speedup (x)")
     pA_serial = mo.ui.slider(start=5, stop=80, value=45, step=5, label="Non-inference fraction (%)")
 
@@ -243,9 +241,7 @@ def _(mo, pA_pred):
     return (pB_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, pB_pred):
-    mo.stop(pB_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pB_time = mo.ui.slider(start=0, stop=600, value=0, step=10, label="Time (seconds)")
     pB_ambient = mo.ui.slider(start=20, stop=45, value=35, step=1, label="Ambient temp (C)")
     pB_cooling = mo.ui.dropdown(
@@ -266,9 +262,7 @@ def _(mo, pB_pred):
     return (pC_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, pC_pred):
-    mo.stop(pC_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pC_batch = mo.ui.slider(start=1, stop=64, value=1, step=1, label="Batch size")
     pC_precision = mo.ui.dropdown(
         options={"FP32": "fp32", "FP16": "fp16", "INT8": "int8"},
@@ -289,8 +283,6 @@ def _(mo, pC_pred):
 
 @app.cell(hide_code=True)
 def _(mo, pD_pred):
-    mo.stop(pD_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
     pD_sigma = mo.ui.slider(start=0.1, stop=1.5, value=0.8, step=0.05, label="Tail heaviness (sigma)")
     pD_slo = mo.ui.slider(start=50, stop=500, value=200, step=10, label="SLO threshold (ms)")
 

--- a/labs/vol1/lab_13_model_serving.py
+++ b/labs/vol1/lab_13_model_serving.py
@@ -212,9 +212,7 @@ def _(
     return (partA_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, partA_pred):
-    mo.stop(partA_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partA_rho = mo.ui.slider(start=0.10, stop=0.95, value=0.80, step=0.05,
                               label="Server utilization (rho)")
     partA_svc = mo.ui.slider(start=1.0, stop=20.0, value=5.0, step=1.0,
@@ -235,9 +233,7 @@ def _(mo, partA_pred):
     return (partB_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, partB_pred):
-    mo.stop(partB_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partB_batch = mo.ui.slider(start=1, stop=64, value=1, step=1, label="Batch size")
     partB_arr = mo.ui.slider(start=100, stop=2000, value=500, step=50, label="Arrival rate (QPS)")
     partB_slo = mo.ui.slider(start=10, stop=100, value=50, step=5, label="SLO budget (ms)")
@@ -255,9 +251,7 @@ def _(mo, partB_pred):
     return (partC_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, partC_pred):
-    mo.stop(partC_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partC_model = mo.ui.dropdown(options={"7B": 7, "13B": 13, "70B": 70}, value="70B",
                                   label="Model size")
     partC_prec = mo.ui.dropdown(
@@ -283,8 +277,6 @@ def _(mo, partC_pred):
 
 @app.cell(hide_code=True)
 def _(mo, partD_pred):
-    mo.stop(partD_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
     partD_model = mo.ui.dropdown(options={"7B": 7, "13B": 13, "70B": 70}, value="70B",
                                   label="Model size")
     partD_stor = mo.ui.dropdown(

--- a/labs/vol1/lab_14_ml_ops.py
+++ b/labs/vol1/lab_14_ml_ops.py
@@ -186,9 +186,7 @@ def _(COLORS, H100_TDP_W, H100_TFLOPS_FP16, JETSON_TDP_W, JETSON_TFLOPS, apply_p
     return (partA_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, partA_pred):
-    mo.stop(partA_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partA_weeks = mo.ui.slider(start=0, stop=26, value=0, step=1,
                                 label="Weeks since deployment")
     partA_drift_rate = mo.ui.slider(start=0.005, stop=0.05, value=0.02, step=0.005,
@@ -207,9 +205,7 @@ def _(mo, partA_pred):
     return (partB_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, partB_pred):
-    mo.stop(partB_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partB_retrain_cost = mo.ui.slider(start=1000, stop=50000, value=10000, step=1000,
                                        label="Retraining cost ($)")
     partB_drift_cost = mo.ui.slider(start=100, stop=5000, value=500, step=100,
@@ -228,9 +224,7 @@ def _(mo, partB_pred):
     return (partC_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, partC_pred):
-    mo.stop(partC_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partC_cloud_cost = mo.ui.slider(start=500, stop=10000, value=1000, step=500,
                                      label="Cloud retrain cost ($)")
     partC_edge_cost = mo.ui.slider(start=10000, stop=500000, value=100000, step=10000,
@@ -252,8 +246,6 @@ def _(mo, partC_pred):
 
 @app.cell(hide_code=True)
 def _(mo, partD_pred):
-    mo.stop(partD_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
     partD_missed = mo.ui.slider(start=1, stop=6, value=3, step=1,
                                  label="Missed retraining cycles")
     partD_downstream = mo.ui.slider(start=0, stop=5, value=2, step=1,

--- a/labs/vol1/lab_15_responsible_engr.py
+++ b/labs/vol1/lab_15_responsible_engr.py
@@ -185,9 +185,7 @@ def _(COLORS, H100_TDP_W, JETSON_TDP_W, apply_plotly_theme, go, math, mo, np):
     return (partA_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, partA_pred):
-    mo.stop(partA_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partA_base_a = mo.ui.slider(start=5, stop=50, value=30, step=5,
                                  label="Group A base rate (%)")
     partA_base_b = mo.ui.slider(start=5, stop=50, value=10, step=5,
@@ -208,9 +206,7 @@ def _(mo, partA_pred):
     return (partB_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, partB_pred):
-    mo.stop(partB_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partB_target_gap = mo.ui.slider(start=0, stop=20, value=5, step=1,
                                      label="Target FPR gap (pp)")
     partB_method = mo.ui.dropdown(
@@ -231,9 +227,7 @@ def _(mo, partB_pred):
     return (partC_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, partC_pred):
-    mo.stop(partC_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partC_features = mo.ui.slider(start=10, stop=200, value=50, step=10,
                                    label="Number of features")
     partC_method = mo.ui.dropdown(
@@ -255,8 +249,6 @@ def _(mo, partC_pred):
 
 @app.cell(hide_code=True)
 def _(mo, partD_pred):
-    mo.stop(partD_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
     partD_retrain_freq = mo.ui.dropdown(
         options={"Weekly": 52, "Monthly": 12, "Quarterly": 4, "Once": 1},
         value="Weekly", label="Retraining frequency")

--- a/labs/vol1/lab_16_ml_conclusion.py
+++ b/labs/vol1/lab_16_ml_conclusion.py
@@ -199,9 +199,7 @@ def _(
     return (partA_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, partA_pred):
-    mo.stop(partA_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partA_model = mo.ui.dropdown(options={"7B": 7, "13B": 13, "70B": 70}, value="70B",
                                   label="Model size")
     partA_prec = mo.ui.dropdown(
@@ -222,9 +220,7 @@ def _(mo, partA_pred):
     return (partB_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, partB_pred):
-    mo.stop(partB_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partB_quant = mo.ui.dropdown(
         options={"FP32": "fp32", "FP16": "fp16", "INT8": "int8", "INT4": "int4"},
         value="INT8", label="Quantization level")
@@ -249,11 +245,9 @@ def _(mo, partB_pred):
     return (partC_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, partC_pred):
+def _(mo):
 
     # ── Part D widgets ────────────────────────────────────────────────────────
-    mo.stop(partC_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
     partD_pred = mo.ui.radio(
         options={
             "A) Preprocessing (35% -- largest non-inference)": "preprocess",
@@ -267,9 +261,7 @@ def _(mo, partC_pred):
     return (partD_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, partD_pred):
-    mo.stop(partD_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partD_preprocess = mo.ui.slider(start=5, stop=50, value=35, step=5,
                                      label="Preprocessing (%)")
     partD_inference = mo.ui.slider(start=5, stop=60, value=40, step=5,
@@ -299,8 +291,6 @@ def _(mo, partD_pred):
 
 @app.cell(hide_code=True)
 def _(mo, partE_pred):
-    mo.stop(partE_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
     partE_int4 = mo.ui.checkbox(label="INT4 Quantization", value=False)
     partE_pruning = mo.ui.checkbox(label="Structured Pruning (50%)", value=False)
     partE_distill = mo.ui.checkbox(label="Knowledge Distillation", value=False)

--- a/labs/vol2/lab_01_introduction.py
+++ b/labs/vol2/lab_01_introduction.py
@@ -259,9 +259,7 @@ def _(
     return (partA_prediction,)
 
 @app.cell(hide_code=True)
-def _(mo, partA_prediction):
-    mo.stop(partA_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partA_fleet_size = mo.ui.slider(
         start=100, stop=25000, value=1000, step=100,
         label="Fleet size (GPUs)",
@@ -285,9 +283,7 @@ def _(mo, partA_prediction):
     return (partB_prediction,)
 
 @app.cell(hide_code=True)
-def _(mo, partB_prediction):
-    mo.stop(partB_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partB_gpu_count = mo.ui.slider(
         start=1, stop=1024, value=256, step=1, label="Number of GPUs",
     )
@@ -318,9 +314,7 @@ def _(mo, partB_prediction):
     return (partC_prediction,)
 
 @app.cell(hide_code=True)
-def _(mo, partC_prediction):
-    mo.stop(partC_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partC_params = mo.ui.slider(start=1, stop=100, value=10, step=1, label="Model params (B)")
     partC_tokens = mo.ui.slider(start=10, stop=10000, value=200, step=10, label="Training tokens (B)")
 
@@ -338,9 +332,7 @@ def _(mo, partC_prediction):
     return (partD_prediction,)
 
 @app.cell(hide_code=True)
-def _(mo, partD_prediction):
-    mo.stop(partD_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partD_comm_frac = mo.ui.slider(start=0.01, stop=0.50, value=0.20, step=0.01, label="Communication fraction (r)")
     partD_n_gpus = mo.ui.slider(start=1, stop=512, value=64, step=1, label="Number of GPUs")
     partD_overlap = mo.ui.slider(start=0, stop=80, value=0, step=10, label="Overlap (%)")

--- a/labs/vol2/lab_02_compute_infra.py
+++ b/labs/vol2/lab_02_compute_infra.py
@@ -263,9 +263,7 @@ def _(
     return (pA_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, pA_pred):
-    mo.stop(pA_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pA_model = mo.ui.dropdown(
         options={"7B": 7, "70B": 70, "175B": 175},
         value="70B", label="Model size (B params)",
@@ -284,9 +282,7 @@ def _(mo, pA_pred):
     return (pB_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, pB_pred):
-    mo.stop(pB_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pB_hw = mo.ui.dropdown(
         options={"V100": "v100", "A100": "a100", "H100": "h100", "B200": "b200"},
         value="H100", label="Accelerator",
@@ -304,9 +300,7 @@ def _(mo, pB_pred):
     return (pC_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, pC_pred):
-    mo.stop(pC_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pC_size = mo.ui.slider(start=1, stop=10000, value=10000, step=100, label="Transfer size (MB)")
 
     pD_pred = mo.ui.radio(
@@ -322,9 +316,7 @@ def _(mo, pC_pred):
     return (pD_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, pD_pred):
-    mo.stop(pD_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pD_model_b = mo.ui.slider(start=1, stop=175, value=175, step=1, label="Model params (B)")
     pD_gpus = mo.ui.slider(start=1, stop=8, value=8, step=1, label="GPUs per node")
     pD_zero = mo.ui.dropdown(
@@ -345,8 +337,6 @@ def _(mo, pD_pred):
 
 @app.cell(hide_code=True)
 def _(mo, pE_pred):
-    mo.stop(pE_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
     pE_n_gpus = mo.ui.slider(start=100, stop=5000, value=1000, step=100, label="GPU count")
     pE_util = mo.ui.slider(start=30, stop=90, value=70, step=5, label="Utilization (%)")
     pE_pue = mo.ui.slider(start=1.06, stop=1.60, value=1.12, step=0.02, label="PUE")

--- a/labs/vol2/lab_03_communication.py
+++ b/labs/vol2/lab_03_communication.py
@@ -230,9 +230,7 @@ def _(
     return (pA_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, pA_pred):
-    mo.stop(pA_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pA_model = mo.ui.dropdown(
         options={"1B": 1, "7B": 7, "13B": 13, "70B": 70, "175B": 175},
         value="70B", label="Model params (B)",
@@ -258,9 +256,7 @@ def _(mo, pA_pred):
     return (pB_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, pB_pred):
-    mo.stop(pB_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pB_msg_exp = mo.ui.slider(start=0, stop=10, value=0, step=1, label="Message size (10^x KB)")
     pB_n_gpus = mo.ui.dropdown(
         options={"64": 64, "256": 256, "1024": 1024},
@@ -279,9 +275,7 @@ def _(mo, pB_pred):
     return (pC_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, pC_pred):
-    mo.stop(pC_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pC_topo = mo.ui.dropdown(
         options={"Flat Ring": "flat", "Hierarchical 2-level": "hier2"},
         value="Flat Ring", label="Topology",
@@ -305,9 +299,7 @@ def _(mo, pC_pred):
     return (pD_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, pD_pred):
-    mo.stop(pD_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pD_comp = mo.ui.dropdown(
         options={"None": 1.0, "FP16 (2x)": 0.5, "INT8 (4x)": 0.25, "Top-K 1%": 0.01, "1-bit": 0.03125},
         value="None", label="Compression method",
@@ -328,8 +320,6 @@ def _(mo, pD_pred):
 
 @app.cell(hide_code=True)
 def _(mo, pE_pred):
-    mo.stop(pE_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
     pE_hier = mo.ui.checkbox(label="Hierarchical AllReduce")
     pE_fp16 = mo.ui.checkbox(label="FP16 gradients")
     pE_bucket = mo.ui.checkbox(label="Bucket fusion")

--- a/labs/vol2/lab_04_data_storage.py
+++ b/labs/vol2/lab_04_data_storage.py
@@ -229,9 +229,7 @@ def _(
     return (pA_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, pA_pred):
-    mo.stop(pA_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pA_gen = mo.ui.dropdown(
         options={"V100 (2017)": "v100", "A100 (2020)": "a100", "H100 (2022)": "h100", "B200 (2024)": "b200"},
         value="H100 (2022)", label="GPU generation",
@@ -249,9 +247,7 @@ def _(mo, pA_pred):
     return (pB_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, pB_pred):
-    mo.stop(pB_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pB_gpus = mo.ui.slider(start=8, stop=1024, value=128, step=8, label="GPU count")
     pB_target = mo.ui.slider(start=50, stop=95, value=80, step=5, label="Target utilization (%)")
 
@@ -267,9 +263,7 @@ def _(mo, pB_pred):
     return (pC_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, pC_pred):
-    mo.stop(pC_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pC_workers = mo.ui.slider(start=8, stop=256, value=256, step=8, label="GPU workers")
     pC_shards = mo.ui.slider(start=100, stop=10000, value=1000, step=100, label="Dataset shards")
 
@@ -285,9 +279,7 @@ def _(mo, pC_pred):
     return (pD_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, pD_pred):
-    mo.stop(pD_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pD_compute = mo.ui.slider(start=100, stop=500, value=200, step=10, label="Compute time (ms)")
     pD_io = mo.ui.slider(start=50, stop=1000, value=300, step=10, label="I/O time (ms)")
     pD_prefetch = mo.ui.slider(start=0, stop=8, value=0, step=1, label="Prefetch depth")
@@ -305,8 +297,6 @@ def _(mo, pD_pred):
 
 @app.cell(hide_code=True)
 def _(mo, pE_pred):
-    mo.stop(pE_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
     pE_mtbf = mo.ui.slider(start=1, stop=24, value=5, step=1, label="Cluster MTBF (hours)")
     pE_write = mo.ui.slider(start=30, stop=300, value=120, step=10, label="Checkpoint write time (s)")
     pE_interval = mo.ui.slider(start=1, stop=120, value=30, step=1, label="Checkpoint interval (min)")

--- a/labs/vol2/lab_07_fleet_orch.py
+++ b/labs/vol2/lab_07_fleet_orch.py
@@ -220,9 +220,7 @@ def _(mo):
 
 # ─── CELL 5: Part B prediction + controls ────────────────────────────────────
 @app.cell(hide_code=True)
-def _(mo, partA_prediction):
-    mo.stop(partA_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partB_prediction = mo.ui.radio(
         options={
             "A) Yes -- a good scheduler can achieve all three simultaneously": "A",
@@ -250,9 +248,7 @@ def _(mo, partA_prediction):
 
 # ─── CELL 5b: Part C prediction + controls ────────────────────────────────
 @app.cell(hide_code=True)
-def _(mo, partB_reflection):
-    mo.stop(partB_reflection.value is None, mo.md("**Complete Part B reflection to unlock Part C.**"))
-
+def _(mo):
     partC_prediction = mo.ui.radio(
         options={
             "A) Zero cost -- preemption just moves jobs around": "A",
@@ -279,9 +275,7 @@ def _(mo, partB_reflection):
 
 # ─── CELL 5c: Part D prediction + controls ────────────────────────────────
 @app.cell(hide_code=True)
-def _(mo, partC_reflection):
-    mo.stop(partC_reflection.value is None, mo.md("**Complete Part C reflection to unlock Part D.**"))
-
+def _(mo):
     partD_prediction = mo.ui.radio(
         options={
             "A) 30% -- same as single cluster": "A",

--- a/labs/vol2/lab_08_inference.py
+++ b/labs/vol2/lab_08_inference.py
@@ -211,9 +211,7 @@ def _(mo):
 
 # ─── CELL 5: Part A controls + Part A reflection + Part B prediction ─────────
 @app.cell(hide_code=True)
-def _(mo, partA_prediction):
-    mo.stop(partA_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     a1_qps = mo.ui.slider(start=10, stop=1000, value=100, step=10, label="Queries per second (QPS)")
     a1_cost_query = mo.ui.slider(start=0.001, stop=0.05, value=0.01, step=0.001, label="Cost per query ($)")
     a1_weeks = mo.ui.slider(start=1, stop=52, value=26, step=1, label="Deployment duration (weeks)")
@@ -245,9 +243,7 @@ def _(mo, partA_prediction):
 
 # ─── CELL 6: Part B controls + Part B reflection ────────────────────────────
 @app.cell(hide_code=True)
-def _(mo, partB_prediction):
-    mo.stop(partB_prediction.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     a2_model_size = mo.ui.dropdown(
         options={"7B (32L, 4096H)": (7, 32, 4096), "70B (80L, 8192H)": (70, 80, 8192), "175B (96L, 12288H)": (175, 96, 12288)},
         value="70B (80L, 8192H)",
@@ -276,9 +272,7 @@ def _(mo, partB_prediction):
 
 # ─── CELL 6b: Part C prediction + controls ─────────────────────────────────
 @app.cell(hide_code=True)
-def _(mo, partB_reflection):
-    mo.stop(partB_reflection.value is None, mo.md("**Complete Part B reflection to unlock Part C.**"))
-
+def _(mo):
     partC_prediction = mo.ui.radio(
         options={
             "A) 1.5x -- modest improvement over static batching": "A",
@@ -305,9 +299,7 @@ def _(mo, partB_reflection):
 
 # ─── CELL 6c: Part D prediction + controls ─────────────────────────────────
 @app.cell(hide_code=True)
-def _(mo, partC_reflection):
-    mo.stop(partC_reflection.value is None, mo.md("**Complete Part C reflection to unlock Part D.**"))
-
+def _(mo):
     partD_prediction = mo.ui.radio(
         options={
             "A) 200 replicas of FP16 with static batching -- brute force": "A",

--- a/labs/vol2/lab_09_perf_engineering.py
+++ b/labs/vol2/lab_09_perf_engineering.py
@@ -305,9 +305,7 @@ def _(mo):
 
 # ─── CELL 5: Part A controls + Part B prediction ────────────────────────────
 @app.cell(hide_code=True)
-def _(mo, pA_pred):
-    mo.stop(pA_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pA_batch = mo.ui.dropdown(
         options={"Batch 1": 1, "Batch 4": 4, "Batch 16": 16,
                  "Batch 64": 64, "Batch 256": 256},
@@ -355,9 +353,7 @@ def _(mo, pA_pred):
 
 # ─── CELL 6: Part B controls + Part C prediction ────────────────────────────
 @app.cell(hide_code=True)
-def _(mo, pB_pred):
-    mo.stop(pB_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pB_seqlen = mo.ui.slider(
         start=512, stop=131072, value=4096, step=512,
         label="Sequence length (tokens)",
@@ -377,9 +373,7 @@ def _(mo, pB_pred):
 
 # ─── CELL 7: Part D prediction ──────────────────────────────────────────────
 @app.cell(hide_code=True)
-def _(mo, pC_pred):
-    mo.stop(pC_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pD_pred = mo.ui.radio(
         options={
             "A: Both are similar -- 4 bits is 4 bits": "A",
@@ -398,9 +392,7 @@ def _(mo, pC_pred):
 
 # ─── CELL 8: Part D controls + Part E prediction ────────────────────────────
 @app.cell(hide_code=True)
-def _(mo, pD_pred):
-    mo.stop(pD_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pD_precision = mo.ui.dropdown(
         options={"FP16": 16, "INT8": 8, "INT4": 4},
         value="INT4",
@@ -425,9 +417,7 @@ def _(mo, pD_pred):
 
 # ─── CELL 9: Part E controls ────────────────────────────────────────────────
 @app.cell(hide_code=True)
-def _(mo, pE_pred):
-    mo.stop(pE_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pE_workload = mo.ui.dropdown(
         options={
             "LLM Decode (batch=1) -- AI=1, memory-bound": "decode",

--- a/labs/vol2/lab_10_edge_intelligence.py
+++ b/labs/vol2/lab_10_edge_intelligence.py
@@ -271,9 +271,7 @@ def _(mo):
 
 # ─── CELL 5: PART A CONTROLS + PART B WIDGETS ────────────────────────────────
 @app.cell(hide_code=True)
-def _(mo, pA_pred):
-    mo.stop(pA_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pA_params = mo.ui.slider(
         start=1, stop=100, value=10, step=1,
         label="Model parameters (millions)",
@@ -306,9 +304,7 @@ def _(mo, pA_pred):
 
 # ─── CELL 6: PART B CONTROLS + PART C WIDGETS ────────────────────────────────
 @app.cell(hide_code=True)
-def _(mo, pB_pred):
-    mo.stop(pB_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pB_contexts = mo.ui.slider(
         start=1, stop=20, value=10, step=1,
         label="Number of user contexts",
@@ -327,9 +323,7 @@ def _(mo, pB_pred):
 
 # ─── CELL 7: PART C CONTROLS + PART D WIDGETS ────────────────────────────────
 @app.cell(hide_code=True)
-def _(mo, pC_pred):
-    mo.stop(pC_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pC_target = mo.ui.radio(
         options={"CPU": "cpu", "GPU (mobile)": "gpu", "NPU": "npu"},
         value="CPU",
@@ -354,9 +348,7 @@ def _(mo, pC_pred):
 
 # ─── CELL 8: PART D CONTROLS ─────────────────────────────────────────────────
 @app.cell(hide_code=True)
-def _(mo, pD_pred):
-    mo.stop(pD_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pD_beta = mo.ui.slider(
         start=0.1, stop=2.0, value=0.5, step=0.1,
         label="Data heterogeneity (beta) -- lower = more non-IID",

--- a/labs/vol2/lab_11_ops_scale.py
+++ b/labs/vol2/lab_11_ops_scale.py
@@ -269,9 +269,7 @@ def _(mo):
 
 # ─── CELL 5: Part B prediction + Part B controls ─────────────────────────────
 @app.cell(hide_code=True)
-def _(mo, pA_pred):
-    mo.stop(pA_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pB_pred = mo.ui.number(
         start=1000, stop=10_000_000, value=None, step=1000,
         label=(
@@ -288,9 +286,7 @@ def _(mo, pA_pred):
 
 # ─── CELL 6: Part C prediction + Part C controls ─────────────────────────────
 @app.cell(hide_code=True)
-def _(mo, pB_pred):
-    mo.stop(pB_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pC_pred = mo.ui.radio(
         options={
             "A: 100+ models": "A",
@@ -313,9 +309,7 @@ def _(mo, pB_pred):
 
 # ─── CELL 7: Part D prediction + Part D controls ─────────────────────────────
 @app.cell(hide_code=True)
-def _(mo, pC_pred):
-    mo.stop(pC_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pD_pred = mo.ui.radio(
         options={
             "A: ~6 minutes": "A",
@@ -336,9 +330,7 @@ def _(mo, pC_pred):
 
 # ─── CELL 8: Part E controls + Synthesis decision log ────────────────────────
 @app.cell(hide_code=True)
-def _(DecisionLog, mo, pD_pred):
-    mo.stop(pD_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(DecisionLog, mo):
     pE_models = mo.ui.slider(start=10, stop=500, value=100, step=10, label="Model count")
     pE_metrics = mo.ui.slider(start=5, stop=20, value=10, step=1, label="Metrics per model")
     pE_sigma = mo.ui.dropdown(

--- a/labs/vol2/lab_12_security_privacy.py
+++ b/labs/vol2/lab_12_security_privacy.py
@@ -273,9 +273,7 @@ def _(mo):
 
 # ─── WIDGET CELL 2: Part A controls + Part B prediction ──────────────────────
 @app.cell(hide_code=True)
-def _(mo, pA_pred):
-    mo.stop(pA_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pA_epsilon = mo.ui.slider(start=0.1, stop=10.0, value=1.0, step=0.1, label="Epsilon")
     pA_N = mo.ui.slider(start=10, stop=10000, value=1000, step=10, label="Dataset size (N)")
 
@@ -297,9 +295,7 @@ def _(mo, pA_pred):
 
 # ─── WIDGET CELL 3: Part C prediction ────────────────────────────────────────
 @app.cell(hide_code=True)
-def _(mo, pB_pred):
-    mo.stop(pB_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pC_pred = mo.ui.radio(
         options={
             "A: ~900 tok/s -- overhead is small": "A",
@@ -317,9 +313,7 @@ def _(mo, pB_pred):
 
 # ─── WIDGET CELL 4: Part C controls + Part D prediction ─────────────────────
 @app.cell(hide_code=True)
-def _(mo, pC_pred):
-    mo.stop(pC_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pC_mig = mo.ui.checkbox(label="MIG Isolation (-15%)", value=True)
     pC_monitor = mo.ui.checkbox(label="Monitoring (+1.5ms/req)", value=True)
     pC_output = mo.ui.checkbox(label="Output Perturbation (+1.0ms/req)", value=True)
@@ -340,9 +334,7 @@ def _(mo, pC_pred):
 
 # ─── WIDGET CELL 5: Part D controls ─────────────────────────────────────────
 @app.cell(hide_code=True)
-def _(mo, pD_pred):
-    mo.stop(pD_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     pD_queries = mo.ui.slider(start=100, stop=100_000, value=10_000, step=100,
                               label="Daily query volume")
     pD_eps_q = mo.ui.slider(start=0.001, stop=0.1, value=0.01, step=0.001,

--- a/labs/vol2/lab_13_robust_ai.py
+++ b/labs/vol2/lab_13_robust_ai.py
@@ -283,9 +283,7 @@ def _(mo):
 # ─── CELL 5: PART B WIDGETS ──────────────────────────────────────────────────
 
 @app.cell(hide_code=True)
-def _(mo, partA_pred):
-    mo.stop(partA_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partB_pred = mo.ui.radio(
         options={
             "A) ~0.1% -- very rare": "0.1",
@@ -305,9 +303,7 @@ def _(mo, partA_pred):
 # ─── CELL 6: PART C WIDGETS ──────────────────────────────────────────────────
 
 @app.cell(hide_code=True)
-def _(mo, partB_pred):
-    mo.stop(partB_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partC_pred = mo.ui.number(
         start=20, stop=95, value=85, step=1,
         label="A model deployed without monitoring degrades from 76% over 6 months. What accuracy (%) remains?",
@@ -332,9 +328,7 @@ def _(mo, partB_pred):
 # ─── CELL 7: PART D WIDGETS ──────────────────────────────────────────────────
 
 @app.cell(hide_code=True)
-def _(mo, partC_pred):
-    mo.stop(partC_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partD_pred = mo.ui.radio(
         options={
             "A) Adversarial training -- direct defense is always cheapest": "adv_train",
@@ -357,9 +351,7 @@ def _(mo, partC_pred):
 # ─── CELL 8: PART E WIDGETS ──────────────────────────────────────────────────
 
 @app.cell(hide_code=True)
-def _(mo, partD_pred):
-    mo.stop(partD_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partE_eps_slider = mo.ui.slider(
         start=0, stop=16, value=4, step=1,
         label="Adversarial perturbation (eps, in units of /255)",

--- a/labs/vol2/lab_14_sustainable_ai.py
+++ b/labs/vol2/lab_14_sustainable_ai.py
@@ -270,9 +270,7 @@ def _(mo):
 # ─── CELL 5: PART B WIDGETS ──────────────────────────────────────────────────
 
 @app.cell(hide_code=True)
-def _(mo, partA_pred):
-    mo.stop(partA_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partB_pred = mo.ui.radio(
         options={
             "A) ~2-3x -- not much variation": "2",
@@ -290,9 +288,7 @@ def _(mo, partA_pred):
 # ─── CELL 6: PART C WIDGETS ──────────────────────────────────────────────────
 
 @app.cell(hide_code=True)
-def _(mo, partB_pred):
-    mo.stop(partB_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partC_pred = mo.ui.radio(
         options={
             "A) <5% -- hardware is a rounding error": "5",
@@ -311,9 +307,7 @@ def _(mo, partB_pred):
 # ─── CELL 7: PART D WIDGETS ──────────────────────────────────────────────────
 
 @app.cell(hide_code=True)
-def _(mo, partC_pred):
-    mo.stop(partC_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partD_pred = mo.ui.number(
         start=-80, stop=200, value=-25, step=5,
         label="You double inference efficiency (cost per query halves). Demand increases 3x (elastic market). What % change in total energy? (negative = decrease)",
@@ -328,9 +322,7 @@ def _(mo, partC_pred):
 # ─── CELL 8: PART E WIDGETS ──────────────────────────────────────────────────
 
 @app.cell(hide_code=True)
-def _(mo, partD_pred):
-    mo.stop(partD_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partE_geo = mo.ui.dropdown(
         options={"Poland (820 g/kWh)": 820, "US Average (429 g/kWh)": 429,
                  "France (56 g/kWh)": 56, "Quebec (20 g/kWh)": 20},

--- a/labs/vol2/lab_15_responsible_ai.py
+++ b/labs/vol2/lab_15_responsible_ai.py
@@ -248,9 +248,7 @@ def _(mo):
 
 # ─── CELL 5: Part B prediction + controls ─────────────────────────────────────
 @app.cell(hide_code=True)
-def _(mo, partA_pred):
-    mo.stop(partA_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partB_pred = mo.ui.number(
         start=60, stop=90, value=83, step=1,
         label="Baseline accuracy 85%. Groups: 60% vs 30% base rate. After enforcing Demographic Parity, accuracy = ?%",
@@ -261,9 +259,7 @@ def _(mo, partA_pred):
 
 # ─── CELL 6: Part C prediction + controls ─────────────────────────────────────
 @app.cell(hide_code=True)
-def _(mo, partB_pred):
-    mo.stop(partB_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partC_pred = mo.ui.radio(
         options={
             "A) ~8% -- modest growth": "8",
@@ -282,9 +278,7 @@ def _(mo, partB_pred):
 
 # ─── CELL 7: Part D prediction + controls ─────────────────────────────────────
 @app.cell(hide_code=True)
-def _(mo, partC_pred):
-    mo.stop(partC_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partD_pred = mo.ui.radio(
         options={
             "A) Yes -- 30+15+50 = 95ms, under budget": "yes_simple",
@@ -311,9 +305,7 @@ def _(mo, partC_pred):
 
 # ─── CELL 8: Part E controls ──────────────────────────────────────────────────
 @app.cell(hide_code=True)
-def _(mo, partD_pred):
-    mo.stop(partD_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partE_sample = mo.ui.dropdown(
         options={"1% of traffic": 0.01, "5% of traffic": 0.05, "10% of traffic": 0.10},
         value="5% of traffic", label="Sampling rate:",

--- a/labs/vol2/lab_16_fleet_synthesis.py
+++ b/labs/vol2/lab_16_fleet_synthesis.py
@@ -274,9 +274,7 @@ def _(mo):
 
 # ─── CELL 5: Part B prediction + Part B sliders ──────────────────────────
 @app.cell(hide_code=True)
-def _(mo, partA_pred):
-    mo.stop(partA_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partB_pred = mo.ui.number(
         start=0.01, stop=1000, value=100, step=1,
         label="10,000 GPUs, each with 10,000-hour MTBF. What is the cluster MTBF (hours)?",
@@ -289,9 +287,7 @@ def _(mo, partA_pred):
 
 # ─── CELL 6: Part C prediction + Part C sliders ──────────────────────────
 @app.cell(hide_code=True)
-def _(mo, partB_pred):
-    mo.stop(partB_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partC_pred = mo.ui.radio(
         options={
             "A) No effect -- they are independent": "independent",
@@ -312,9 +308,7 @@ def _(mo, partB_pred):
 
 # ─── CELL 7: Part D prediction + Part D controls ─────────────────────────
 @app.cell(hide_code=True)
-def _(mo, partC_pred):
-    mo.stop(partC_pred.value is None, mo.md("**Make your prediction above to unlock this part.**"))
-
+def _(mo):
     partD_refl = mo.ui.radio(
         options={
             "A) Yes -- fairness overhead for communication efficiency": "yes_trade",


### PR DESCRIPTION
completes the systematic migration started by #1351 (lab_06 proof). 30 labs refactored across vol1 and vol2, each verified individually.

## what changed

for each lab, a script applied the Pattern C transformation:

1. remove cell-level `mo.stop(<prediction>.value is None, ...)` calls from @app.cell widget cells
2. simplify cell signatures when the gate dep was only used in the removed mo.stop
3. trust the internal `build_part_X()` gates that already exist in every lab (they already show the 'unlock' callout inside each tab until that part's prediction is answered)

## labs updated (30, one commit each)

| vol1 | vol2 |
|------|------|
| lab_01_ml_intro ✓ | lab_01_introduction ✓ |
| lab_02_ml_systems ✓ | lab_02_compute_infra ✓ |
| lab_03_ml_workflow ✓ | lab_03_communication ✓ |
| lab_04_data_engr ✓ | lab_04_data_storage ✓ |
| lab_05_nn_compute ✓ | lab_07_fleet_orch ✓ |
| lab_06_nn_arch ✓ | lab_08_inference ✓ |
| lab_07_ml_frameworks ✓ | lab_09_perf_engineering ✓ |
| lab_08_model_train ✓ | lab_10_edge_intelligence ✓ |
| lab_09_data_selection ✓ | lab_11_ops_scale ✓ |
| lab_10_model_compress ✓ | lab_12_security_privacy ✓ |
| lab_11_hw_accel ✓ | lab_13_robust_ai ✓ |
| lab_12_perf_bench ✓ | lab_14_sustainable_ai ✓ |
| lab_13_model_serving ✓ | lab_15_responsible_ai ✓ |
| lab_14_ml_ops ✓ | lab_16_fleet_synthesis ✓ |
| lab_15_responsible_engr ✓ | |
| lab_16_ml_conclusion ✓ | |

not touched:
- `vol2/lab_05_dist_train` — already Pattern C (no changes needed)
- `vol2/lab_06_fault_tolerance` — merged via #1351
- `vol1/lab_00_introduction` — its check1/check2/check3 pattern is structurally different, mechanical transformation broke engine tests, kept in the grandfather list in #1347 for manual refactor

## verification

each lab passed:
- `marimo check` — clean
- `pytest labs/tests/test_engine.py -k <lab_name>` — cells execute, produce outputs
- if any lab failed either check, the branch was reverted (that's what happened to lab_00, reverted cleanly)

full repo run after all commits:
- `pytest labs/tests/test_static.py` — 688 passed, 5 skipped (grandfather list + pre-existing), 1 xfailed (unrelated)
- `pytest labs/tests/test_engine.py` — 70 passed

## commits

30 per-lab commits + 1 grandfather-list update. each per-lab commit is independently reviewable (small diff, typically 3-14 lines).

## related

- #1347 — the tracking issue. this PR closes out 30 of 31 remaining labs; only lab_00 still open.
- #1350 — the test refinement (multi-widget leak threshold with grandfather list). this PR shrinks the grandfather list to just {lab_00}.
- #1351 — the proof-of-pattern PR (lab_06), landed first to validate the approach.