### PR TITLE
fix(labs): widget return-tuple sweep across 33 labs + static regression guard (#1332)

### DIFF
--- a/labs/tests/test_static.py
+++ b/labs/tests/test_static.py
@@ -516,3 +516,85 @@ class TestMarimoDataflow:
                 "canonical pattern: each gated cell returns only the next "
                 "prediction widget."
             )
+
+
+# ── Test: Widget Return Completeness ─────────────────────────────────────────
+
+# Cells whose mo.ui.* assignment is a render sink (tabs composition) do not
+# need to be in the return tuple. Widgets defined inside the tabs cell itself
+# are also local to that cell's closures and do not flow outward.
+_SINK_WIDGET_NAMES = {"tabs", "_tabs", "_tour_tabs"}
+
+
+def _is_tabs_cell_function(func):
+    """True if this cell defines `build_*` closures or calls `mo.ui.tabs`."""
+    for node in ast.walk(func):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node is not func:
+            if node.name.startswith("build_"):
+                return True
+        if isinstance(node, ast.Call):
+            f = node.func
+            if (
+                isinstance(f, ast.Attribute)
+                and f.attr == "tabs"
+                and isinstance(f.value, ast.Attribute)
+                and f.value.attr == "ui"
+                and isinstance(f.value.value, ast.Name)
+                and f.value.value.id == "mo"
+            ):
+                return True
+    return False
+
+
+class TestWidgetReturnCompleteness:
+    """Every `mo.ui.*` widget defined in a cell must appear in that cell's
+    return tuple (or be a render-sink name like `tabs`). When a cell defines
+    N widgets but only returns M < N, marimo's dataflow never routes the
+    unreturned widgets to downstream cells, so sliders and dropdowns gated
+    behind a prediction radio never render — even though the prediction
+    itself works and tests pass. Peter Koellner (#1332) hit this for lab_02
+    and lab_03; a sweep across all 33 labs found it in 17 of them.
+
+    This test blocks new regressions of the same class.
+    """
+
+    def test_widget_return_complete(self, lab_path):
+        tree = parse_tree(lab_path)
+        violations = []
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if not _has_app_cell_decorator(node):
+                continue
+            # The tabs cell's internal widgets are consumed by its own
+            # closures and do not need to be returned outward.
+            if _is_tabs_cell_function(node):
+                continue
+            defined: list[str] = []
+            for stmt in node.body:
+                name = _is_mo_ui_assign(stmt)
+                if name is not None:
+                    defined.append(name)
+            if not defined:
+                continue
+            returned = _returned_names(node)
+            missing = [
+                n for n in defined
+                if n not in returned and n not in _SINK_WIDGET_NAMES
+            ]
+            if missing:
+                violations.append((node.lineno, missing))
+
+        if violations:
+            summary = "\n".join(
+                f"  cell at line {line}: defined but NOT returned: {names}"
+                for line, names in violations
+            )
+            pytest.fail(
+                "widgets defined but not returned from their cell (marimo dataflow breaks):\n"
+                + summary
+                + "\n\nfix: add each defined widget to the cell's `return (...)` "
+                "tuple. downstream cells can only see widgets that are exported "
+                "via the return statement. see #1332 for the class of bug this "
+                "prevents."
+            )

--- a/labs/vol1/lab_00_introduction.py
+++ b/labs/vol1/lab_00_introduction.py
@@ -412,7 +412,7 @@ def _(mo):
         value=False,
         label="Deploy the model directly on the vehicle"
     )
-    return edge_deploy, faster_gpu, model_size, move_server, quantization
+    return (edge_deploy, faster_gpu, model_size, move_server, quantization)
 
 
 @app.cell
@@ -778,7 +778,10 @@ def _(check1, check2empty, check3, mo):
 
 
 @app.cell
-def _(COLORS, check1, check2empty, check3, mo):
+def _(
+    COLORS, check2empty, mo, check1,
+    check3,
+):
     mo.stop(check1.value is None or check2empty() or check3.value is None)
 
     # ── ZONE ANATOMY DIAGRAM ─────────────────────────────────────────

--- a/labs/vol1/lab_01_ml_intro.py
+++ b/labs/vol1/lab_01_ml_intro.py
@@ -365,26 +365,22 @@ def _(DecisionLog, mo):
         placeholder="Based on what I learned in this lab, the most important diagnostic "
                     "question before investing in hardware is..."
     )
-    return (partA_scenario, partA_fix, partB_batch, partC_target, partD_scale, synth_decision_input, synth_decision_ui)
+    return (partA_fix, partA_scenario, partB_batch, partC_target, partD_scale)
 
 @app.cell(hide_code=True)
 def _(
-    COLORS,
-    H100_TFLOPS_FP16, H100_BW_GBS, H100_RAM_GB, H100_TDP_W,
-    A100_TFLOPS_FP16, A100_BW_GBS, A100_RAM_GB,
+    COLORS, H100_TFLOPS_FP16, H100_BW_GBS, H100_RAM_GB,
+    H100_TDP_W, A100_TFLOPS_FP16, A100_BW_GBS, A100_RAM_GB,
     JETSON_TFLOPS, JETSON_BW_GBS, JETSON_RAM_GB, JETSON_TDP_W,
     IPHONE_TFLOPS, IPHONE_BW_GBS, IPHONE_RAM_GB, IPHONE_TDP_W,
-    ESP32_TFLOPS, ESP32_BW_GBS, ESP32_RAM_KB, ESP32_RAM_GB, ESP32_TDP_W,
-    HIMAX_TFLOPS, HIMAX_BW_GBS, HIMAX_RAM_GB, HIMAX_TDP_W,
-    RESNET50_PARAMS, RESNET50_FLOPS, RESNET50_SIZE_MB,
-    Engine, Models, Hardware,
-    apply_plotly_theme, go, math, mo, np,
-    partA_prediction, partA_scenario, partA_fix,
-    partB_prediction, partB_batch,
-    partC_prediction, partC_target,
-    partD_prediction, partD_scale,
-    synth_decision_input, synth_decision_ui,
-    ledger,
+    ESP32_TFLOPS, ESP32_BW_GBS, ESP32_RAM_KB, ESP32_RAM_GB,
+    ESP32_TDP_W, HIMAX_TFLOPS, HIMAX_BW_GBS, HIMAX_RAM_GB,
+    HIMAX_TDP_W, RESNET50_PARAMS, RESNET50_FLOPS, RESNET50_SIZE_MB,
+    Engine, Models, Hardware, apply_plotly_theme,
+    go, math, mo, np,
+    synth_decision_input, synth_decision_ui, ledger, partA_fix,
+    partA_prediction, partA_scenario, partB_batch, partB_prediction,
+    partC_prediction, partC_target, partD_prediction, partD_scale,
 ):
     # ─────────────────────────────────────────────────────────────────────
     # PART A BUILDER -- Three Axes, One System

--- a/labs/vol1/lab_02_ml_systems.py
+++ b/labs/vol1/lab_02_ml_systems.py
@@ -313,7 +313,7 @@ def _(mo):
         value="10 ms (AV safety)",
         label="SLA budget:",
     )
-    return partB_distance, partB_sla
+    return (partB_distance, partB_sla)
 
 
 @app.cell(hide_code=True)
@@ -352,7 +352,7 @@ def _(mo):
         value="ResNet-50 (4.1 GFLOPs)",
         label="Model:",
     )
-    return partC_model, partC_target
+    return (partC_model, partC_target)
 
 
 @app.cell(hide_code=True)
@@ -384,27 +384,23 @@ def _(mo):
         value="BLE (1 Mbps)",
         label="Wireless technology:",
     )
-    return partD_data_size, partD_wireless
+    return (partD_data_size, partD_wireless)
 
 
 # ─── CELL N: TABS COMPOSITION ────────────────────────────────────────────
 @app.cell(hide_code=True)
 def _(
-    COLORS,
-    H100_TFLOPS, H100_BW, H100_RAM, H100_TDP,
-    A100_TFLOPS, A100_BW, A100_RAM,
+    COLORS, H100_TFLOPS, H100_BW, H100_RAM,
+    H100_TDP, A100_TFLOPS, A100_BW, A100_RAM,
     JETSON_TFLOPS, JETSON_BW, JETSON_RAM, JETSON_TDP,
-    IPHONE_TFLOPS, IPHONE_TDP,
-    ESP32_TFLOPS, ESP32_TDP, ESP32_RAM_KB,
-    RESNET50_FLOPS, RESNET50_SIZE_MB,
-    MOBILENET_FLOPS, DSCNN_FLOPS,
-    SPEED_OF_LIGHT_KM_S, FIBER_FACTOR,
-    Engine, Models, Hardware,
-    apply_plotly_theme, go, math, mo, np,
-    partA_prediction, partA_ai,
-    partB_prediction, partB_distance, partB_sla,
-    partC_prediction, partC_target, partC_model,
-    partD_prediction, partD_data_size, partD_wireless,
+    IPHONE_TFLOPS, IPHONE_TDP, ESP32_TFLOPS, ESP32_TDP,
+    ESP32_RAM_KB, RESNET50_FLOPS, RESNET50_SIZE_MB, MOBILENET_FLOPS,
+    DSCNN_FLOPS, SPEED_OF_LIGHT_KM_S, FIBER_FACTOR, Engine,
+    Models, Hardware, apply_plotly_theme, go,
+    math, mo, np, partA_ai,
+    partA_prediction, partB_distance, partB_prediction, partB_sla,
+    partC_model, partC_prediction, partC_target, partD_data_size,
+    partD_prediction, partD_wireless,
 ):
     # ─────────────────────────────────────────────────────────────────────
     # PART A -- The Memory Wall Revelation

--- a/labs/vol1/lab_03_ml_workflow.py
+++ b/labs/vol1/lab_03_ml_workflow.py
@@ -240,7 +240,7 @@ def _(mo):
         start=1, stop=168, value=1, step=1,
         label="Team B cycle time (hours)",
     )
-    return partB_cycle_a, partB_cycle_b
+    return (partB_cycle_a, partB_cycle_b)
 
 
 @app.cell(hide_code=True)
@@ -303,13 +303,11 @@ def _(mo):
 @app.cell(hide_code=True)
 def _(
     COLORS, H100_TFLOPS, H100_RAM, ESP32_RAM_KB,
-    RESNET50_PARAMS, RESNET50_SIZE_MB,
-    Engine, Models, Hardware,
-    apply_plotly_theme, go, math, mo, np,
-    partA_prediction, partA_stage,
-    partB_prediction, partB_cycle_a, partB_cycle_b,
-    partC_prediction, partC_sliders,
-    partD_prediction, partD_months,
+    RESNET50_PARAMS, RESNET50_SIZE_MB, Engine, Models,
+    Hardware, apply_plotly_theme, go, math,
+    mo, np, partA_prediction, partA_stage,
+    partB_cycle_a, partB_cycle_b, partB_prediction, partC_prediction,
+    partC_sliders, partD_months, partD_prediction,
 ):
 
     # ═════════════════════════════════════════════════════════════════════

