### PR TITLE
fix(staffml): unblock staffml-preview-dev type check + build

### DIFF
--- a/interviews/staffml/src/app/practice/page.tsx
+++ b/interviews/staffml/src/app/practice/page.tsx
@@ -768,8 +768,7 @@ function PracticePage() {
                     {chainInfo && !showAnswer && (
                       <div className="mb-3">
                         <ChainBadge
-                          chainId={chainInfo.id}
-                          chainName={chainInfo.name}
+                          chainId={chainInfo.chainId}
                           position={chainInfo.position + 1}  /* 1-indexed for display */
                           total={chainInfo.total}
                         />

--- a/interviews/staffml/src/components/ChainBadge.tsx
+++ b/interviews/staffml/src/components/ChainBadge.tsx
@@ -15,7 +15,7 @@
 import { Link } from "lucide-react";
 import clsx from "clsx";
 
-import { trackEvent } from "@/lib/analytics";
+import { track } from "@/lib/analytics";
 
 export interface ChainBadgeProps {
   chainId: string;
@@ -37,7 +37,7 @@ export default function ChainBadge({
   // Fire shown-event on mount (debounced per-session by analytics layer).
   if (typeof window !== "undefined") {
     queueMicrotask(() => {
-      trackEvent({
+      track({
         type: "chain_badge_shown",
         chainId,
         position,
@@ -54,7 +54,7 @@ export default function ChainBadge({
       data-testid="chain-badge"
       aria-label={`Chained question: ${label}. Click to view chain siblings.`}
       onClick={() => {
-        trackEvent({
+        track({
           type: "chain_badge_clicked",
           chainId,
           position,

--- a/interviews/staffml/src/lib/corpus-vault.ts
+++ b/interviews/staffml/src/lib/corpus-vault.ts
@@ -13,6 +13,15 @@
 import type { Question as VaultQuestion } from "@staffml/vault-types";
 import { makeClientFromEnv, VaultApiClient } from "./vault-api";
 
+// The vault worker enriches each Question with track/level/zone derived from
+// the source filesystem path (classification is path-encoded per vault_cli
+// models.py). These fields are not on the schema itself.
+type EnrichedVaultQuestion = VaultQuestion & {
+  track?: string;
+  level?: string;
+  zone?: string;
+};
+
 // The legacy corpus.ts exports a specific Question shape; this vault-backed
 // module adapts the @staffml/vault-types Question to that shape so callers
 // don't need to change.
@@ -38,7 +47,7 @@ export interface Question {
   };
 }
 
-function adapt(v: VaultQuestion): Question {
+function adapt(v: EnrichedVaultQuestion): Question {
   return {
     id: v.id,
     track: v.track ?? "global",
@@ -79,7 +88,7 @@ export async function getQuestionById(id: string): Promise<Question | null> {
   if (_byId.has(id)) return _byId.get(id)!;
   try {
     const v = await client().getQuestion(id);
-    const q = adapt(v as VaultQuestion);
+    const q = adapt(v as EnrichedVaultQuestion);
     _byId.set(id, q);
     return q;
   } catch {
@@ -91,12 +100,12 @@ export async function listQuestions(params: {
   track?: string; level?: string; zone?: string; limit?: number;
 } = {}): Promise<Question[]> {
   const res = await client().listQuestions(params);
-  return (res.items as VaultQuestion[]).map(adapt);
+  return (res.items as EnrichedVaultQuestion[]).map(adapt);
 }
 
 export async function searchQuestions(q: string, limit = 20): Promise<Question[]> {
   const res = await client().search(q, limit);
-  return (res.results as VaultQuestion[]).map(adapt);
+  return (res.results as EnrichedVaultQuestion[]).map(adapt);
 }
 
 /**

--- a/interviews/staffml/tsconfig.json
+++ b/interviews/staffml/tsconfig.json
@@ -19,7 +19,8 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@staffml/vault-types": ["../staffml-vault-types/index.ts"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## Summary

`staffml-preview-dev.yml` has been failing its \`Type check\` step since the vault-architecture merge (#1348). Five TS errors, three root causes, all fixed here in atomic commits.

## Root causes

1. **`@staffml/vault-types` unresolved** — the shared types package at \`interviews/staffml-vault-types/\` was never wired into the staffml app. No tsconfig path, no workspace entry. Added tsconfig path mapping.
2. **Adapter read non-existent fields** — \`corpus-vault.ts:adapt()\` reads \`v.track\`, \`v.level\`, \`v.zone\`, but the vault-types \`Question\` (correctly) omits these because classification is path-encoded (per \`vault_cli/models.py\` comment). Introduced a local \`EnrichedVaultQuestion\` type for the API-returned shape.
3. **ChainBadge + ChainInfo drift** — \`practice/page.tsx\` passed \`chainInfo.id\` and \`chainInfo.name\` to \`<ChainBadge>\`, but \`ChainInfo\` exports \`chainId\` (not \`id\`) and has no \`name\`. \`ChainBadge.tsx\` also imported \`trackEvent\` but \`analytics.ts\` exports \`track\`.

## Commits

- \`40957e3f0\` — fix(staffml): map @staffml/vault-types to workspace path in tsconfig
- \`53df5a347\` — fix(staffml): type adapter input as enriched VaultQuestion
- \`ec99c5c9b\` — fix(staffml): align ChainBadge wiring with corpus ChainInfo + analytics API

## Verification

Local against Node.js 20 + Next 15:

\`\`\`
$ cd interviews/staffml
$ npm install  →  217 packages, 0 vulnerabilities
$ npx tsc --noEmit  →  exit 0
$ npm test  →  Test Files 2 passed (2), Tests 34 passed (34)
$ npm run build  →  exit 0, 12 routes compiled
\`\`\`

## Out of scope

- AnalyticsEvent union doesn't yet include \`chain_badge_shown\` / \`chain_badge_clicked\` — ChainBadge casts via \`as any\`. Adding those to the union is a small follow-up.
- The \`@staffml/vault-types\` package is referenced via tsconfig path only, not as an installed workspace package. Proper pnpm-workspace wiring (per index.ts comment) remains a follow-up — tsconfig path is sufficient for the type-only imports here.

## Test plan

- [ ] CI \`Type check\` step passes
- [ ] CI \`Run tests\` step passes
- [ ] CI \`Build StaffML\` step passes
- [ ] Dev-site deploy succeeds and the StaffML badge recovers