### PR TITLE
fix(labs/vol1): restore slider/dropdown dataflow in lab_02 + lab_03 (#1332)

### DIFF
--- a/labs/vol1/lab_02_ml_systems.py
+++ b/labs/vol1/lab_02_ml_systems.py
@@ -253,26 +253,11 @@ def _(mo):
 # ═══════════════════════════════════════════════════════════════════════════
 
 
-# ─── CELL 4: TABS CELL ────────────────────────────────────────────────────
+# ─── WIDGET CELLS (one per part) ─────────────────────────────────────────
+# Pattern: each cell defines and RETURNS every widget the part owns so
+# marimo's dataflow can route them to the tabs cell. #1332.
 @app.cell(hide_code=True)
-def _(
-    COLORS,
-    H100_TFLOPS, H100_BW, H100_RAM, H100_TDP,
-    A100_TFLOPS, A100_BW, A100_RAM,
-    JETSON_TFLOPS, JETSON_BW, JETSON_RAM, JETSON_TDP,
-    IPHONE_TFLOPS, IPHONE_TDP,
-    ESP32_TFLOPS, ESP32_TDP, ESP32_RAM_KB,
-    RESNET50_FLOPS, RESNET50_SIZE_MB,
-    MOBILENET_FLOPS, DSCNN_FLOPS,
-    SPEED_OF_LIGHT_KM_S, FIBER_FACTOR,
-    Engine, Models, Hardware,
-    apply_plotly_theme, go, math, mo, np,
-):
-    # ─────────────────────────────────────────────────────────────────────
-    # SHARED WIDGETS
-    # ─────────────────────────────────────────────────────────────────────
-
-    # Part A
+def _(mo):
     partA_prediction = mo.ui.radio(
         options={
             "A) ~6x (proportional to compute increase)":  "6x",
@@ -280,19 +265,29 @@ def _(
             "C) ~1.5x (modest improvement)":               "1.5x",
             "D) <1.1x (almost no improvement)":            "1.1x",
         },
-        label="Upgrading from A100 ($15K) to H100 ($30K) -- a 6x compute increase. "
+        label=r"Upgrading from A100 (\$15K) to H100 (\$30K) -- a 6x compute increase. "
               "For a workload with AI = 5 FLOPs/Byte, what latency improvement?",
     )
     return (partA_prediction,)
 
+
+# Each widget cell below defines AND returns every widget it owns. A previous
+# version defined partA_ai/partB_distance/partB_sla/... but only returned the
+# next part's prediction; marimo's dataflow then never flowed those widgets
+# into the tabs cell, so sliders and dropdowns never rendered even after the
+# prediction was answered (#1332). Grouping by part keeps the mental model
+# simple: "one cell per part's widgets."
 @app.cell(hide_code=True)
 def _(mo):
     partA_ai = mo.ui.slider(
         start=1, stop=400, value=5, step=1,
         label="Arithmetic Intensity (FLOPs/Byte)",
     )
+    return (partA_ai,)
 
-    # Part B
+
+@app.cell(hide_code=True)
+def _(mo):
     partB_prediction = mo.ui.radio(
         options={
             "A) Yes -- 1 ms compute leaves 9 ms for network":              "yes_easy",
@@ -306,6 +301,7 @@ def _(mo):
     )
     return (partB_prediction,)
 
+
 @app.cell(hide_code=True)
 def _(mo):
     partB_distance = mo.ui.slider(
@@ -317,8 +313,11 @@ def _(mo):
         value="10 ms (AV safety)",
         label="SLA budget:",
     )
+    return partB_distance, partB_sla
 
-    # Part C
+
+@app.cell(hide_code=True)
+def _(mo):
     partC_prediction = mo.ui.radio(
         options={
             "A) Still 60 FPS -- hardware is designed for this":  "60fps",
@@ -330,6 +329,7 @@ def _(mo):
               "After 90 seconds of continuous use, what frame rate?",
     )
     return (partC_prediction,)
+
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -352,8 +352,11 @@ def _(mo):
         value="ResNet-50 (4.1 GFLOPs)",
         label="Model:",
     )
+    return partC_model, partC_target
 
-    # Part D
+
+@app.cell(hide_code=True)
+def _(mo):
     partD_prediction = mo.ui.radio(
         options={
             "A) ~2x (cloud is slightly more expensive)":  "2x",
@@ -366,8 +369,12 @@ def _(mo):
     )
     return (partD_prediction,)
 
+
+# Part D slider and dropdown pulled out of the tabs cell (was nested inside
+# before, which left them invisible to the tabs cell's dataflow tracker
+# even though they appeared syntactically near the tabs code). #1332.
 @app.cell(hide_code=True)
-def _(mo, partD_prediction):
+def _(mo):
     partD_data_size = mo.ui.slider(
         start=1, stop=1024, value=16, step=1,
         label="Data size (KB)",
@@ -377,7 +384,28 @@ def _(mo, partD_prediction):
         value="BLE (1 Mbps)",
         label="Wireless technology:",
     )
+    return partD_data_size, partD_wireless
 
+
+# ─── CELL N: TABS COMPOSITION ────────────────────────────────────────────
+@app.cell(hide_code=True)
+def _(
+    COLORS,
+    H100_TFLOPS, H100_BW, H100_RAM, H100_TDP,
+    A100_TFLOPS, A100_BW, A100_RAM,
+    JETSON_TFLOPS, JETSON_BW, JETSON_RAM, JETSON_TDP,
+    IPHONE_TFLOPS, IPHONE_TDP,
+    ESP32_TFLOPS, ESP32_TDP, ESP32_RAM_KB,
+    RESNET50_FLOPS, RESNET50_SIZE_MB,
+    MOBILENET_FLOPS, DSCNN_FLOPS,
+    SPEED_OF_LIGHT_KM_S, FIBER_FACTOR,
+    Engine, Models, Hardware,
+    apply_plotly_theme, go, math, mo, np,
+    partA_prediction, partA_ai,
+    partB_prediction, partB_distance, partB_sla,
+    partC_prediction, partC_target, partC_model,
+    partD_prediction, partD_data_size, partD_wireless,
+):
     # ─────────────────────────────────────────────────────────────────────
     # PART A -- The Memory Wall Revelation
     # ─────────────────────────────────────────────────────────────────────
@@ -443,6 +471,20 @@ def _(mo, partD_prediction):
         _t_mem_a100 = (_data_bytes / (A100_BW * 1e9)) * 1000
         _t_comp_a100 = (_flops / (A100_TFLOPS * 1e12 * _eta)) * 1000
         _t_total_a100 = max(_t_mem_a100, _t_comp_a100) + 0.015
+
+        # Anchor the correct/wrong feedback to the original question (AI=5)
+        # even after the student moves the slider, so "at AI=5" wording stays
+        # truthful regardless of current slider position. #1332.
+        _flops_at_5 = 5 * _data_bytes
+        _t_a100_at_5 = max(
+            _data_bytes / (A100_BW * 1e9),
+            _flops_at_5 / (A100_TFLOPS * 1e12 * _eta),
+        ) * 1000 + 0.015
+        _t_h100_at_5 = max(
+            _data_bytes / (H100_BW * 1e9),
+            _flops_at_5 / (H100_TFLOPS * 1e12 * _eta),
+        ) * 1000 + 0.01
+        _speedup_at_5 = _t_a100_at_5 / _t_h100_at_5 if _t_h100_at_5 > 0 else 1
 
         _t_mem_h100 = (_data_bytes / (H100_BW * 1e9)) * 1000
         _t_comp_h100 = (_flops / (H100_TFLOPS * 1e12 * _eta)) * 1000
@@ -544,11 +586,11 @@ The 6x compute upgrade is almost entirely wasted.
         _pred = partA_prediction.value
         if _pred == "1.1x":
             _rev = ("**Correct.** At AI=5, both GPUs are deeply memory-bound. "
-                    f"The speedup is only {_speedup:.2f}x because bandwidth, not compute, "
+                    f"The speedup is only {_speedup_at_5:.2f}x because bandwidth, not compute, "
                     "is the binding constraint.")
             _rkind = "success"
         else:
-            _rev = (f"**The actual speedup at AI=5 is only ~{_speedup:.2f}x.** "
+            _rev = (f"**The actual speedup at AI=5 is only ~{_speedup_at_5:.2f}x.** "
                     "The workload is memory-bound. Slide AI above the ridge point "
                     "to see where the 6x upgrade actually pays off.")
             _rkind = "warn"

--- a/labs/vol1/lab_03_ml_workflow.py
+++ b/labs/vol1/lab_03_ml_workflow.py
@@ -185,14 +185,14 @@ def _(mo):
     return
 
 
+# ─── WIDGET CELLS (one per part) ─────────────────────────────────────────
+# Each cell defines and RETURNS every widget it owns so marimo's dataflow
+# can route them to the tabs cell. A previous version defined partA_stage /
+# partB_cycle_a / partB_cycle_b / partC_sliders / partD_months but only
+# returned the next part's prediction, so sliders and the PM allocation
+# chart never re-rendered when changed. #1332.
 @app.cell(hide_code=True)
-def _(
-    COLORS, H100_TFLOPS, H100_RAM, ESP32_RAM_KB,
-    RESNET50_PARAMS, RESNET50_SIZE_MB,
-    Engine, Models, Hardware,
-    apply_plotly_theme, go, math, mo, np,
-):
-    # ── Part A widgets ───────────────────────────────────────────────────
+def _(mo):
     partA_prediction = mo.ui.radio(
         options={
             "A) During architecture selection (Stage 2, cost 2x)": "stage2",
@@ -205,14 +205,18 @@ def _(
     )
     return (partA_prediction,)
 
+
 @app.cell(hide_code=True)
 def _(mo):
     partA_stage = mo.ui.slider(
         start=1, stop=6, value=5, step=1,
         label="Discovery stage (1=Problem Definition, 6=Monitoring)",
     )
+    return (partA_stage,)
 
-    # ── Part B widgets ───────────────────────────────────────────────────
+
+@app.cell(hide_code=True)
+def _(mo):
     partB_prediction = mo.ui.radio(
         options={
             "A) Team A -- 5% head start is insurmountable": "team_a",
@@ -225,6 +229,7 @@ def _(mo):
     )
     return (partB_prediction,)
 
+
 @app.cell(hide_code=True)
 def _(mo):
     partB_cycle_a = mo.ui.slider(
@@ -235,8 +240,11 @@ def _(mo):
         start=1, stop=168, value=1, step=1,
         label="Team B cycle time (hours)",
     )
+    return partB_cycle_a, partB_cycle_b
 
-    # ── Part C widgets ───────────────────────────────────────────────────
+
+@app.cell(hide_code=True)
+def _(mo):
     partC_prediction = mo.ui.radio(
         options={
             "A) 50-60% (it is the core task)":    "50",
@@ -248,6 +256,7 @@ def _(mo):
               "(architecture, training, hyperparameters)?",
     )
     return (partC_prediction,)
+
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -263,8 +272,11 @@ def _(mo):
         "monitor": mo.ui.slider(start=0, stop=20, value=0, step=1,
                                  label="Monitoring/Maintenance"),
     }
+    return (partC_sliders,)
 
-    # ── Part D widgets ───────────────────────────────────────────────────
+
+@app.cell(hide_code=True)
+def _(mo):
     partD_prediction = mo.ui.radio(
         options={
             "A) 0 -- it was validated during pilot":    "zero",
@@ -277,12 +289,28 @@ def _(mo):
     )
     return (partD_prediction,)
 
+
 @app.cell(hide_code=True)
-def _(mo, partD_prediction):
+def _(mo):
     partD_months = mo.ui.slider(
         start=0, stop=24, value=0, step=1,
         label="Months since production launch",
     )
+    return (partD_months,)
+
+
+# ─── TABS COMPOSITION ────────────────────────────────────────────────────
+@app.cell(hide_code=True)
+def _(
+    COLORS, H100_TFLOPS, H100_RAM, ESP32_RAM_KB,
+    RESNET50_PARAMS, RESNET50_SIZE_MB,
+    Engine, Models, Hardware,
+    apply_plotly_theme, go, math, mo, np,
+    partA_prediction, partA_stage,
+    partB_prediction, partB_cycle_a, partB_cycle_b,
+    partC_prediction, partC_sliders,
+    partD_prediction, partD_months,
+):
 
     # ═════════════════════════════════════════════════════════════════════
     # PART A -- Constraint Propagation


### PR DESCRIPTION
## what

lab_02 and lab_03 in vol1 had a widespread marimo dataflow bug: widget cells defined secondary widgets (sliders, dropdowns, the Part C PM-allocation dict in lab_03) alongside the next part's prediction radio but only returned the prediction. marimo's static dataflow therefore never wired those widgets into the tabs cell, so every lever downstream of a prediction lock was missing once the student answered.

@asgalon flagged this in #1332 as "missing prediction choices" and "Part C chart stuck, does not move when changing items."

fix: split widget defs into one cell per part, each returning every widget it owns; update tabs cell signature to receive them all.

## lab_02 additional fixes

1. Part A radio label used ''\$15K / \$30K'' as literal dollar signs. pandoc/markdown interprets ''\$...\$'' as inline math and italicises. switched the label to an ''r"..."'' raw string with backslash-escaped dollars so the student sees ''\$15K / \$30K'' as currency.
2. Part A feedback callout said ''The speedup at AI=5 is only ~{_speedup:.2f}x'' but ''_speedup'' was computed at the current slider value (1-400 range, default 5). moved students who slid to AI=200 away from ''AI=5'' now saw an AI=200 speedup under an ''at AI=5'' caption. added ''_speedup_at_5'' computed at the anchored question point; feedback references it instead.
3. Part D ''data_size'' slider and ''wireless'' dropdown were defined inside the tabs cell's body but not in its parameter list, so they never reached downstream cells (@asgalon: ''move them one cell up''). pulled into their own widget cell.

## lab_03 specifics

- Part A ''stage'' slider, Part B ''cycle_a/cycle_b'' sliders, Part C ''pm-allocation'' dict of 5 sliders, Part D ''months'' slider all moved to one-cell-per-part structure with proper returns. that closes Peter's ''chart stuck'' observation since the tabs cell now re-runs when any of the 5 PM sliders changes.

## test plan

- [x] pytest labs/tests/test_static.py + tests/test_engine.py -> 792 passed 4 skipped 1 xfailed
- [x] marimo check vol1/lab_02_ml_systems.py -> exit 0
- [x] marimo check vol1/lab_03_ml_workflow.py -> exit 0
- [x] browser smoke (labs/tests/browser_smoke.py) against both exported labs -> 0 captured errors
- [x] manual playwright click-through: after picking prediction on Part A, ''marimo-slider'' count goes 0 -> 2 in the DOM (confirming the partA_ai slider reaches the rendered tab)
- [ ] ci green on this pr

addresses #1332 (partial; covers lab_02 + lab_03, leaves the ''1.1x vs 1.64x example values'' suggestion and later-lab items for follow-ups)