--- a/labs/vol1/lab_04_data_engr.py
+++ b/labs/vol1/lab_04_data_engr.py
@@ -232,7 +232,7 @@ def _(mo):
         },
         label="50 TB dataset, 10 Gbps link. How long to transfer?",
     )
-    return (partB_prediction,)
+    return (partA_storage, partA_workers, partB_prediction)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -256,7 +256,7 @@ def _(mo):
         },
         label="A pipeline has 2% error at ingestion. What accuracy degradation at output?",
     )
-    return (partC_prediction,)
+    return (partB_bandwidth, partB_dataset, partC_prediction)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -280,10 +280,14 @@ def _(mo):
         label="Always-on speaker, 1 false wake per month max. "
               "What rejection rate is required?",
     )
-    return (partD_prediction,)
+    return (partC_error_rate, partC_stages, partD_prediction)
 
 @app.cell(hide_code=True)
-def _(mo, partD_prediction):
+def _(
+    mo, partA_prediction, partA_storage, partA_workers,
+    partB_bandwidth, partB_dataset, partB_prediction, partC_error_rate,
+    partC_prediction, partC_stages, partD_prediction,
+):
     partD_tolerance = mo.ui.slider(
         start=1, stop=50, value=1, step=1,
         label="False wake-ups per month (tolerance)",

--- a/labs/vol1/lab_05_nn_compute.py
+++ b/labs/vol1/lab_05_nn_compute.py
@@ -273,7 +273,7 @@ def _(mo):
         label="A layer produces a 16 KB activation tensor in L2 cache. You double the "
               "batch size (32 KB now). How does latency change on a mobile NPU?",
     )
-    return (partB_prediction,)
+    return (partA_act_l1, partA_act_l2, partA_act_l3, partA_act_l4, partA_context, partB_prediction)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -301,7 +301,7 @@ def _(mo):
         label="A 3-layer MLP has hidden layers of width 128. You double the hidden "
               "width to 256. By how much do total FLOPs increase?",
     )
-    return (partC_prediction,)
+    return (partB_batch, partB_context, partB_width, partC_prediction)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -320,10 +320,15 @@ def _(mo):
         label="A 20-layer model uses 50 MB for inference. How much memory does training "
               "require (weights + gradients + activations, ignoring optimizer state)?",
     )
-    return (partD_prediction,)
+    return (partC_width, partD_prediction)
 
 @app.cell(hide_code=True)
-def _(mo, partD_prediction):
+def _(
+    mo, partA_act_l1, partA_act_l2, partA_act_l3,
+    partA_act_l4, partA_context, partA_prediction, partB_batch,
+    partB_context, partB_prediction, partB_width, partC_prediction,
+    partC_width, partD_prediction,
+):
     partD_depth = mo.ui.slider(
         start=3, stop=50, value=20, step=1, label="Network depth (layers)",
     )

--- a/labs/vol1/lab_06_nn_arch.py
+++ b/labs/vol1/lab_06_nn_arch.py
@@ -250,7 +250,7 @@ def _(mo):
         label="Doubling a Transformer's context from 4,096 to 8,192 tokens -- "
               "how much more memory does attention require?",
     )
-    return (partB_prediction,)
+    return (partA_arch, partA_resolution, partB_prediction)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -272,7 +272,7 @@ def _(mo):
         label="Two networks: identical FLOPs/params. One is 128 layers deep (width 32). "
               "The other is 2 layers deep (width 512). Which is faster at inference?",
     )
-    return (partC_prediction,)
+    return (partB_heads, partB_seq_len, partC_prediction)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -294,10 +294,14 @@ def _(mo):
         },
         label="Which architecture family achieves the highest GPU utilization (MFU) at batch=1?",
     )
-    return (partD_prediction,)
+    return (partC_context_c, partC_depth, partD_prediction)
 
 @app.cell(hide_code=True)
-def _(mo, partD_prediction):
+def _(
+    mo, partA_arch, partA_prediction, partA_resolution,
+    partB_heads, partB_prediction, partB_seq_len, partC_context_c,
+    partC_depth, partC_prediction, partD_prediction,
+):
     partD_batch_d = mo.ui.slider(
         start=1, stop=256, value=1, step=1, label="Batch size",
     )

--- a/labs/vol1/lab_07_ml_frameworks.py
+++ b/labs/vol1/lab_07_ml_frameworks.py
@@ -260,7 +260,7 @@ def _(mo):
         label="Fusing 3 element-wise operations into one kernel eliminates intermediate "
               "HBM writes. What speedup do you expect?",
     )
-    return (partB_prediction,)
+    return (partA_compute_us, partA_kernels, partB_prediction)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -282,7 +282,7 @@ def _(mo):
         label="torch.compile gives 48% speedup on ResNet-50 but takes 30s to compile. "
               "How many inferences before compilation pays off?",
     )
-    return (partC_prediction,)
+    return (partB_num_ops, partB_tensor_mb, partC_prediction)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -304,10 +304,14 @@ def _(mo):
         label="PyTorch runtime alone requires ~1,800 MB. The ESP32 has 512 KB. "
               "By what factor does the runtime exceed device memory?",
     )
-    return (partD_prediction,)
+    return (partC_compile_time, partC_volume, partD_prediction)
 
 @app.cell(hide_code=True)
-def _(mo, partD_prediction):
+def _(
+    mo, partA_compute_us, partA_kernels, partA_prediction,
+    partB_num_ops, partB_prediction, partB_tensor_mb, partC_compile_time,
+    partC_prediction, partC_volume, partD_prediction,
+):
     partD_framework = mo.ui.dropdown(
         options={"PyTorch": "PyTorch", "TensorFlow": "TensorFlow",
                  "ONNX Runtime": "ONNX Runtime", "TF Lite": "TF Lite",

--- a/labs/vol1/lab_08_model_train.py
+++ b/labs/vol1/lab_08_model_train.py
@@ -257,7 +257,7 @@ def _(mo):
         label="GPT-2 training on V100 with SSD storage and 4 GPUs over PCIe. "
               "Which stage is the bottleneck?",
     )
-    return (partB_prediction,)
+    return (partA_model_size, partA_optimizer, partA_precision_a, partB_prediction)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -285,7 +285,7 @@ def _(mo):
         label="GPT-2 (1.5B) requires ~77 GB in full FP32 (with activations). "
               "Mixed precision (FP16 forward + FP32 master + FP32 Adam) requires how much?",
     )
-    return (partC_prediction,)
+    return (partB_compute_ms, partB_data_ms, partB_pcie_ms, partB_sync_ms, partC_prediction)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -308,10 +308,15 @@ def _(mo):
         label="Training on 8 GPUs with r=0.15 (gradient sync = 15% of step time). "
               "What speedup over 1 GPU?",
     )
-    return (partD_prediction,)
+    return (partC_model_c, partC_precision_c, partD_prediction)
 
 @app.cell(hide_code=True)
-def _(mo, partD_prediction):
+def _(
+    mo, partA_model_size, partA_optimizer, partA_precision_a,
+    partA_prediction, partB_compute_ms, partB_data_ms, partB_pcie_ms,
+    partB_prediction, partB_sync_ms, partC_model_c, partC_precision_c,
+    partC_prediction, partD_prediction,
+):
     partD_gpus = mo.ui.slider(
         start=1, stop=256, value=8, step=1, label="Number of GPUs",
     )

--- a/labs/vol1/lab_09_data_selection.py
+++ b/labs/vol1/lab_09_data_selection.py
@@ -250,7 +250,7 @@ def _(mo):
         label="ResNet-50 scores 1M images on A100 (2.8 hrs). Full training: 8.0 hrs. "
               "Coreset (50%) training: 4.2 hrs. Is selection worth it?",
     )
-    return (partB_pred,)
+    return (partA_frac, partA_redundancy, partB_pred)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -286,7 +286,7 @@ def _(mo):
               "feeding an A100 GPU. GPU forward-backward: 12 ms/batch. "
               "What fraction of step time is GPU compute?",
     )
-    return (partC_pred,)
+    return (partB_coreset, partB_hw, partB_scorer, partC_pred)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -320,10 +320,15 @@ def _(mo):
         },
         label="Fixed budget: 10^21 FLOPs. Which achieves lower loss?",
     )
-    return (partD_pred,)
+    return (partC_augment, partC_model, partC_workers, partD_pred)
 
 @app.cell(hide_code=True)
-def _(mo, partD_pred):
+def _(
+    mo, partA_frac, partA_pred, partA_redundancy,
+    partB_coreset, partB_hw, partB_pred, partB_scorer,
+    partC_augment, partC_model, partC_pred, partC_workers,
+    partD_pred,
+):
     partD_params_b = mo.ui.slider(
         start=0.5, stop=50, value=10, step=0.5,
         label="Model size (B parameters)",

--- a/labs/vol1/lab_10_model_compress.py
+++ b/labs/vol1/lab_10_model_compress.py
@@ -258,7 +258,7 @@ def _(mo):
         label="You prune ResNet-50 to 90% sparsity (unstructured). "
               "What inference speedup on an H100?",
     )
-    return (pB_pred,)
+    return (pA_model_sel, pA_precision, pB_pred)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -278,7 +278,7 @@ def _(mo):
         },
         label="Deploy Llama-3 8B on 4 GB RAM. Which strategy fits?",
     )
-    return (pC_pred,)
+    return (pB_sparsity, pB_type, pC_pred)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -315,10 +315,14 @@ def _(mo):
         },
         label="ResNet-50 teacher: 76.1% ImageNet. Distill to MobileNetV2 student. Student accuracy?",
     )
-    return (pE_pred,)
+    return (pD_hw, pD_precision_e, pE_pred)
 
 @app.cell(hide_code=True)
-def _(mo, pE_pred):
+def _(
+    mo, pA_model_sel, pA_precision, pA_pred,
+    pB_pred, pB_sparsity, pB_type, pC_pred,
+    pD_hw, pD_precision_e, pD_pred, pE_pred,
+):
     pE_temp = mo.ui.slider(start=1.0, stop=20.0, value=4.0, step=0.5, label="Temperature")
 
     # ─────────────────────────────────────────────────────────────────────

--- a/labs/vol1/lab_11_hw_accel.py
+++ b/labs/vol1/lab_11_hw_accel.py
@@ -243,7 +243,7 @@ def _(mo):
         },
         label="Fuse LayerNorm + Dropout + ReLU into one kernel, eliminating 2 HBM writes. Speedup?",
     )
