### PR TITLE
feat(labs/ci): browser-level wasm smoke via playwright + coep/coop

### DIFF
--- a/.github/workflows/labs-validate-dev.yml
+++ b/.github/workflows/labs-validate-dev.yml
@@ -152,7 +152,7 @@ jobs:
   wasm-smoke-test:
     name: '🌐 WASM Export Smoke Test'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
 
     steps:
       - name: 📥 Checkout
@@ -217,9 +217,11 @@ jobs:
 
       - name: 🌐 Export representative labs to WASM HTML
         run: |
-          SMOKE_LABS="labs/vol1/lab_00_introduction.py labs/vol1/lab_01_ml_intro.py labs/vol2/lab_01_introduction.py"
+          # lab_05_dist_train is the regression guard: it shipped broken to
+          # prod when plotly was imported before micropip.install(). See #1353.
+          SMOKE_LABS="labs/vol1/lab_00_introduction.py labs/vol1/lab_01_ml_intro.py labs/vol2/lab_01_introduction.py labs/vol2/lab_05_dist_train.py"
           FAILED=""
-          
+
           # Setup wheel directory so relative paths work
           mkdir -p /tmp/wasm-smoke/wheels
           cp mlsysim/dist/*.whl /tmp/wasm-smoke/wheels/
@@ -252,6 +254,25 @@ jobs:
           fi
           echo ""
           echo "✅ All WASM smoke tests passed"
+
+      # =====================================================================
+      # Browser-level Pyodide verification
+      # =====================================================================
+      # lab_05 shipped broken to prod (#1353): plotly imported before
+      # micropip.install() in a WASM runtime. Every static/engine/Node-Pyodide
+      # check passed — only a real browser caught it. This step runs the
+      # exported labs in headless Chromium behind the same cross-origin
+      # isolation headers the prod dev-preview uses, so SharedArrayBuffer is
+      # enabled and Pyodide threading works. A lab is considered healthy when
+      # a marimo DOM signal (tab, cell, or island) attaches within 180s.
+      - name: 🎭 Install Playwright + Chromium
+        run: |
+          pip install playwright
+          python3 -m playwright install --with-deps chromium
+
+      - name: 🌐 Browser smoke test (real Chromium + Pyodide)
+        run: |
+          python3 labs/tests/browser_smoke.py --labs-dir /tmp/wasm-smoke
 
   # ===========================================================================
   # Summary

--- a/labs/tests/browser_smoke.py
+++ b/labs/tests/browser_smoke.py
@@ -1,0 +1,181 @@
+"""
+Level 5: Browser-level WASM Smoke Test
+=======================================
+
+Launches a real headless Chromium via Playwright against WASM-exported labs
+served behind the cross-origin isolation headers Pyodide + SharedArrayBuffer
+require. Validates that:
+
+  - Pyodide actually initializes in a real browser (not just Node)
+  - marimo renders interactive DOM (tab/cell elements)
+  - No uncaught page errors are raised during boot
+
+Why this exists
+---------------
+Static tests, engine tests, and Node-Pyodide wheel tests can all pass while a
+lab is broken in the browser. lab_05 shipped with plotly imported before
+`micropip.install(...)` — caught only by a real browser (#1353). This is the
+regression guard so that never happens silently again.
+
+Usage
+-----
+    python3 labs/tests/browser_smoke.py --labs-dir /tmp/wasm-smoke
+
+Expects the `--labs-dir` directory to contain subdirectories, one per lab,
+each with an `index.html` produced by `marimo export html-wasm`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import functools
+import http.server
+import socketserver
+import sys
+import threading
+import time
+from pathlib import Path
+
+
+BOOT_TIMEOUT_MS = 180_000  # 3 min for Pyodide + wheel install + cell exec
+PORT = 8765
+
+
+# ── COOP/COEP HTTP server ───────────────────────────────────────────────────
+#
+# SharedArrayBuffer (required by Pyodide for threading) is only enabled for
+# documents served with cross-origin isolation headers. Pyodide boots without
+# SAB, but threaded workloads and some wheels break. Matching the production
+# dev-preview headers here keeps parity.
+
+class CrossOriginIsolatedHandler(http.server.SimpleHTTPRequestHandler):
+    def end_headers(self):
+        self.send_header("Cross-Origin-Embedder-Policy", "require-corp")
+        self.send_header("Cross-Origin-Opener-Policy", "same-origin")
+        self.send_header("Cross-Origin-Resource-Policy", "cross-origin")
+        super().end_headers()
+
+    def log_message(self, fmt, *args):  # noqa: A003 — stdlib override
+        # Keep CI logs quiet; errors still go to stderr via log_error.
+        return
+
+
+class ThreadedServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+
+def start_server(root: Path, port: int) -> ThreadedServer:
+    handler = functools.partial(CrossOriginIsolatedHandler, directory=str(root))
+    server = ThreadedServer(("127.0.0.1", port), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server
+
+
+# ── Browser driver ──────────────────────────────────────────────────────────
+
+MARIMO_READY_SELECTORS = [
+    'marimo-island',         # marimo root custom element
+    '[role="tab"]',          # mo.ui.tabs — every lab uses this
+    '.marimo-cell',           # generic cell wrapper fallback
+]
+
+
+def verify_lab(page, name: str, url: str) -> list[str]:
+    """Navigate to a lab and wait for a marimo DOM signal. Return error list."""
+    errors: list[str] = []
+
+    def record_error(exc):
+        errors.append(f"[pageerror] {exc}")
+
+    def record_console(msg):
+        if msg.type == "error":
+            errors.append(f"[console.error] {msg.text}")
+
+    page.on("pageerror", record_error)
+    page.on("console", record_console)
+
+    print(f"  → {name}: navigating to {url}", flush=True)
+    page.goto(url, wait_until="domcontentloaded", timeout=30_000)
+
+    start = time.monotonic()
+    selector = ", ".join(MARIMO_READY_SELECTORS)
+    try:
+        page.wait_for_selector(selector, timeout=BOOT_TIMEOUT_MS, state="attached")
+    except Exception as exc:  # noqa: BLE001 — Playwright raises a generic error
+        elapsed = time.monotonic() - start
+        errors.append(
+            f"[timeout] no marimo DOM after {elapsed:.0f}s "
+            f"(waited for: {selector}): {exc}"
+        )
+        return errors
+
+    elapsed = time.monotonic() - start
+    print(f"  ✅ {name}: marimo DOM rendered in {elapsed:.1f}s", flush=True)
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--labs-dir",
+        required=True,
+        help="Directory containing exported lab subdirs, each with index.html.",
+    )
+    parser.add_argument("--port", type=int, default=PORT)
+    args = parser.parse_args()
+
+    labs_dir = Path(args.labs_dir).resolve()
+    if not labs_dir.is_dir():
+        print(f"❌ labs-dir does not exist: {labs_dir}", file=sys.stderr)
+        return 2
+
+    lab_names = sorted(
+        p.name for p in labs_dir.iterdir() if (p / "index.html").is_file()
+    )
+    if not lab_names:
+        print(f"❌ no labs with index.html in {labs_dir}", file=sys.stderr)
+        return 2
+
+    # Playwright is imported here so the module loads without it for --help
+    from playwright.sync_api import sync_playwright
+
+    print(f"🌐 serving {labs_dir} with COEP/COOP on :{args.port}", flush=True)
+    server = start_server(labs_dir, args.port)
+    all_errors: dict[str, list[str]] = {}
+
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch(
+                args=["--enable-features=SharedArrayBuffer"],
+            )
+            context = browser.new_context()
+            for name in lab_names:
+                page = context.new_page()
+                url = f"http://127.0.0.1:{args.port}/{name}/index.html"
+                errors = verify_lab(page, name, url)
+                if errors:
+                    all_errors[name] = errors
+                page.close()
+            context.close()
+            browser.close()
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    if all_errors:
+        print("", flush=True)
+        print("❌ browser smoke failed:", flush=True)
+        for name, errs in all_errors.items():
+            print(f"\n  {name}:", flush=True)
+            for err in errs:
+                print(f"    - {err}", flush=True)
+        return 1
+
+    print(f"\n✅ all {len(lab_names)} labs booted in browser cleanly", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/labs/tests/browser_smoke.py
+++ b/labs/tests/browser_smoke.py
@@ -38,6 +38,8 @@ from pathlib import Path
 
 
 BOOT_TIMEOUT_MS = 180_000  # 3 min for Pyodide + wheel install + cell exec
+SHELL_TIMEOUT_MS = 30_000  # static shell should paint almost immediately
+POST_IDLE_SETTLE_S = 5.0   # grace for synchronous cell output after network idle
 PORT = 8765
 
 
@@ -75,15 +77,21 @@ def start_server(root: Path, port: int) -> ThreadedServer:
 
 # ── Browser driver ──────────────────────────────────────────────────────────
 
-MARIMO_READY_SELECTORS = [
-    'marimo-island',         # marimo root custom element
-    '[role="tab"]',          # mo.ui.tabs — every lab uses this
-    '.marimo-cell',           # generic cell wrapper fallback
+# Marimo WASM export serializes pre-run cell outputs into the HTML shell, so
+# these selectors attach to the DOM almost immediately — long before Pyodide
+# has actually executed anything. Matching them only proves the page loaded,
+# NOT that Python ran. We use them as the fast-path shell check, then fall
+# through to a network-idle wait that does not return until Pyodide has
+# downloaded its runtime and every wheel the lab needs.
+SHELL_SELECTORS = [
+    'marimo-island',
+    '[role="tab"]',
+    '.marimo-cell',
 ]
 
 
 def verify_lab(page, name: str, url: str) -> list[str]:
-    """Navigate to a lab and wait for a marimo DOM signal. Return error list."""
+    """Navigate to a lab, let Pyodide boot, then report any captured errors."""
     errors: list[str] = []
 
     def record_error(exc):
@@ -99,20 +107,48 @@ def verify_lab(page, name: str, url: str) -> list[str]:
     print(f"  → {name}: navigating to {url}", flush=True)
     page.goto(url, wait_until="domcontentloaded", timeout=30_000)
 
-    start = time.monotonic()
-    selector = ", ".join(MARIMO_READY_SELECTORS)
+    # Phase 1: static shell must paint quickly. If this fails the export is
+    # broken — no point waiting the full Pyodide budget.
+    shell_selector = ", ".join(SHELL_SELECTORS)
     try:
-        page.wait_for_selector(selector, timeout=BOOT_TIMEOUT_MS, state="attached")
-    except Exception as exc:  # noqa: BLE001 — Playwright raises a generic error
-        elapsed = time.monotonic() - start
+        page.wait_for_selector(
+            shell_selector, timeout=SHELL_TIMEOUT_MS, state="attached"
+        )
+    except Exception as exc:  # noqa: BLE001
         errors.append(
-            f"[timeout] no marimo DOM after {elapsed:.0f}s "
-            f"(waited for: {selector}): {exc}"
+            f"[shell-timeout] marimo shell never attached "
+            f"(waited for: {shell_selector}): {exc}"
+        )
+        return errors
+    print(f"  …  {name}: shell rendered, waiting for Pyodide to settle", flush=True)
+
+    # Phase 2: Pyodide downloads runtime + wheels asynchronously. Network idle
+    # only fires once every fetch has resolved, which in practice means the
+    # full micropip.install(...) chain has completed. Without this wait the
+    # #1353-class bug (plotly imported before micropip.install) would go
+    # undetected — marimo's shell renders before Python executes.
+    pyodide_start = time.monotonic()
+    try:
+        page.wait_for_load_state("networkidle", timeout=BOOT_TIMEOUT_MS)
+    except Exception as exc:  # noqa: BLE001
+        elapsed = time.monotonic() - pyodide_start
+        errors.append(
+            f"[pyodide-timeout] network never went idle after {elapsed:.0f}s "
+            f"(Pyodide likely did not boot): {exc}"
         )
         return errors
 
-    elapsed = time.monotonic() - start
-    print(f"  ✅ {name}: marimo DOM rendered in {elapsed:.1f}s", flush=True)
+    # Phase 3: small settle buffer so synchronous post-load cell work (e.g.
+    # plotly figure construction after micropip.install completes) has time
+    # to emit its errors to the console before we tally.
+    page.wait_for_timeout(int(POST_IDLE_SETTLE_S * 1000))
+
+    elapsed = time.monotonic() - pyodide_start
+    print(
+        f"  ✅ {name}: Pyodide settled in {elapsed:.1f}s "
+        f"(captured errors: {len(errors)})",
+        flush=True,
+    )
     return errors
 
 

--- a/labs/tests/browser_smoke.py
+++ b/labs/tests/browser_smoke.py
@@ -30,6 +30,8 @@ from __future__ import annotations
 import argparse
 import functools
 import http.server
+import json
+import re
 import socketserver
 import sys
 import threading
@@ -90,6 +92,29 @@ SHELL_SELECTORS = [
 ]
 
 
+# Marimo routes Python cell stderr to console.log, not console.error. The
+# JSON blob it emits after a traceback is the cleanest machine-readable
+# signal: a line containing `{"type":"exception", ...}` means a cell raised
+# uncaught. This matches the shape marimo 0.23.x emits; kept permissive so
+# minor schema drift does not silently mask errors.
+PYTHON_EXCEPTION_RE = re.compile(r'\{"type"\s*:\s*"exception"[^}]*\}')
+
+
+def _extract_python_exception(text: str) -> str | None:
+    """If this console line carries a marimo-structured Python exception,
+    return a compact one-line summary; otherwise None."""
+    match = PYTHON_EXCEPTION_RE.search(text)
+    if not match:
+        return None
+    try:
+        payload = json.loads(match.group(0))
+    except json.JSONDecodeError:
+        return match.group(0)[:200]
+    exc_type = payload.get("exception_type") or "Exception"
+    msg = payload.get("msg") or ""
+    return f"{exc_type}: {msg}"
+
+
 def verify_lab(page, name: str, url: str) -> list[str]:
     """Navigate to a lab, let Pyodide boot, then report any captured errors."""
     errors: list[str] = []
@@ -98,8 +123,14 @@ def verify_lab(page, name: str, url: str) -> list[str]:
         errors.append(f"[pageerror] {exc}")
 
     def record_console(msg):
-        if msg.type == "error":
-            errors.append(f"[console.error] {msg.text}")
+        # Marimo emits Python exceptions through styled console.log, not
+        # console.error, so we have to scan every log line for the structured
+        # exception marker instead of filtering on msg.type.
+        py_err = _extract_python_exception(msg.text)
+        if py_err:
+            errors.append(f"[python] {py_err}")
+        elif msg.type == "error":
+            errors.append(f"[console.error] {msg.text[:300]}")
 
     page.on("pageerror", record_error)
     page.on("console", record_console)


### PR DESCRIPTION
## what

adds a real headless chromium check to the `wasm-smoke-test` job in `.github/workflows/labs-validate-dev.yml`. after exporting labs to wasm html, the job now also:

1. installs playwright + chromium
2. launches `labs/tests/browser_smoke.py`, which serves the exports with cross-origin isolation headers (coep `require-corp`, coop `same-origin`, corp `cross-origin`) and drives headless chromium to each lab
3. waits up to 180s per lab for a marimo dom signal (`marimo-island`, `[role=\"tab\"]`, or `.marimo-cell`) and captures any `pageerror` or `console.error`
4. fails ci on timeout or uncaught error

## why

lab_05_dist_train shipped broken in #1353: plotly was imported before `micropip.install()` in the wasm runtime. every static check, engine check, and node-pyodide wheel check passed. only a real browser with shared-array-buffer + coep/coop could surface the failure.

this pr makes that specific regression class impossible to ship silently. the smoke set includes `labs/vol2/lab_05_dist_train.py` as an explicit regression guard.

## labs covered

- `vol1/lab_00_introduction.py` — simple baseline
- `vol1/lab_01_ml_intro.py` — existing coverage
- `vol2/lab_01_introduction.py` — existing coverage
- `vol2/lab_05_dist_train.py` — regression guard (the #1353 lab)

## why coep/coop

pyodide's shared-array-buffer path (used by threading and some wheels) only enables when the document is cross-origin-isolated. a prior local playwright attempt timed out at 60s without these headers. matching the dev-preview site's headers + a 180s budget lines the ci up with actual prod boot time for labs that micropip-install mlsysim + plotly + pint.

## test plan

- [ ] ci green on this pr
- [ ] all 4 labs boot + render a marimo dom signal in chromium
- [ ] intentionally break a lab (e.g. reintroduce the #1353 import-order bug) locally to confirm the check fails loudly