### PR TITLE
refactor(labs/lab_00): manual Pattern C migration (closes #1347)

### DIFF
--- a/labs/tests/test_static.py
+++ b/labs/tests/test_static.py
@@ -478,29 +478,11 @@ class TestMarimoDataflow:
     are allowed.
     """
 
-    # Labs with known multi-widget-leak debt, grandfathered until refactored
-    # per-lab (tracked in #1347). As each lab is converted to the
-    # one-widget-per-gated-cell pattern (see lab_01 post-#1339 or lab_05_dist_train),
-    # remove it from this set. When the set is empty the bug class is closed.
-    # Only vol1/lab_00 remains. Its check1/check2/check3 pattern is structurally
-    # different from the partX_prediction idiom and the mechanical Pattern C
-    # transformation breaks test_engine.py. Needs manual per-cell refactor.
-    _KNOWN_MULTI_LEAK_LABS = frozenset({
-        "vol1/lab_00_introduction.py",
-    })
+    # #1347 closed 2026-04-16: all 33 labs now follow the one-widget-per-gated-cell
+    # pattern. The grandfather mechanism was removed when the set went empty.
+    # New labs and refactors are strictly enforced against this rule.
 
     def test_no_multi_widget_leak_in_gated_cell(self, lab_path):
-        # Grandfather known-debt labs: skip with a pointer to the tracking issue
-        # rather than fail. New labs and labs that have been refactored are
-        # strictly enforced.
-        rel_path = str(Path(lab_path).resolve().relative_to(REPO_ROOT / "labs"))
-        if rel_path in self._KNOWN_MULTI_LEAK_LABS:
-            pytest.skip(
-                f"{rel_path} has known multi-widget-leak debt, tracked in #1347. "
-                "remove from _KNOWN_MULTI_LEAK_LABS once refactored to the "
-                "one-widget-per-gated-cell pattern."
-            )
-
         tree = parse_tree(lab_path)
         violations = []
         for node in ast.walk(tree):

--- a/labs/vol1/lab_00_introduction.py
+++ b/labs/vol1/lab_00_introduction.py
@@ -383,10 +383,11 @@ def _(check1, mo):
 
 # ─── CHECK 2 (multi-select) ────────────────────────────────────────────────────
 
+# Pattern C: widget definitions are ungated so they are always defined at
+# module load. Downstream helpers (check2empty, check2value_list) and render
+# cells depend on these being globally available even before check1 is answered.
 @app.cell
-def _(check1, mo):
-    mo.stop(check1.value is None)
-
+def _(mo):
     model_size = mo.ui.checkbox(
         value=False,
         label="Use a smaller model with fewer parameters"
@@ -411,6 +412,20 @@ def _(check1, mo):
         value=False,
         label="Deploy the model directly on the vehicle"
     )
+    return edge_deploy, faster_gpu, model_size, move_server, quantization
+
+
+@app.cell
+def _(
+    check1,
+    edge_deploy,
+    faster_gpu,
+    mo,
+    model_size,
+    move_server,
+    quantization,
+):
+    mo.stop(check1.value is None)
 
     mo.vstack([
         mo.md("""**Check your understanding.** An autonomous vehicle perception system
@@ -424,7 +439,7 @@ def _(check1, mo):
         faster_gpu,
         edge_deploy
     ])
-    return edge_deploy, faster_gpu, model_size, move_server, quantization
+    return
 
 
 @app.cell


### PR DESCRIPTION
## what

split the gated 5-widget check-2 cell in vol1/lab_00_introduction.py into:
- ungated widget-defs cell (always defines model_size, quantization, move_server, faster_gpu, edge_deploy)
- gated display cell (renders them conditionally on check1 being answered)

this matches the canonical pattern from lab_01 post-#1339 and keeps downstream helpers (check2empty, check2value_list at line 1372) from hitting undefined widgets when check1 has not been answered.

also removed the `_KNOWN_MULTI_LEAK_LABS` grandfather set in labs/tests/test_static.py now that it is empty. the one-widget-per-gated-cell rule applies strictly to all 33 labs going forward.

## why manual

lab_00 uses check1/check2/check3 sequential concept checks, structurally different from the partX_prediction idiom elsewhere. the mechanical Pattern C transform from #1352 would have broken test_engine because check2 helpers rely on all 5 checkboxes being globally defined.

## test plan

- [x] labs/tests/test_static.py passes (no more skip for lab_00, 792 passed 4 skipped 1 xfailed)
- [x] labs/tests/test_engine.py passes (app.run headlessly)
- [x] python3 -m marimo check vol1/lab_00_introduction.py clean (exit 0)
- [ ] CI green on dev

closes #1347