-    return (pB_pred,)
+    return (pA_dim, pA_prec, pB_pred)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -262,7 +262,7 @@ def _(mo):
         },
         label="GEMM at N=1024 is compute-bound on Jetson Orin NX. Is it compute-bound on H100?",
     )
-    return (pC_pred,)
+    return (pB_batch, pB_mode, pC_pred)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -280,7 +280,7 @@ def _(mo):
         },
         label="Memory-bound (AI=10) and compute-bound (AI=500) do the same FLOPs. Which uses more energy?",
     )
-    return (pD_pred,)
+    return (pC_hw, pD_pred)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -296,7 +296,11 @@ def _(mo):
     return (pE_pred,)
 
 @app.cell(hide_code=True)
-def _(mo, pE_pred):
+def _(
+    mo, pA_dim, pA_prec, pA_pred,
+    pB_batch, pB_mode, pB_pred, pC_hw,
+    pC_pred, pD_pred, pE_pred,
+):
     pE_tile = mo.ui.slider(start=32, stop=2048, value=256, step=32, label="Tile size (elements)")
     pE_seq = mo.ui.slider(start=512, stop=16384, value=4096, step=512, label="Sequence length")
 

--- a/labs/vol1/lab_12_perf_bench.py
+++ b/labs/vol1/lab_12_perf_bench.py
@@ -238,7 +238,7 @@ def _(mo):
         label="Edge device benchmarks at 30 FPS (1-min vendor test). "
               "Sustained FPS after 10 min in fanless enclosure at 35C?",
     )
-    return (pB_pred,)
+    return (pA_serial, pA_speedup, pB_pred)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -259,7 +259,7 @@ def _(mo):
         },
         label="Config A has highest accuracy (94%). Is it deployable?",
     )
-    return (pC_pred,)
+    return (pB_ambient, pB_cooling, pB_time, pC_pred)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -279,10 +279,14 @@ def _(mo):
         },
         label="Inference service: 50 ms average latency. SLO: 200 ms p99. Is the SLO satisfied?",
     )
-    return (pD_pred,)
+    return (pC_batch, pC_precision, pD_pred)
 
 @app.cell(hide_code=True)
-def _(mo, pD_pred):
+def _(
+    mo, pA_pred, pA_serial, pA_speedup,
+    pB_ambient, pB_cooling, pB_pred, pB_time,
+    pC_batch, pC_precision, pC_pred, pD_pred,
+):
     pD_sigma = mo.ui.slider(start=0.1, stop=1.5, value=0.8, step=0.05, label="Tail heaviness (sigma)")
     pD_slo = mo.ui.slider(start=50, stop=500, value=200, step=10, label="SLO threshold (ms)")
 

--- a/labs/vol1/lab_13_model_serving.py
+++ b/labs/vol1/lab_13_model_serving.py
@@ -230,7 +230,7 @@ def _(mo):
         },
         label="Batch size 1 to 32, arrival 500 QPS, SLO 50 ms. What happens?",
     )
-    return (partB_pred,)
+    return (partA_rho, partA_slo, partA_svc, partB_pred)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -248,7 +248,7 @@ def _(mo):
         },
         label="Llama-2 70B, 128K context, 8xH100 (640 GB). Max concurrent batch?",
     )
-    return (partC_pred,)
+    return (partB_arr, partB_batch, partB_slo, partC_pred)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -273,10 +273,15 @@ def _(mo):
         },
         label="Auto-scaling Llama-2 70B during traffic spike. First-user wait?",
     )
-    return (partD_pred,)
+    return (partC_ctx, partC_gpus, partC_model, partC_prec, partD_pred)
 
 @app.cell(hide_code=True)
-def _(mo, partD_pred):
+def _(
+    mo, partA_pred, partA_rho, partA_slo,
+    partA_svc, partB_arr, partB_batch, partB_pred,
+    partB_slo, partC_ctx, partC_gpus, partC_model,
+    partC_prec, partC_pred, partD_pred,
+):
     partD_model = mo.ui.dropdown(options={"7B": 7, "13B": 13, "70B": 70}, value="70B",
                                   label="Model size")
     partD_stor = mo.ui.dropdown(

--- a/labs/vol1/lab_14_ml_ops.py
+++ b/labs/vol1/lab_14_ml_ops.py
@@ -202,7 +202,7 @@ def _(mo):
         },
         label="Retraining costs $10K. Drift costs $500/day. Current cadence: 30 days. Optimal?",
     )
-    return (partB_pred,)
+    return (partA_drift_rate, partA_weeks, partB_pred)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -221,7 +221,7 @@ def _(mo):
         },
         label="Cloud retraining: $1K, T*=7 days. Edge: $100K. What is edge T*?",
     )
-    return (partC_pred,)
+    return (partB_drift_cost, partB_retrain_cost, partC_pred)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -242,10 +242,14 @@ def _(mo):
         },
         label="You defer retraining for 3 consecutive T* cycles. Total accuracy loss vs single miss?",
     )
-    return (partD_pred,)
+    return (partC_cloud_cost, partC_drift_cost, partC_edge_cost, partD_pred)
 
 @app.cell(hide_code=True)
-def _(mo, partD_pred):
+def _(
+    mo, partA_drift_rate, partA_pred, partA_weeks,
+    partB_drift_cost, partB_pred, partB_retrain_cost, partC_cloud_cost,
+    partC_drift_cost, partC_edge_cost, partC_pred, partD_pred,
+):
     partD_missed = mo.ui.slider(start=1, stop=6, value=3, step=1,
                                  label="Missed retraining cycles")
     partD_downstream = mo.ui.slider(start=0, stop=5, value=2, step=1,

--- a/labs/vol1/lab_15_responsible_engr.py
+++ b/labs/vol1/lab_15_responsible_engr.py
@@ -203,7 +203,7 @@ def _(mo):
         },
         label="Apply equalized odds to reduce FPR gap from 15% to 5%. Accuracy loss?",
     )
-    return (partB_pred,)
+    return (partA_base_a, partA_base_b, partA_threshold, partB_pred)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -224,7 +224,7 @@ def _(mo):
         },
         label="Loan model has 50 features. How much does SHAP add to inference latency?",
     )
-    return (partC_pred,)
+    return (partB_method, partB_target_gap, partC_pred)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -245,10 +245,14 @@ def _(mo):
         },
         label="Weekly retraining + SHAP for 10% of predictions. Carbon vs baseline?",
     )
-    return (partD_pred,)
+    return (partC_features, partC_method, partD_pred)
 
 @app.cell(hide_code=True)
-def _(mo, partD_pred):
+def _(
+    mo, partA_base_a, partA_base_b, partA_pred,
+    partA_threshold, partB_method, partB_pred, partB_target_gap,
+    partC_features, partC_method, partC_pred, partD_pred,
+):
     partD_retrain_freq = mo.ui.dropdown(
         options={"Weekly": 52, "Monthly": 12, "Quarterly": 4, "Once": 1},
         value="Weekly", label="Retraining frequency")

--- a/labs/vol1/lab_16_ml_conclusion.py
+++ b/labs/vol1/lab_16_ml_conclusion.py
@@ -217,7 +217,7 @@ def _(mo):
         },
         label="You quantized MobileNetV2 to INT8, deployed on mobile. After 6 months without monitoring?",
     )
-    return (partB_pred,)
+    return (partA_batch, partA_model, partA_prec, partB_pred)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -242,7 +242,7 @@ def _(mo):
         value="Memory Wall",
         label="Which invariant do you think you most consistently underestimated?",
     )
-    return (partC_pred,)
+    return (partB_monitoring, partB_months, partB_quant, partC_pred)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -287,10 +287,16 @@ def _(mo):
         },
         label="Quantize Llama-2 70B FP16 to INT4 (35 GB < 80 GB HBM). New binding constraint?",
     )
-    return (partE_pred,)
+    return (partD_inference, partD_logging, partD_optimize, partD_postprocess, partD_preprocess, partD_speedup, partE_pred)
 
 @app.cell(hide_code=True)
-def _(mo, partE_pred):
+def _(
+    mo, partA_batch, partA_model, partA_prec,
+    partA_pred, partB_monitoring, partB_months, partB_pred,
+    partB_quant, partC_pred, partD_inference, partD_logging,
+    partD_optimize, partD_postprocess, partD_pred, partD_preprocess,
+    partD_speedup, partE_pred,
+):
     partE_int4 = mo.ui.checkbox(label="INT4 Quantization", value=False)
     partE_pruning = mo.ui.checkbox(label="Structured Pruning (50%)", value=False)
     partE_distill = mo.ui.checkbox(label="Knowledge Distillation", value=False)

--- a/labs/vol2/lab_01_introduction.py
+++ b/labs/vol2/lab_01_introduction.py
@@ -280,7 +280,7 @@ def _(mo):
         label="You scale a 175B model from 1 GPU to 256 GPUs on InfiniBand NDR. "
               "What fleet efficiency do you expect?",
     )
-    return (partB_prediction,)
+    return (partA_fleet_size, partA_node_rel, partB_prediction)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -311,7 +311,7 @@ def _(mo):
         label="Fixed budget of 10^23 FLOPs. Which achieves lower loss: "
               "a 10B model on 200B tokens, or a 3B model on 600B tokens?",
     )
-    return (partC_prediction,)
+    return (partB_gpu_count, partB_model_size, partB_network, partC_prediction)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -329,7 +329,7 @@ def _(mo):
         label="For a workload with 20% communication overhead (r = 0.20), "
               "how many GPUs before scaling efficiency drops below 50%?",
     )
-    return (partD_prediction,)
+    return (partC_params, partC_tokens, partD_prediction)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -350,10 +350,16 @@ def _(mo):
         options={"Computation": "comp", "Communication": "comm", "Coordination": "coord"},
         label="Federated MobileNet (edge devices) -- dominant bottleneck?",
     )
-    return (partE_llm, partE_dlrm, partE_fed)
+    return (partD_comm_frac, partD_n_gpus, partD_overlap, partE_dlrm, partE_fed, partE_llm)
 
 @app.cell(hide_code=True)
-def _(mo, partE_llm, partE_dlrm, partE_fed):
+def _(
+    mo, partA_fleet_size, partA_node_rel, partA_prediction,
+    partB_gpu_count, partB_model_size, partB_network, partB_prediction,
+    partC_params, partC_prediction, partC_tokens, partD_comm_frac,
+    partD_n_gpus, partD_overlap, partD_prediction, partE_dlrm,
+    partE_fed, partE_llm,
+):
 
     # ═════════════════════════════════════════════════════════════════════════
     # PART A: THE RELIABILITY COLLAPSE

--- a/labs/vol2/lab_02_compute_infra.py
+++ b/labs/vol2/lab_02_compute_infra.py
@@ -279,7 +279,7 @@ def _(mo):
         },
         label="Which fleet-scale workloads fall above the H100 ridge point?",
     )
-    return (pB_pred,)
+    return (pA_batch, pA_model, pB_pred)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -297,7 +297,7 @@ def _(mo):
         },
         label="How much slower is a 10 GB AllReduce over IB NDR vs NVLink 4.0?",
     )
-    return (pC_pred,)
+    return (pB_hw, pC_pred)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -313,7 +313,7 @@ def _(mo):
         label="Can a single 8-GPU DGX H100 node (640 GB HBM) train a 175B "
               "model with Adam in FP16 without ZeRO?",
     )
-    return (pD_pred,)
+    return (pC_size, pD_pred)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -333,10 +333,15 @@ def _(mo):
         },
         label="For a 1,000-GPU H100 cluster over 3 years: GPUs or electricity costs more?",
     )
-    return (pE_pred,)
+    return (pD_gpus, pD_model_b, pD_zero, pE_pred)
 
 @app.cell(hide_code=True)
-def _(mo, pE_pred):
+def _(
+    mo, pA_batch, pA_model, pA_pred,
+    pB_hw, pB_pred, pC_pred, pC_size,
+    pD_gpus, pD_model_b, pD_pred, pD_zero,
+    pE_pred,
+):
     pE_n_gpus = mo.ui.slider(start=100, stop=5000, value=1000, step=100, label="GPU count")
     pE_util = mo.ui.slider(start=30, stop=90, value=70, step=5, label="Utilization (%)")
     pE_pue = mo.ui.slider(start=1.06, stop=1.60, value=1.12, step=0.02, label="PUE")

--- a/labs/vol2/lab_03_communication.py
+++ b/labs/vol2/lab_03_communication.py
@@ -253,7 +253,7 @@ def _(mo):
         },
         label="256 GPUs on IB NDR. Which AllReduce is faster for a 1 MB message?",
     )
-    return (pB_pred,)
+    return (pA_gpus, pA_model, pA_prec, pB_pred)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -272,7 +272,7 @@ def _(mo):
         },
         label="Hierarchical AllReduce vs flat ring for 64 GPUs (8 nodes x 8). Speedup?",
     )
-    return (pC_pred,)
+    return (pB_msg_exp, pB_n_gpus, pC_pred)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -296,7 +296,7 @@ def _(mo):
         label="INT8 gradient compression (4x BW reduction) for 70B on 64 GPUs with IB NDR. "
               "Does total training time decrease?",
     )
-    return (pD_pred,)
+    return (pC_gpus_per_node, pC_oversub, pC_topo, pD_pred)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -316,10 +316,15 @@ def _(mo):
         label="Starting from 11s AllReduce for 70B: how many optimizations "
               "to get under 20% of step time?",
     )
-    return (pE_pred,)
+    return (pD_bw, pD_comp, pE_pred)
 
 @app.cell(hide_code=True)
-def _(mo, pE_pred):
+def _(
+    mo, pA_gpus, pA_model, pA_prec,
+    pA_pred, pB_msg_exp, pB_n_gpus, pB_pred,
+    pC_gpus_per_node, pC_oversub, pC_pred, pC_topo,
+    pD_bw, pD_comp, pD_pred, pE_pred,
+):
     pE_hier = mo.ui.checkbox(label="Hierarchical AllReduce")
     pE_fp16 = mo.ui.checkbox(label="FP16 gradients")
     pE_bucket = mo.ui.checkbox(label="Bucket fusion")

--- a/labs/vol2/lab_04_data_storage.py
+++ b/labs/vol2/lab_04_data_storage.py
@@ -244,7 +244,7 @@ def _(mo):
         },
         label="128 GPUs at 80% utilization. Double to 256 without upgrading storage. What happens?",
     )
-    return (pB_pred,)
+    return (pA_gen, pB_pred)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -260,7 +260,7 @@ def _(mo):
         },
         label="256 GPUs, 1,000 shards, random selection. Collision probability?",
     )
-    return (pC_pred,)
+    return (pB_gpus, pB_target, pC_pred)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -276,7 +276,7 @@ def _(mo):
         },
         label="200 ms compute, 300 ms I/O. Add prefetch depth 4. Does the stall disappear?",
     )
-    return (pD_pred,)
+    return (pC_shards, pC_workers, pD_pred)
 
 @app.cell(hide_code=True)
 def _(mo):
@@ -293,10 +293,15 @@ def _(mo):
         },
         label="1,000-GPU cluster, MTBF = 5 hours, checkpoint write = 2 min. Optimal interval?",
     )
-    return (pE_pred,)
+    return (pD_compute, pD_io, pD_prefetch, pE_pred)
 
 @app.cell(hide_code=True)
-def _(mo, pE_pred):
+def _(
+    mo, pA_gen, pA_pred, pB_gpus,
+    pB_pred, pB_target, pC_pred, pC_shards,
+    pC_workers, pD_compute, pD_io, pD_pred,
+    pD_prefetch, pE_pred,
+):
     pE_mtbf = mo.ui.slider(start=1, stop=24, value=5, step=1, label="Cluster MTBF (hours)")
     pE_write = mo.ui.slider(start=30, stop=300, value=120, step=10, label="Checkpoint write time (s)")
     pE_interval = mo.ui.slider(start=1, stop=120, value=30, step=1, label="Checkpoint interval (min)")

--- a/labs/vol2/lab_05_dist_train.py
+++ b/labs/vol2/lab_05_dist_train.py
@@ -280,7 +280,7 @@ def _(mo):
         },
         label="What is the most effective strategy to overcome the DP communication wall for frontier models?",
     )
-    return (partA_prediction, a1_model_select, a1_gpu_slider, a1_interconnect, partA_reflection)
+    return (a1_gpu_slider, a1_interconnect, a1_model_select, partA_prediction, partA_reflection)
 
 
 # ─── CELL 5: PART B WIDGETS ───────────────────────────────────────────────────
@@ -318,7 +318,7 @@ def _(mo, partB_prediction):
         },
         label="Why must TP map to NVLink, PP to InfiniBand, and DP to the remaining bandwidth?",
     )
-    return (a2_tp, a2_pp, a2_microbatches, a2_zero_stage, partC_reflection)
+    return (a2_microbatches, a2_pp, a2_tp, a2_zero_stage, partC_reflection)
 
 
 # ─── CELL 6b: PART D WIDGETS ─────────────────────────────────────────────────
@@ -357,7 +357,7 @@ def _(mo, partC_reflection):
         },
         label="What principle governs hardware tier selection for distributed training?",
     )
-    return (partD_prediction, d1_hw_tier, d1_model_size, d1_gpu_count, partD_reflection)
+    return (d1_gpu_count, d1_hw_tier, d1_model_size, partD_prediction, partD_reflection)
 
 
 # ─── CELL 7: SYNTHESIS WIDGETS ────────────────────────────────────────────────
@@ -379,13 +379,13 @@ def _(DecisionLog, mo, partD_reflection):
 # ─── CELL 8: ALL PARTS + TABS COMPOSITION ─────────────────────────────────────
 @app.cell(hide_code=True)
 def _(
-    COLORS, apply_plotly_theme, go, math, mo, np,
-    H100_TFLOPS_FP16, H100_RAM_GB, NVLINK4_BW_GBS, GPUS_PER_NODE,
-    partA_prediction, a1_model_select, a1_gpu_slider, a1_interconnect, partA_reflection,
-    partB_prediction,
-    a2_tp, a2_pp, a2_microbatches, a2_zero_stage, partC_reflection,
-    partD_prediction, d1_hw_tier, d1_model_size, d1_gpu_count, partD_reflection,
-    synth_decision_input, synth_decision_ui,
+    COLORS, apply_plotly_theme, go, math,
+    mo, np, H100_TFLOPS_FP16, H100_RAM_GB,
+    NVLINK4_BW_GBS, GPUS_PER_NODE, synth_decision_input, synth_decision_ui,
+    a1_gpu_slider, a1_interconnect, a1_model_select, a2_microbatches,
+    a2_pp, a2_tp, a2_zero_stage, d1_gpu_count,
+    d1_hw_tier, d1_model_size, partA_prediction, partA_reflection,
+    partB_prediction, partC_reflection, partD_prediction, partD_reflection,
 ):
     # ─────────────────────────────────────────────────────────────────────
     # PART A BUILDER -- The Communication Wall

--- a/labs/vol2/lab_06_fault_tolerance.py
+++ b/labs/vol2/lab_06_fault_tolerance.py
@@ -208,7 +208,7 @@ def _(mo):
     a1_cluster_gpus = mo.ui.slider(start=1000, stop=25000, value=16000, step=1000, label="Cluster GPUs")
     a1_write_time_s = mo.ui.slider(start=10, stop=300, value=120, step=10, label="Checkpoint write time (seconds)")
     a1_interval_s = mo.ui.slider(start=60, stop=10800, value=600, step=60, label="Your checkpoint interval (seconds)")
-    return (partA_prediction, a1_cluster_gpus, a1_write_time_s, a1_interval_s)
+    return (a1_cluster_gpus, a1_interval_s, a1_write_time_s, partA_prediction)
 
 
 # ─── CELL 5: PART A REFLECTION + PART B PREDICTION WIDGETS ──────────────────
@@ -256,7 +256,7 @@ def _(mo):
         },
         label="What is the most practical solution to the checkpoint storm?",
     )
-    return (a2_model_b, a2_cluster_gpus, a2_storage, partB_reflection)
+    return (a2_cluster_gpus, a2_model_b, a2_storage, partB_reflection)
 
 
 # ─── CELL 6b: PART C WIDGETS ─────────────────────────────────────────────────
@@ -283,7 +283,7 @@ def _(mo):
         },
         label="What is the key requirement for async checkpointing to work?",
     )
-    return (partC_prediction, c1_nvme_bw, c1_drain_bw, c1_cluster_gpus, partC_reflection)
+    return (c1_cluster_gpus, c1_drain_bw, c1_nvme_bw, partC_prediction, partC_reflection)
 
 
 # ─── CELL 6c: PART D WIDGETS ─────────────────────────────────────────────────
@@ -311,7 +311,7 @@ def _(mo):
         },
         label="How does serving fault tolerance differ from training fault tolerance?",
     )
-    return (partD_prediction, d1_replicas, d1_qps, d1_recovery_s, d1_slo_p99_ms, partD_reflection)
+    return (d1_qps, d1_recovery_s, d1_replicas, d1_slo_p99_ms, partD_prediction, partD_reflection)
 
 
 # ─── CELL 7: DECISION LOG WIDGET ────────────────────────────────────────────
@@ -332,18 +332,15 @@ def _(DecisionLog, mo, partD_reflection):
 # ─── CELL 8: TABS ───────────────────────────────────────────────────────────
 @app.cell(hide_code=True)
 def _(
-    COLORS, apply_plotly_theme, go, math, mo, np,
-    GPU_MTTF_HOURS, GPU_COST_HR, H100_RAM_GB,
-    partA_prediction, a1_cluster_gpus, a1_write_time_s, a1_interval_s,
-    partA_reflection,
-    partB_prediction, a2_model_b, a2_cluster_gpus, a2_storage,
-    partB_reflection,
-    partC_prediction, c1_nvme_bw, c1_drain_bw, c1_cluster_gpus,
-    partC_reflection,
-    partD_prediction, d1_replicas, d1_qps, d1_recovery_s, d1_slo_p99_ms,
+    COLORS, apply_plotly_theme, go, math,
+    mo, np, GPU_MTTF_HOURS, GPU_COST_HR,
+    H100_RAM_GB, synth_decision_input, synth_decision_ui, ledger,
+    a1_cluster_gpus, a1_interval_s, a1_write_time_s, a2_cluster_gpus,
+    a2_model_b, a2_storage, c1_cluster_gpus, c1_drain_bw,
+    c1_nvme_bw, d1_qps, d1_recovery_s, d1_replicas,
+    d1_slo_p99_ms, partA_prediction, partA_reflection, partB_prediction,
+    partB_reflection, partC_prediction, partC_reflection, partD_prediction,
     partD_reflection,
-    synth_decision_input, synth_decision_ui,
-    ledger,
 ):
     # ─────────────────────────────────────────────────────────────────────
     # PART A BUILDER -- The Young-Daly Sweet Spot

--- a/labs/vol2/lab_07_fleet_orch.py
+++ b/labs/vol2/lab_07_fleet_orch.py
@@ -215,7 +215,7 @@ def _(mo):
         },
         label="What is the most effective way to reduce queue wait for ML workloads?",
     )
-    return (partA_prediction, a1_utilization, a1_workload, a1_service_min, partA_reflection)
+    return (a1_service_min, a1_utilization, a1_workload, partA_prediction, partA_reflection)
 
 
 # ─── CELL 5: Part B prediction + controls ────────────────────────────────────
@@ -243,7 +243,7 @@ def _(mo):
         },
         label="Given the impossibility of simultaneous optimization, what is the best operational approach?",
     )
-    return (partB_prediction, a2_w_throughput, a2_w_fairness, a2_w_latency, a2_n_teams, partB_reflection)
+    return (a2_n_teams, a2_w_fairness, a2_w_latency, a2_w_throughput, partB_prediction, partB_reflection)
 
 
 # ─── CELL 5b: Part C prediction + controls ────────────────────────────────
@@ -270,7 +270,7 @@ def _(mo):
         },
         label="What is the correct preemption strategy?",
     )
-    return (partC_prediction, c1_preempt_interval_h, c1_job_gpus, c1_preemptions_day, partC_reflection)
+    return (c1_job_gpus, c1_preempt_interval_h, c1_preemptions_day, partC_prediction, partC_reflection)
 
 
 # ─── CELL 5c: Part D prediction + controls ────────────────────────────────
@@ -297,7 +297,7 @@ def _(mo):
         },
         label="What is the correct fleet composition strategy?",
     )
-    return (partD_prediction, d1_h100_count, d1_t4_count, d1_small_job_pct, partD_reflection)
+    return (d1_h100_count, d1_small_job_pct, d1_t4_count, partD_prediction, partD_reflection)
 
 
 # ─── CELL 5d: DECISION LOG WIDGET ─────────────────────────────────────────
@@ -313,34 +313,13 @@ def _(DecisionLog, mo, partD_reflection):
 
 @app.cell(hide_code=True)
 def _(
-    COLORS,
-    apply_plotly_theme,
-    go,
-    math,
-    mo,
-    np,
-    GPU_COST_HR,
-    partA_prediction,
-    a1_utilization,
-    a1_workload,
-    a1_service_min,
-    partA_reflection,
-    partB_prediction,
-    a2_w_throughput,
-    a2_w_fairness,
-    a2_w_latency,
-    a2_n_teams,
-    partB_reflection,
-    partC_prediction,
-    c1_preempt_interval_h,
-    c1_job_gpus,
-    c1_preemptions_day,
-    partC_reflection,
-    partD_prediction,
-    d1_h100_count,
-    d1_t4_count,
-    d1_small_job_pct,
-    partD_reflection,
+    COLORS, apply_plotly_theme, go, math,
+    mo, np, GPU_COST_HR, a1_service_min,
+    a1_utilization, a1_workload, a2_n_teams, a2_w_fairness,
+    a2_w_latency, a2_w_throughput, c1_job_gpus, c1_preempt_interval_h,
+    c1_preemptions_day, d1_h100_count, d1_small_job_pct, d1_t4_count,
+    partA_prediction, partA_reflection, partB_prediction, partB_reflection,
+    partC_prediction, partC_reflection, partD_prediction, partD_reflection,
 ):
 
     # ═════════════════════════════════════════════════════════════════════════

--- a/labs/vol2/lab_08_inference.py
+++ b/labs/vol2/lab_08_inference.py
@@ -238,7 +238,7 @@ def _(mo):
         },
         label="70B model (FP16) on 8xH100 (640 GB). Weights = 140 GB. At 128K context, how many concurrent requests?",
     )
-    return (a1_qps, a1_cost_query, a1_weeks, a1_optimization, partA_reflection, partB_prediction)
+    return (a1_cost_query, a1_optimization, a1_qps, a1_weeks, partA_reflection, partB_prediction)
 
 
 # ─── CELL 6: Part B controls + Part B reflection ────────────────────────────
@@ -267,7 +267,7 @@ def _(mo):
         },
         label="What is the most effective way to increase concurrent serving capacity at 128K context?",
     )
-    return (a2_model_size, a2_precision, a2_context_len, a2_n_gpus, partB_reflection)
+    return (a2_context_len, a2_model_size, a2_n_gpus, a2_precision, partB_reflection)
 
 
 # ─── CELL 6b: Part C prediction + controls ─────────────────────────────────
@@ -294,7 +294,7 @@ def _(mo):
         },
         label="Why is continuous batching the standard for production LLM serving?",
     )
-    return (partC_prediction, c1_avg_len, c1_max_len, c1_batch_size, partC_reflection)
+    return (c1_avg_len, c1_batch_size, c1_max_len, partC_prediction, partC_reflection)
 
 
 # ─── CELL 6c: Part D prediction + controls ─────────────────────────────────
@@ -330,7 +330,7 @@ def _(mo):
         },
         label="What is the correct objective function for fleet design?",
     )
-    return (partD_prediction, d1_target_qps, d1_quant, d1_batching, d1_gpus_per_replica, partD_reflection)
+    return (d1_batching, d1_gpus_per_replica, d1_quant, d1_target_qps, partD_prediction, partD_reflection)
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -339,38 +339,14 @@ def _(mo):
 
 @app.cell(hide_code=True)
 def _(
-    COLORS,
-    H100_RAM_GB,
-    H100_COST_HR,
-    TRAINING_COST_2M,
-    a1_cost_query,
-    a1_optimization,
-    a1_qps,
-    a1_weeks,
-    a2_context_len,
-    a2_model_size,
-    a2_n_gpus,
-    a2_precision,
-    apply_plotly_theme,
-    go,
-    math,
-    mo,
-    np,
-    partA_prediction,
-    partA_reflection,
-    partB_prediction,
-    partB_reflection,
-    partC_prediction,
-    c1_avg_len,
-    c1_max_len,
-    c1_batch_size,
-    partC_reflection,
-    partD_prediction,
-    d1_target_qps,
-    d1_quant,
-    d1_batching,
-    d1_gpus_per_replica,
-    partD_reflection,
+    COLORS, H100_RAM_GB, H100_COST_HR, TRAINING_COST_2M,
+    apply_plotly_theme, go, math, mo,
+    np, a1_cost_query, a1_optimization, a1_qps,
+    a1_weeks, a2_context_len, a2_model_size, a2_n_gpus,
+    a2_precision, c1_avg_len, c1_batch_size, c1_max_len,
+    d1_batching, d1_gpus_per_replica, d1_quant, d1_target_qps,
+    partA_prediction, partA_reflection, partB_prediction, partB_reflection,
+    partC_prediction, partC_reflection, partD_prediction, partD_reflection,
 ):
 
     # ═════════════════════════════════════════════════════════════════════════

--- a/labs/vol2/lab_09_perf_engineering.py
+++ b/labs/vol2/lab_09_perf_engineering.py
@@ -438,7 +438,7 @@ def _(mo):
         value="FlashAttention (reduces HBM traffic)",
         label="Select optimization",
     )
-    return (pE_workload, pE_optim)
+    return (pE_optim, pE_workload)
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -447,19 +447,16 @@ def _(mo):
 
 @app.cell(hide_code=True)
 def _(
-    COLORS, apply_plotly_theme, go, math, mo, np,
-    H100_TFLOPS_FP16, H100_BW_GBS, H100_RAM_GB, H100_RIDGE,
-    V100_TFLOPS_FP16, V100_BW_GBS, V100_RIDGE,
-    A100_TFLOPS_FP16, A100_BW_GBS, A100_RIDGE,
-    B200_TFLOPS_FP16, B200_BW_GBS, B200_RIDGE,
-    HEAD_DIM, NUM_HEADS, BYTES_FP16, ELEM_FUSION_SAVE_MB,
-    PPL_FP16, PPL_INT8_NAIVE, PPL_INT8_OUTLIER,
-    PPL_INT4_NAIVE, PPL_INT4_OUTLIER,
-    pA_pred, pA_batch, pA_gpu, pA_op,
-    pB_pred, pB_seqlen,
-    pC_pred,
-    pD_pred, pD_precision,
-    pE_pred, pE_workload, pE_optim,
+    COLORS, apply_plotly_theme, go, math,
+    mo, np, H100_TFLOPS_FP16, H100_BW_GBS,
+    H100_RAM_GB, H100_RIDGE, V100_TFLOPS_FP16, V100_BW_GBS,
+    V100_RIDGE, A100_TFLOPS_FP16, A100_BW_GBS, A100_RIDGE,
+    B200_TFLOPS_FP16, B200_BW_GBS, B200_RIDGE, HEAD_DIM,
+    NUM_HEADS, BYTES_FP16, ELEM_FUSION_SAVE_MB, PPL_FP16,
+    PPL_INT8_NAIVE, PPL_INT8_OUTLIER, PPL_INT4_NAIVE, PPL_INT4_OUTLIER,
+    pA_batch, pA_gpu, pA_op, pA_pred,
+    pB_pred, pB_seqlen, pC_pred, pD_precision,
+    pD_pred, pE_optim, pE_pred, pE_workload,
 ):
     # ═════════════════════════════════════════════════════════════════════════
     # PART A: THE ROOFLINE DIAGNOSTIC

--- a/labs/vol2/lab_10_edge_intelligence.py
+++ b/labs/vol2/lab_10_edge_intelligence.py
@@ -299,7 +299,7 @@ def _(mo):
             "the adapter weights. What is the total LoRA storage?"
         ),
     )
-    return (pA_params, pA_batch, pA_strategy, pB_pred)
+    return (pA_batch, pA_params, pA_strategy, pB_pred)
 
 
 # ─── CELL 6: PART B CONTROLS + PART C WIDGETS ────────────────────────────────
@@ -367,7 +367,7 @@ def _(mo):
         value="No compression",
         label="Gradient compression",
     )
-    return (pD_beta, pD_epochs, pD_compress)
+    return (pD_beta, pD_compress, pD_epochs)
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -377,17 +377,15 @@ def _(mo):
 # ─── CELL 9: TABS CELL ──────────────────────────────────────────────────────
 @app.cell(hide_code=True)
 def _(
-    COLORS, apply_plotly_theme, go, math, mo, np, ledger,
-    ACTIVATION_RATIO, ADAM_MULTIPLIER, BYTES_FP16, BYTES_FP32,
-    BIAS_FRACTION, LORA_FRACTION,
-    MOBILE_RAM_AVAIL_MB, MOBILE_BATTERY_WH,
-    MOBILE_CPU_POWER_W, MOBILE_NPU_POWER_W,
-    NPU_SPEEDUP, NPU_ENERGY_GAIN,
-    IID_ROUNDS, FL_TARGET_ACC,
-    pA_pred, pA_params, pA_batch, pA_strategy,
-    pB_pred, pB_contexts,
-    pC_pred, pC_target,
-    pD_pred, pD_beta, pD_epochs, pD_compress,
+    COLORS, apply_plotly_theme, go, math,
+    mo, np, ledger, ACTIVATION_RATIO,
+    ADAM_MULTIPLIER, BYTES_FP16, BYTES_FP32, BIAS_FRACTION,
+    LORA_FRACTION, MOBILE_RAM_AVAIL_MB, MOBILE_BATTERY_WH, MOBILE_CPU_POWER_W,
+    MOBILE_NPU_POWER_W, NPU_SPEEDUP, NPU_ENERGY_GAIN, IID_ROUNDS,
+    FL_TARGET_ACC, pA_batch, pA_params, pA_pred,
+    pA_strategy, pB_contexts, pB_pred, pC_pred,
+    pC_target, pD_beta, pD_compress, pD_epochs,
+    pD_pred,
 ):
     # ─────────────────────────────────────────────────────────────────────
     # PART A BUILDER -- The Memory Amplification Tax

--- a/labs/vol2/lab_11_ops_scale.py
+++ b/labs/vol2/lab_11_ops_scale.py
@@ -264,7 +264,7 @@ def _(mo):
         options={"Platform OFF": "off", "Platform ON": "on"},
         value="Platform OFF", label="Shared ML Platform", inline=True,
     )
-    return (pA_pred, pA_models, pA_platform)
+    return (pA_models, pA_platform, pA_pred)
 
 
 # ─── CELL 5: Part B prediction + Part B controls ─────────────────────────────
@@ -281,7 +281,7 @@ def _(mo):
     pB_ctr_drop = mo.ui.slider(start=0.1, stop=2.0, value=0.5, step=0.1, label="CTR drop (%)")
     pB_rev = mo.ui.slider(start=0.10, stop=2.00, value=0.50, step=0.10, label="Revenue per click ($)")
     pB_detect = mo.ui.slider(start=1, stop=48, value=24, step=1, label="Detection time (hours)")
-    return (pB_pred, pB_qps, pB_ctr_drop, pB_rev, pB_detect)
+    return (pB_ctr_drop, pB_detect, pB_pred, pB_qps, pB_rev)
 
 
 # ─── CELL 6: Part C prediction + Part C controls ─────────────────────────────
@@ -304,7 +304,7 @@ def _(mo):
         options={"$1M/year": 1_000_000, "$2M/year": 2_000_000, "$5M/year": 5_000_000},
         value="$2M/year", label="Platform cost tier",
     )
-    return (pC_pred, pC_models, pC_platform_cost)
+    return (pC_models, pC_platform_cost, pC_pred)
 
 
 # ─── CELL 7: Part D prediction + Part D controls ─────────────────────────────
@@ -325,7 +325,7 @@ def _(mo):
     pD_req_rate = mo.ui.slider(start=100_000, stop=10_000_000, value=1_000_000, step=100_000,
                                label="Total request rate (req/hour)")
     pD_canary_pct = mo.ui.slider(start=1, stop=50, value=1, step=1, label="Canary percentage (%)")
-    return (pD_pred, pD_req_rate, pD_canary_pct)
+    return (pD_canary_pct, pD_pred, pD_req_rate)
 
 
 # ─── CELL 8: Part E controls + Synthesis decision log ────────────────────────
@@ -346,7 +346,7 @@ def _(DecisionLog, mo):
         placeholder="Based on what I learned in this lab, the most important insight about "
                     "fleet-scale ML operations is..."
     )
-    return (pE_models, pE_metrics, pE_sigma, pE_hier, synth_decision_input, synth_decision_ui)
+    return (pE_hier, pE_metrics, pE_models, pE_sigma)
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -356,16 +356,15 @@ def _(DecisionLog, mo):
 # ─── CELL 9: ALL PARTS + TABS ────────────────────────────────────────────────
 @app.cell(hide_code=True)
 def _(
-    COLORS, apply_plotly_theme, go, math, mo, np, ledger,
-    TEAM_CAPACITY_HOURS, ALERT_COST_PER_MODEL,
-    COORD_COST_LOG, DEP_COST_QUAD,
-    PER_MODEL_SAVINGS, REQUIRED_SAMPLES, HUMAN_CAPACITY,
-    pA_pred, pA_models, pA_platform,
-    pB_pred, pB_qps, pB_ctr_drop, pB_rev, pB_detect,
-    pC_pred, pC_models, pC_platform_cost,
-    pD_pred, pD_req_rate, pD_canary_pct,
-    pE_models, pE_metrics, pE_sigma, pE_hier,
-    synth_decision_input, synth_decision_ui,
+    COLORS, apply_plotly_theme, go, math,
+    mo, np, ledger, TEAM_CAPACITY_HOURS,
+    ALERT_COST_PER_MODEL, COORD_COST_LOG, DEP_COST_QUAD, PER_MODEL_SAVINGS,
+    REQUIRED_SAMPLES, HUMAN_CAPACITY, synth_decision_input, synth_decision_ui,
+    pA_models, pA_platform, pA_pred, pB_ctr_drop,
+    pB_detect, pB_pred, pB_qps, pB_rev,
+    pC_models, pC_platform_cost, pC_pred, pD_canary_pct,
+    pD_pred, pD_req_rate, pE_hier, pE_metrics,
+    pE_models, pE_sigma,
 ):
     # ─────────────────────────────────────────────────────────────────────
     # PART A BUILDER -- The Complexity Explosion

--- a/labs/vol2/lab_12_security_privacy.py
+++ b/labs/vol2/lab_12_security_privacy.py
@@ -290,7 +290,7 @@ def _(mo):
             "what accuracy does DP-SGD achieve?"
         ),
     )
-    return (pA_epsilon, pA_N, pB_pred)
+    return (pA_N, pA_epsilon, pB_pred)
 
 
 # ─── WIDGET CELL 3: Part C prediction ────────────────────────────────────────
@@ -329,7 +329,7 @@ def _(mo):
             "(Enter days, e.g., 0.1 for 2.4 hours.)"
         ),
     )
-    return (pC_mig, pC_monitor, pC_output, pC_rate, pC_dpsgd, pD_pred)
+    return (pC_dpsgd, pC_mig, pC_monitor, pC_output, pC_rate, pD_pred)
 
 
 # ─── WIDGET CELL 5: Part D controls ─────────────────────────────────────────
@@ -345,7 +345,7 @@ def _(mo):
         options={"Basic Composition": "basic", "Advanced Composition": "advanced"},
         value="Basic Composition", label="Composition theorem", inline=True,
     )
-    return (pD_queries, pD_eps_q, pD_budget, pD_comp)
+    return (pD_budget, pD_comp, pD_eps_q, pD_queries)
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -354,17 +354,15 @@ def _(mo):
 
 @app.cell(hide_code=True)
 def _(
-    mo, go, np, math, COLORS, apply_plotly_theme,
-    DEFAULT_SENSITIVITY, DEFAULT_DELTA,
-    MNIST_NO_DP, MNIST_EPS1, MNIST_EPS01,
-    CIFAR_NO_DP, CIFAR_EPS8, CIFAR_EPS1,
-    MIG_OVERHEAD, DPSGD_OVERHEAD, MONITORING_OVERHEAD_MS,
-    OUTPUT_PERTURB_MS, RATE_LIMIT_OVERHEAD,
-    BASELINE_THROUGHPUT, SLO_THROUGHPUT,
-    pA_pred, pA_epsilon, pA_N,
-    pB_pred,
-    pC_pred, pC_mig, pC_monitor, pC_output, pC_rate, pC_dpsgd,
-    pD_pred, pD_queries, pD_eps_q, pD_budget, pD_comp,
+    mo, go, np, math,
+    COLORS, apply_plotly_theme, DEFAULT_SENSITIVITY, DEFAULT_DELTA,
+    MNIST_NO_DP, MNIST_EPS1, MNIST_EPS01, CIFAR_NO_DP,
+    CIFAR_EPS8, CIFAR_EPS1, MIG_OVERHEAD, DPSGD_OVERHEAD,
+    MONITORING_OVERHEAD_MS, OUTPUT_PERTURB_MS, RATE_LIMIT_OVERHEAD, BASELINE_THROUGHPUT,
+    SLO_THROUGHPUT, pA_N, pA_epsilon, pA_pred,
+    pB_pred, pC_dpsgd, pC_mig, pC_monitor,
+    pC_output, pC_pred, pC_rate, pD_budget,
+    pD_comp, pD_eps_q, pD_pred, pD_queries,
 ):
 
     # ═════════════════════════════════════════════════════════════════════════

--- a/labs/vol2/lab_13_robust_ai.py
+++ b/labs/vol2/lab_13_robust_ai.py
@@ -277,7 +277,7 @@ def _(mo):
         },
         label="Which statement best describes the cost profiles of PGD vs randomized smoothing?",
     )
-    return (partA_pred, partA_eps_slider, partA_refl)
+    return (partA_eps_slider, partA_pred, partA_refl)
 
 
 # ─── CELL 5: PART B WIDGETS ──────────────────────────────────────────────────
@@ -297,7 +297,7 @@ def _(mo):
         start=100, stop=100_000, value=10_000, step=100,
         label="Cluster size (GPUs)",
     )
-    return (partB_pred, partB_cluster_slider)
+    return (partB_cluster_slider, partB_pred)
 
 
 # ─── CELL 6: PART C WIDGETS ──────────────────────────────────────────────────
@@ -322,7 +322,7 @@ def _(mo):
         start=100, stop=10_000, value=1000, step=100,
         label="Labeled samples per hour:",
     )
-    return (partC_pred, partC_drift_rate, partC_monitoring, partC_sample_rate)
+    return (partC_drift_rate, partC_monitoring, partC_pred, partC_sample_rate)
 
 
 # ─── CELL 7: PART D WIDGETS ──────────────────────────────────────────────────
@@ -345,7 +345,7 @@ def _(mo):
         options={"None": "none", "Hourly": "hourly", "Real-time": "realtime"},
         value="None", label="Monitoring frequency",
     )
-    return (partD_pred, partD_adv_train, partD_feat_squeeze, partD_conf_thresh, partD_monitoring)
+    return (partD_adv_train, partD_conf_thresh, partD_feat_squeeze, partD_monitoring, partD_pred)
 
 
 # ─── CELL 8: PART E WIDGETS ──────────────────────────────────────────────────
@@ -371,18 +371,16 @@ def _(mo):
 
 @app.cell(hide_code=True)
 def _(
-    mo, go, np, math, apply_plotly_theme, COLORS, ledger,
-    CLEAN_ACC_BASELINE, ADV_TRAINED_CLEAN_ACC, ADV_TRAINED_ROBUST_ACC,
-    ROBUST_TAX_PP, PGD_STEPS, PGD_COMPUTE_MULT, SMOOTHING_INFERENCE_MULT,
-    FEATURE_SQUEEZE_CLEAN, FEATURE_SQUEEZE_ROBUST,
-    SDC_RATE_PER_HOUR, ACC_AFTER_BITFLIP,
-    DRIFT_RATE_MODERATE, PSI_THRESHOLD,
-    FP32_ADV_ACC_EPS4, INT8_ADV_ACC_EPS4, INT8_CLEAN_DELTA,
-    partA_pred, partA_eps_slider, partA_refl,
-    partB_pred, partB_cluster_slider,
-    partC_pred, partC_drift_rate, partC_monitoring, partC_sample_rate,
-    partD_pred, partD_adv_train, partD_feat_squeeze, partD_conf_thresh, partD_monitoring,
-    partE_eps_slider, partE_precision,
+    mo, go, np, math,
+    apply_plotly_theme, COLORS, ledger, CLEAN_ACC_BASELINE,
+    ADV_TRAINED_CLEAN_ACC, ADV_TRAINED_ROBUST_ACC, ROBUST_TAX_PP, PGD_STEPS,
+    PGD_COMPUTE_MULT, SMOOTHING_INFERENCE_MULT, FEATURE_SQUEEZE_CLEAN, FEATURE_SQUEEZE_ROBUST,
+    SDC_RATE_PER_HOUR, ACC_AFTER_BITFLIP, DRIFT_RATE_MODERATE, PSI_THRESHOLD,
+    FP32_ADV_ACC_EPS4, INT8_ADV_ACC_EPS4, INT8_CLEAN_DELTA, partA_eps_slider,
+    partA_pred, partA_refl, partB_cluster_slider, partB_pred,
+    partC_drift_rate, partC_monitoring, partC_pred, partC_sample_rate,
+    partD_adv_train, partD_conf_thresh, partD_feat_squeeze, partD_monitoring,
+    partD_pred, partE_eps_slider, partE_precision,
 ):
     # ─────────────────────────────────────────────────────────────────────
     # PART A BUILDER -- The Robustness Tax

--- a/labs/vol2/lab_14_sustainable_ai.py
+++ b/labs/vol2/lab_14_sustainable_ai.py
@@ -264,7 +264,7 @@ def _(mo):
         label="AI compute demand doubles every ~3.4 months. Hardware efficiency doubles every ~24 months. Over 7 years (2012-2019), how large is the gap?",
     )
     partA_years_slider = mo.ui.slider(start=1, stop=10, value=7, step=1, label="Timeline (years)")
-    return (partA_pred, partA_years_slider,)
+    return (partA_pred, partA_years_slider)
 
 
 # ─── CELL 5: PART B WIDGETS ──────────────────────────────────────────────────
@@ -282,7 +282,7 @@ def _(mo):
     )
     partB_energy_slider = mo.ui.slider(start=1000, stop=100000, value=10000, step=1000, label="Training energy (MWh)")
     partB_pue_slider = mo.ui.slider(start=1.0, stop=2.0, value=1.12, step=0.02, label="PUE")
-    return (partB_pred, partB_energy_slider, partB_pue_slider,)
+    return (partB_energy_slider, partB_pred, partB_pue_slider)
 
 
 # ─── CELL 6: PART C WIDGETS ──────────────────────────────────────────────────
@@ -301,7 +301,7 @@ def _(mo):
     partC_refresh_slider = mo.ui.slider(start=2, stop=5, value=3, step=1, label="Hardware refresh cycle (years)")
     partC_util_slider = mo.ui.slider(start=30, stop=90, value=60, step=5, label="GPU utilization (%)")
     partC_gpu_count = mo.ui.slider(start=100, stop=10000, value=1000, step=100, label="GPU count")
-    return (partC_pred, partC_refresh_slider, partC_util_slider, partC_gpu_count,)
+    return (partC_gpu_count, partC_pred, partC_refresh_slider, partC_util_slider)
 
 
 # ─── CELL 7: PART D WIDGETS ──────────────────────────────────────────────────
@@ -316,7 +316,7 @@ def _(mo):
     partD_elast_slider = mo.ui.slider(start=0.1, stop=3.0, value=2.0, step=0.1, label="Demand elasticity")
     partD_cap_toggle = mo.ui.switch(label="Carbon cap enabled", value=False)
     partD_cap_level = mo.ui.slider(start=0.5, stop=2.0, value=1.0, step=0.1, label="Cap level (fraction of baseline)")
-    return (partD_pred, partD_eff_slider, partD_elast_slider, partD_cap_toggle, partD_cap_level,)
+    return (partD_cap_level, partD_cap_toggle, partD_eff_slider, partD_elast_slider, partD_pred)
 
 
 # ─── CELL 8: PART E WIDGETS ──────────────────────────────────────────────────
@@ -331,7 +331,7 @@ def _(mo):
     partE_temporal = mo.ui.slider(start=0, stop=60, value=0, step=5, label="Temporal shift (% of jobs to off-peak)")
     partE_eff_gain = mo.ui.slider(start=1.0, stop=4.0, value=1.0, step=0.5, label="Efficiency improvement (x)")
     partE_cap = mo.ui.slider(start=0.3, stop=1.5, value=1.0, step=0.1, label="Carbon cap (fraction of baseline)")
-    return (partE_geo, partE_temporal, partE_eff_gain, partE_cap,)
+    return (partE_cap, partE_eff_gain, partE_geo, partE_temporal)
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -343,18 +343,17 @@ def _(mo):
 
 @app.cell(hide_code=True)
 def _(
-    mo, go, np, math, COLORS, apply_plotly_theme,
-    CI_QUEBEC, CI_ICELAND, CI_FRANCE, CI_US_AVG, CI_TEXAS,
-    CI_GERMANY, CI_CHINA_AVG, CI_POLAND, CI_INDIA,
-    PUE_LIQUID, PUE_AIR, PUE_LEGACY,
-    H100_EMBODIED_KG, H100_TDP_W,
-    DEMAND_DOUBLING_MONTHS, EFFICIENCY_DOUBLING_MONTHS,
-    JEVONS_ELASTICITY_INELASTIC, JEVONS_ELASTICITY_UNIT, JEVONS_ELASTICITY_ELASTIC,
-    partA_pred, partA_years_slider,
-    partB_pred, partB_energy_slider, partB_pue_slider,
-    partC_pred, partC_refresh_slider, partC_util_slider, partC_gpu_count,
-    partD_pred, partD_eff_slider, partD_elast_slider, partD_cap_toggle, partD_cap_level,
-    partE_geo, partE_temporal, partE_eff_gain, partE_cap,
+    mo, go, np, math,
+    COLORS, apply_plotly_theme, CI_QUEBEC, CI_ICELAND,
+    CI_FRANCE, CI_US_AVG, CI_TEXAS, CI_GERMANY,
+    CI_CHINA_AVG, CI_POLAND, CI_INDIA, PUE_LIQUID,
+    PUE_AIR, PUE_LEGACY, H100_EMBODIED_KG, H100_TDP_W,
+    DEMAND_DOUBLING_MONTHS, EFFICIENCY_DOUBLING_MONTHS, JEVONS_ELASTICITY_INELASTIC, JEVONS_ELASTICITY_UNIT,
+    JEVONS_ELASTICITY_ELASTIC, partA_pred, partA_years_slider, partB_energy_slider,
+    partB_pred, partB_pue_slider, partC_gpu_count, partC_pred,
+    partC_refresh_slider, partC_util_slider, partD_cap_level, partD_cap_toggle,
+    partD_eff_slider, partD_elast_slider, partD_pred, partE_cap,
+    partE_eff_gain, partE_geo, partE_temporal,
 ):
 
     # ─────────────────────────────────────────────────────────────────────

--- a/labs/vol2/lab_15_responsible_ai.py
+++ b/labs/vol2/lab_15_responsible_ai.py
@@ -243,7 +243,7 @@ def _(mo):
     partA_threshold_slider = mo.ui.slider(start=0.05, stop=0.95, value=0.5, step=0.05, label="Classification threshold")
     partA_base_rate_a = mo.ui.slider(start=0.1, stop=0.9, value=0.6, step=0.05, label="Group A base rate")
     partA_base_rate_b = mo.ui.slider(start=0.1, stop=0.9, value=0.3, step=0.05, label="Group B base rate")
-    return (partA_pred, partA_threshold_slider, partA_base_rate_a, partA_base_rate_b)
+    return (partA_base_rate_a, partA_base_rate_b, partA_pred, partA_threshold_slider)
 
 
 # ─── CELL 5: Part B prediction + controls ─────────────────────────────────────
@@ -254,7 +254,7 @@ def _(mo):
         label="Baseline accuracy 85%. Groups: 60% vs 30% base rate. After enforcing Demographic Parity, accuracy = ?%",
     )
     partB_gap_slider = mo.ui.slider(start=0.0, stop=0.5, value=0.3, step=0.05, label="Base rate gap (|rate_A - rate_B|)")
-    return (partB_pred, partB_gap_slider)
+    return (partB_gap_slider, partB_pred)
 
 
 # ─── CELL 6: Part C prediction + controls ─────────────────────────────────────
@@ -273,7 +273,7 @@ def _(mo):
     partC_fairness_constraint = mo.ui.switch(label="Fairness Constraint", value=False)
     partC_output_monitor = mo.ui.switch(label="Output Monitoring", value=False)
     partC_feedback_gov = mo.ui.switch(label="Feedback Governance", value=False)
-    return (partC_pred, partC_data_audit, partC_fairness_constraint, partC_output_monitor, partC_feedback_gov)
+    return (partC_data_audit, partC_fairness_constraint, partC_feedback_gov, partC_output_monitor, partC_pred)
 
 
 # ─── CELL 7: Part D prediction + controls ─────────────────────────────────────
@@ -300,7 +300,7 @@ def _(mo):
         options={"None (0ms)": "none", "LIME (25ms)": "lime", "SHAP (50ms)": "shap"},
         value="None (0ms)", label="Explainability:",
     )
-    return (partD_pred, partD_metric, partD_monitor, partD_explain)
+    return (partD_explain, partD_metric, partD_monitor, partD_pred)
 
 
 # ─── CELL 8: Part E controls ──────────────────────────────────────────────────
@@ -316,7 +316,7 @@ def _(mo):
     )
     partE_threshold = mo.ui.slider(start=0.01, stop=0.10, value=0.05, step=0.01, label="Disparity trigger threshold")
     partE_ab_days = mo.ui.slider(start=1, stop=7, value=3, step=1, label="A/B test duration (days)")
-    return (partE_sample, partE_test, partE_threshold, partE_ab_days)
+    return (partE_ab_days, partE_sample, partE_test, partE_threshold)
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -327,17 +327,16 @@ def _(mo):
 # ─── CELL 9: TABS CELL ───────────────────────────────────────────────────────
 @app.cell(hide_code=True)
 def _(
-    mo, go, np, math, apply_plotly_theme, COLORS, ledger,
-    BASELINE_ACCURACY, DP_TAX_PER_GAP, EO_TAX_PER_GAP, EQOP_TAX_PER_GAP,
-    INITIAL_BIAS, AMPLIFICATION_RATE,
-    INFERENCE_LATENCY_MS, MONITORING_BASIC_MS, MONITORING_FULL_MS,
+    mo, go, np, math,
+    apply_plotly_theme, COLORS, ledger, BASELINE_ACCURACY,
+    DP_TAX_PER_GAP, EO_TAX_PER_GAP, EQOP_TAX_PER_GAP, INITIAL_BIAS,
+    AMPLIFICATION_RATE, INFERENCE_LATENCY_MS, MONITORING_BASIC_MS, MONITORING_FULL_MS,
     LIME_OVERHEAD_MS, SHAP_OVERHEAD_MS, NETWORK_OVERHEAD_MS, SLA_MS,
-    AUDIT_COMPUTE_BASE,
-    partA_pred, partA_threshold_slider, partA_base_rate_a, partA_base_rate_b,
-    partB_pred, partB_gap_slider,
-    partC_pred, partC_data_audit, partC_fairness_constraint, partC_output_monitor, partC_feedback_gov,
-    partD_pred, partD_metric, partD_monitor, partD_explain,
-    partE_sample, partE_test, partE_threshold, partE_ab_days,
+    AUDIT_COMPUTE_BASE, partA_base_rate_a, partA_base_rate_b, partA_pred,
+    partA_threshold_slider, partB_gap_slider, partB_pred, partC_data_audit,
+    partC_fairness_constraint, partC_feedback_gov, partC_output_monitor, partC_pred,
+    partD_explain, partD_metric, partD_monitor, partD_pred,
+    partE_ab_days, partE_sample, partE_test, partE_threshold,
 ):
     # ─────────────────────────────────────────────────────────────────────
     # PART A BUILDER -- The Impossibility Wall

--- a/labs/vol2/lab_16_fleet_synthesis.py
+++ b/labs/vol2/lab_16_fleet_synthesis.py
@@ -269,7 +269,7 @@ def _(mo):
         options={"8 GPUs": 8, "64 GPUs": 64, "1,000 GPUs": 1000, "10,000 GPUs": 10000},
         value="1,000 GPUs", label="Fleet size:", inline=True,
     )
-    return (partA_pred, partA_fleet_toggle,)
+    return (partA_fleet_toggle, partA_pred)
 
 
 # ─── CELL 5: Part B prediction + Part B sliders ──────────────────────────
@@ -282,7 +282,7 @@ def _(mo):
     partB_fleet_slider = mo.ui.slider(start=10, stop=100000, value=10000, step=100, label="Fleet size (GPUs)")
     partB_mtbf_slider = mo.ui.slider(start=1000, stop=100000, value=10000, step=1000, label="Per-GPU MTBF (hours)")
     partB_ckpt_slider = mo.ui.slider(start=1, stop=30, value=10, step=1, label="Checkpoint interval (minutes)")
-    return (partB_pred, partB_fleet_slider, partB_mtbf_slider, partB_ckpt_slider,)
+    return (partB_ckpt_slider, partB_fleet_slider, partB_mtbf_slider, partB_pred)
 
 
 # ─── CELL 6: Part C prediction + Part C sliders ──────────────────────────
@@ -303,7 +303,7 @@ def _(mo):
     partC_sched = mo.ui.slider(start=30, stop=100, value=70, step=5, label="Scheduling (%)")
     partC_sustain = mo.ui.slider(start=30, stop=100, value=70, step=5, label="Sustainability (%)")
     partC_fair = mo.ui.slider(start=30, stop=100, value=70, step=5, label="Fairness (%)")
-    return (partC_pred, partC_compute, partC_comm, partC_fault, partC_sched, partC_sustain, partC_fair,)
+    return (partC_comm, partC_compute, partC_fair, partC_fault, partC_pred, partC_sched, partC_sustain)
 
 
 # ─── CELL 7: Part D prediction + Part D controls ─────────────────────────
@@ -327,7 +327,7 @@ def _(mo):
         options={"Static": "static", "Elastic": "elastic"},
         value="Static", label="Scheduling mode:",
     )
-    return (partD_refl, partD_gpus, partD_comm_strategy, partD_ckpt_freq, partD_scheduling,)
+    return (partD_ckpt_freq, partD_comm_strategy, partD_gpus, partD_refl, partD_scheduling)
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -337,17 +337,16 @@ def _(mo):
 
 @app.cell(hide_code=True)
 def _(
-    mo, go, np, math, apply_plotly_theme, COLORS,
-    CARBON_CAP, CARBON_STRATEGY, FAIRNESS_METRIC,
-    FAIRNESS_OVERHEAD_MS, FAIRNESS_THRESHOLD,
-    H100_TFLOPS_FP16, H100_RAM_GB, H100_TDP_W,
-    NVLINK_BW_GBS, IB_BW_GBPS, MTBF_GPU_HOURS, CHECKPOINT_COST_S,
-    ALLREDUCE_RING_EFF, GRADIENT_COMPRESS,
-    partA_pred, partA_fleet_toggle,
-    partB_pred, partB_fleet_slider, partB_mtbf_slider, partB_ckpt_slider,
-    partC_pred, partC_compute, partC_comm, partC_fault, partC_sched, partC_sustain, partC_fair,
-    partD_refl, partD_gpus, partD_comm_strategy, partD_ckpt_freq, partD_scheduling,
-    ledger,
+    mo, go, np, math,
+    apply_plotly_theme, COLORS, CARBON_CAP, CARBON_STRATEGY,
+    FAIRNESS_METRIC, FAIRNESS_OVERHEAD_MS, FAIRNESS_THRESHOLD, H100_TFLOPS_FP16,
+    H100_RAM_GB, H100_TDP_W, NVLINK_BW_GBS, IB_BW_GBPS,
+    MTBF_GPU_HOURS, CHECKPOINT_COST_S, ALLREDUCE_RING_EFF, GRADIENT_COMPRESS,
+    ledger, partA_fleet_toggle, partA_pred, partB_ckpt_slider,
+    partB_fleet_slider, partB_mtbf_slider, partB_pred, partC_comm,
+    partC_compute, partC_fair, partC_fault, partC_pred,
+    partC_sched, partC_sustain, partD_ckpt_freq, partD_comm_strategy,
+    partD_gpus, partD_refl, partD_scheduling,
 ):
     # ─────────────────────────────────────────────────────────────────────
     # PART A BUILDER -- The Sensitivity Wall


### PR DESCRIPTION
## what

sweeps the whole labs tree to fix a marimo dataflow bug class that left widgets invisible to the tabs cell in 17 of 33 labs. reported by @asgalon in #1332 for lab_02 + lab_03 (fixed in #1385); this pr does the rest and locks the regression out via a new static test.

## the bug

marimo routes widget state strictly through each cell's return tuple. every `@app.cell` that defined helper widgets (sliders, dropdowns) alongside the terminal `partX_prediction` returned only the prediction. the helpers were defined but never reached the tabs cell — they were effectively dead allocations. sliders never rendered after the prediction unlocked; chart inputs never re-ran on change. every static and engine test still passed because the cells executed fine in isolation.

the audit script (`/tmp/audit_widget_returns.py`) found:

| scope | before | after |
|-|-|-|
| labs scanned | 33 | 33 |
| offending labs | 17 | 0 |
| unreturned widgets | 175 | 0 |

(the 42 "hits" that remain in the updated audit are all widgets defined inside the tabs cell itself, consumed by its own `build_part_*` closures via scope — they don't need to flow outward. the new static test excludes those.)

## changes

1. **codemod over all 33 labs.** every widget cell's `return (...)` tuple now lists every `mo.ui.*` it defines, alphabetical. every tabs-cell signature is rewritten to declare every widget it references. no logic, labels, or UI copy touched.
2. **`TestWidgetReturnCompleteness` in `labs/tests/test_static.py`.** fails on any new cell defining a widget without returning it (render sinks like `tabs`/`_tabs` and tabs-cell-local widgets excluded). 33 / 33 labs pass; a regression is blocked at CI time.

## test plan

- [x] `labs/tests/test_static.py` + `tests/test_engine.py`: 825 passed 4 skipped 1 xfailed (up from 792 — 33 new test runs)
- [x] `marimo check` spot-sampled on several labs: exit 0
- [x] audit script: 17 → 0 offending labs on the meaningful check
- [ ] CI green on this pr

closes the main thread of #1332. @asgalon's "updated example values" suggestion for Lab 02 and the tabs-cell widget extraction cleanup left as follow-ups.