### PR TITLE
fix(labs): lab_02 Part A scenario alignment + extract tabs-cell widgets (#1332)

### DIFF
--- a/labs/vol1/lab_02_ml_systems.py
+++ b/labs/vol1/lab_02_ml_systems.py
@@ -175,7 +175,7 @@ def _(COLORS, ledger, mo):
             </div>
             <div style="font-size: 0.9rem; color: {COLORS['TextSec']}; line-height: 1.7;">
                 <div style="margin-bottom: 3px;">1. <strong>Diagnose the Memory Wall</strong> &mdash;
-                    show that a 6x GPU upgrade (A100 to H100) yields only ~8% latency improvement
+                    show that a 3x GPU upgrade (A100 to H100) yields only ~1.6x latency improvement
                     for a memory-bound workload (AI = 5 FLOPs/Byte).</div>
                 <div style="margin-bottom: 3px;">2. <strong>Calculate the Light Barrier</strong> &mdash;
                     compute the propagation delay floor for a given datacenter distance and determine
@@ -258,14 +258,18 @@ def _(mo):
 # marimo's dataflow can route them to the tabs cell. #1332.
 @app.cell(hide_code=True)
 def _(mo):
+    # Options aligned to actual Hardware registry specs (A100 312 TFLOPS /
+    # 2039 GB/s, H100 989 TFLOPS / 3350 GB/s): compute ratio is 3.17x, BW
+    # ratio is 1.64x. For an AI=5 workload both GPUs are deeply memory-bound
+    # so the speedup collapses to the BW ratio. Option C is correct (#1332).
     partA_prediction = mo.ui.radio(
         options={
-            "A) ~6x (proportional to compute increase)":  "6x",
-            "B) ~3x (half the compute gain)":              "3x",
-            "C) ~1.5x (modest improvement)":               "1.5x",
-            "D) <1.1x (almost no improvement)":            "1.1x",
+            "A) ~3x (proportional to compute increase)":     "3x",
+            "B) ~2x (partial benefit from compute bump)":    "2x",
+            "C) ~1.6x (approximately the BW ratio)":         "1.6x",
+            "D) <1.1x (no improvement at all)":              "1.1x",
         },
-        label=r"Upgrading from A100 (\$15K) to H100 (\$30K) -- a 6x compute increase. "
+        label=r"Upgrading from A100 (\$15K) to H100 (\$30K) -- a 3x compute increase. "
               "For a workload with AI = 5 FLOPs/Byte, what latency improvement?",
     )
     return (partA_prediction,)
@@ -418,7 +422,7 @@ def _(
             </div>
             <div style="font-style:italic; font-size:1.0rem; color:#1e293b; line-height:1.65;">
                 &ldquo;We are considering upgrading our inference fleet from A100s ($15K each)
-                to H100s ($30K each). The H100 has 6x the compute throughput. Engineering
+                to H100s ($30K each). The H100 has 3x the compute throughput. Engineering
                 says we should see proportional latency reduction. Finance wants your analysis
                 before approving $2M in hardware spend.&rdquo;
             </div>
@@ -507,8 +511,8 @@ def _(
             name="A100 to H100 Speedup",
             line=dict(color=COLORS["BlueLine"], width=2.5),
         ))
-        _fig.add_hline(y=6, line_dash="dash", line_color=COLORS["GreenLine"], line_width=1,
-                       annotation_text="Ideal 6x", annotation_position="top right",
+        _fig.add_hline(y=3, line_dash="dash", line_color=COLORS["GreenLine"], line_width=1,
+                       annotation_text="Ideal 3x (compute ratio)", annotation_position="top right",
                        annotation_font_color=COLORS["GreenLine"])
         _fig.add_hline(y=1, line_dash="dot", line_color=COLORS["TextMuted"], line_width=1)
         _fig.add_vline(x=_ridge_a100, line_dash="dash", line_color=COLORS["OrangeLine"], line_width=1.5,
@@ -576,19 +580,20 @@ Speedup = {_speedup:.2f}x   Improvement = {_improvement_pct:.1f}%
 ```
 
 At AI=5: BW ratio is {H100_BW/A100_BW:.2f}x ({H100_BW:,.0f} vs {A100_BW:,.0f} GB/s).
-The 6x compute upgrade is almost entirely wasted.
+The 3x compute upgrade collapses to just the BW ratio.
 """))
 
         _pred = partA_prediction.value
-        if _pred == "1.1x":
-            _rev = ("**Correct.** At AI=5, both GPUs are deeply memory-bound. "
-                    f"The speedup is only {_speedup_at_5:.2f}x because bandwidth, not compute, "
-                    "is the binding constraint.")
+        if _pred == "1.6x":
+            _rev = ("**Correct.** At AI=5, both GPUs are deeply memory-bound, so "
+                    f"the speedup collapses to the bandwidth ratio ({_speedup_at_5:.2f}x). "
+                    "Compute throughput is irrelevant in this regime.")
             _rkind = "success"
         else:
             _rev = (f"**The actual speedup at AI=5 is only ~{_speedup_at_5:.2f}x.** "
-                    "The workload is memory-bound. Slide AI above the ridge point "
-                    "to see where the 6x upgrade actually pays off.")
+                    "The workload is memory-bound, so the speedup tracks the BW "
+                    "ratio (1.64x), not the compute ratio. Slide AI above the "
+                    "ridge point to see where the 3x upgrade actually pays off.")
             _rkind = "warn"
 
         items.append(mo.callout(mo.md(_rev), kind=_rkind))
@@ -1112,8 +1117,9 @@ The energy ratio is often **~1,000x**, making local inference the only viable op
                 <div style="font-size: 0.92rem; color: {COLORS['Text']}; line-height: 1.75;">
                     <div style="margin-bottom: 10px;">
                         <strong>1. The Memory Wall makes compute upgrades worthless for
-                        memory-bound workloads.</strong> At AI=5, a 6x GPU upgrade yields
-                        only ~8% improvement.
+                        memory-bound workloads.</strong> At AI=5, a 3x GPU compute upgrade
+                        (A100 to H100) only delivers the 1.64x BW ratio speedup -- roughly
+                        half the hardware gain, because bandwidth is the binding constraint.
                     </div>
                     <div style="margin-bottom: 10px;">
                         <strong>2. The speed of light is irreducible.</strong>
@@ -1189,7 +1195,7 @@ def _(COLORS, ledger, mo, partA_prediction, partB_prediction, partC_prediction, 
             "light_barrier_prediction": partB_prediction.value,
             "power_wall_prediction": partC_prediction.value,
             "energy_wall_prediction": partD_prediction.value,
-            "memory_wall_correct": partA_prediction.value == "1.1x",
+            "memory_wall_correct": partA_prediction.value == "1.6x",
             "light_barrier_correct": partB_prediction.value == "no_physics",
             "power_wall_correct": partC_prediction.value == "15fps",
             "energy_wall_correct": partD_prediction.value == "1000x",

--- a/labs/vol1/lab_04_data_engr.py
+++ b/labs/vol1/lab_04_data_engr.py
@@ -282,12 +282,9 @@ def _(mo):
     )
     return (partC_error_rate, partC_stages, partD_prediction)
 
+# ─── widget cell: extracted from tabs cell body (#1332 polish) ────
 @app.cell(hide_code=True)
-def _(
-    mo, partA_prediction, partA_storage, partA_workers,
-    partB_bandwidth, partB_dataset, partB_prediction, partC_error_rate,
-    partC_prediction, partC_stages, partD_prediction,
-):
+def _(mo):
     partD_tolerance = mo.ui.slider(
         start=1, stop=50, value=1, step=1,
         label="False wake-ups per month (tolerance)",
@@ -296,6 +293,16 @@ def _(
         start=1, stop=24, value=24, step=1,
         label="Duty cycle (hours per day)",
     )
+    return (partD_duty, partD_tolerance)
+
+
+@app.cell(hide_code=True)
+def _(
+    mo, partA_prediction, partA_storage, partA_workers,
+    partB_bandwidth, partB_dataset, partB_prediction, partC_error_rate,
+    partC_prediction, partC_stages, partD_prediction, partD_duty,
+    partD_tolerance,
+):
 
     # ═════════════════════════════════════════════════════════════════════
     # PART A -- The Feeding Tax

--- a/labs/vol1/lab_05_nn_compute.py
+++ b/labs/vol1/lab_05_nn_compute.py
@@ -322,13 +322,9 @@ def _(mo):
     )
     return (partC_width, partD_prediction)
 
+# ─── widget cell: extracted from tabs cell body (#1332 polish) ────
 @app.cell(hide_code=True)
-def _(
-    mo, partA_act_l1, partA_act_l2, partA_act_l3,
-    partA_act_l4, partA_context, partA_prediction, partB_batch,
-    partB_context, partB_prediction, partB_width, partC_prediction,
-    partC_width, partD_prediction,
-):
+def _(mo):
     partD_depth = mo.ui.slider(
         start=3, stop=50, value=20, step=1, label="Network depth (layers)",
     )
@@ -344,6 +340,17 @@ def _(
     partD_width_d = mo.ui.slider(
         start=64, stop=2048, value=512, step=64, label="Layer width",
     )
+    return (partD_batch, partD_depth, partD_phase, partD_width_d)
+
+
+@app.cell(hide_code=True)
+def _(
+    mo, partA_act_l1, partA_act_l2, partA_act_l3,
+    partA_act_l4, partA_context, partA_prediction, partB_batch,
+    partB_context, partB_prediction, partB_width, partC_prediction,
+    partC_width, partD_prediction, partD_batch, partD_depth,
+    partD_phase, partD_width_d,
+):
 
     # ─────────────────────────────────────────────────────────────────────
     # PART A BUILDER: The Transistor Tax

--- a/labs/vol1/lab_06_nn_arch.py
+++ b/labs/vol1/lab_06_nn_arch.py
@@ -296,15 +296,21 @@ def _(mo):
     )
     return (partC_context_c, partC_depth, partD_prediction)
 
+# ─── widget cell: extracted from tabs cell body (#1332 polish) ────
+@app.cell(hide_code=True)
+def _(mo):
+    partD_batch_d = mo.ui.slider(
+        start=1, stop=256, value=1, step=1, label="Batch size",
+    )
+    return (partD_batch_d,)
+
+
 @app.cell(hide_code=True)
 def _(
     mo, partA_arch, partA_prediction, partA_resolution,
     partB_heads, partB_prediction, partB_seq_len, partC_context_c,
-    partC_depth, partC_prediction, partD_prediction,
+    partC_depth, partC_prediction, partD_prediction, partD_batch_d,
 ):
-    partD_batch_d = mo.ui.slider(
-        start=1, stop=256, value=1, step=1, label="Batch size",
-    )
 
     # ─────────────────────────────────────────────────────────────────────
     # PART A BUILDER: The Cost of No Structure

--- a/labs/vol1/lab_07_ml_frameworks.py
+++ b/labs/vol1/lab_07_ml_frameworks.py
@@ -306,12 +306,9 @@ def _(mo):
     )
     return (partC_compile_time, partC_volume, partD_prediction)
 
+# ─── widget cell: extracted from tabs cell body (#1332 polish) ────
 @app.cell(hide_code=True)
-def _(
-    mo, partA_compute_us, partA_kernels, partA_prediction,
-    partB_num_ops, partB_prediction, partB_tensor_mb, partC_compile_time,
-    partC_prediction, partC_volume, partD_prediction,
-):
+def _(mo):
     partD_framework = mo.ui.dropdown(
         options={"PyTorch": "PyTorch", "TensorFlow": "TensorFlow",
                  "ONNX Runtime": "ONNX Runtime", "TF Lite": "TF Lite",
@@ -322,6 +319,16 @@ def _(
         options={"Cloud (H100)": "cloud", "Edge (Jetson 16GB)": "edge", "MCU (ESP32 512KB)": "mcu"},
         value="MCU (ESP32 512KB)", label="Deployment target:", inline=True,
     )
+    return (partD_framework, partD_target)
+
+
+@app.cell(hide_code=True)
+def _(
+    mo, partA_compute_us, partA_kernels, partA_prediction,
+    partB_num_ops, partB_prediction, partB_tensor_mb, partC_compile_time,
+    partC_prediction, partC_volume, partD_prediction, partD_framework,
+    partD_target,
+):
 
     # ─────────────────────────────────────────────────────────────────────
     # PART A BUILDER: The Dispatch Tax

--- a/labs/vol1/lab_08_model_train.py
+++ b/labs/vol1/lab_08_model_train.py
@@ -310,19 +310,25 @@ def _(mo):
     )
     return (partC_model_c, partC_precision_c, partD_prediction)
 
+# ─── widget cell: extracted from tabs cell body (#1332 polish) ────
 @app.cell(hide_code=True)
-def _(
-    mo, partA_model_size, partA_optimizer, partA_precision_a,
-    partA_prediction, partB_compute_ms, partB_data_ms, partB_pcie_ms,
-    partB_prediction, partB_sync_ms, partC_model_c, partC_precision_c,
-    partC_prediction, partD_prediction,
-):
+def _(mo):
     partD_gpus = mo.ui.slider(
         start=1, stop=256, value=8, step=1, label="Number of GPUs",
     )
     partD_r = mo.ui.slider(
         start=0.01, stop=0.50, value=0.15, step=0.01, label="Communication fraction (r)",
     )
+    return (partD_gpus, partD_r)
+
+
+@app.cell(hide_code=True)
+def _(
+    mo, partA_model_size, partA_optimizer, partA_precision_a,
+    partA_prediction, partB_compute_ms, partB_data_ms, partB_pcie_ms,
+    partB_prediction, partB_sync_ms, partC_model_c, partC_precision_c,
+    partC_prediction, partD_prediction, partD_gpus, partD_r,
+):
 
     # ─────────────────────────────────────────────────────────────────────
     # PART A BUILDER: The Memory Budget Shock

--- a/labs/vol1/lab_09_data_selection.py
+++ b/labs/vol1/lab_09_data_selection.py
@@ -322,17 +322,23 @@ def _(mo):
     )
     return (partC_augment, partC_model, partC_workers, partD_pred)
 
+# ─── widget cell: extracted from tabs cell body (#1332 polish) ────
+@app.cell(hide_code=True)
+def _(mo):
+    partD_params_b = mo.ui.slider(
+        start=0.5, stop=50, value=10, step=0.5,
+        label="Model size (B parameters)",
+    )
+    return (partD_params_b,)
+
+
 @app.cell(hide_code=True)
 def _(
     mo, partA_frac, partA_pred, partA_redundancy,
     partB_coreset, partB_hw, partB_pred, partB_scorer,
     partC_augment, partC_model, partC_pred, partC_workers,
-    partD_pred,
+    partD_pred, partD_params_b,
 ):
-    partD_params_b = mo.ui.slider(
-        start=0.5, stop=50, value=10, step=0.5,
-        label="Model size (B parameters)",
-    )
 
     # ─────────────────────────────────────────────────────────────────────
     # PART A: ICR Frontier

--- a/labs/vol1/lab_10_model_compress.py
+++ b/labs/vol1/lab_10_model_compress.py
@@ -317,13 +317,20 @@ def _(mo):
     )
     return (pD_hw, pD_precision_e, pE_pred)
 
+# ─── widget cell: extracted from tabs cell body (#1332 polish) ────
+@app.cell(hide_code=True)
+def _(mo):
+    pE_temp = mo.ui.slider(start=1.0, stop=20.0, value=4.0, step=0.5, label="Temperature")
+    return (pE_temp,)
+
+
 @app.cell(hide_code=True)
 def _(
     mo, pA_model_sel, pA_precision, pA_pred,
     pB_pred, pB_sparsity, pB_type, pC_pred,
     pD_hw, pD_precision_e, pD_pred, pE_pred,
+    pE_temp,
 ):
-    pE_temp = mo.ui.slider(start=1.0, stop=20.0, value=4.0, step=0.5, label="Temperature")
 
     # ─────────────────────────────────────────────────────────────────────
     # PART A: Quantization Free Lunch

--- a/labs/vol1/lab_11_hw_accel.py
+++ b/labs/vol1/lab_11_hw_accel.py
@@ -295,14 +295,21 @@ def _(mo):
     )
     return (pE_pred,)
 
+# ─── widget cell: extracted from tabs cell body (#1332 polish) ────
+@app.cell(hide_code=True)
+def _(mo):
+    pE_tile = mo.ui.slider(start=32, stop=2048, value=256, step=32, label="Tile size (elements)")
+    pE_seq = mo.ui.slider(start=512, stop=16384, value=4096, step=512, label="Sequence length")
+    return (pE_seq, pE_tile)
+
+
 @app.cell(hide_code=True)
 def _(
     mo, pA_dim, pA_prec, pA_pred,
     pB_batch, pB_mode, pB_pred, pC_hw,
-    pC_pred, pD_pred, pE_pred,
+    pC_pred, pD_pred, pE_pred, pE_seq,
+    pE_tile,
 ):
-    pE_tile = mo.ui.slider(start=32, stop=2048, value=256, step=32, label="Tile size (elements)")
-    pE_seq = mo.ui.slider(start=512, stop=16384, value=4096, step=512, label="Sequence length")
 
     # ── Helper: draw roofline ─────────────────────────────────────────────
     def _draw_roofline(fig, peak_tflops, bw_gbs, ridge, color, name):

--- a/labs/vol1/lab_12_perf_bench.py
+++ b/labs/vol1/lab_12_perf_bench.py
@@ -281,14 +281,21 @@ def _(mo):
     )
     return (pC_batch, pC_precision, pD_pred)
 
+# ─── widget cell: extracted from tabs cell body (#1332 polish) ────
+@app.cell(hide_code=True)
+def _(mo):
+    pD_sigma = mo.ui.slider(start=0.1, stop=1.5, value=0.8, step=0.05, label="Tail heaviness (sigma)")
+    pD_slo = mo.ui.slider(start=50, stop=500, value=200, step=10, label="SLO threshold (ms)")
+    return (pD_sigma, pD_slo)
+
+
 @app.cell(hide_code=True)
 def _(
     mo, pA_pred, pA_serial, pA_speedup,
     pB_ambient, pB_cooling, pB_pred, pB_time,
     pC_batch, pC_precision, pC_pred, pD_pred,
+    pD_sigma, pD_slo,
 ):
-    pD_sigma = mo.ui.slider(start=0.1, stop=1.5, value=0.8, step=0.05, label="Tail heaviness (sigma)")
-    pD_slo = mo.ui.slider(start=50, stop=500, value=200, step=10, label="SLO threshold (ms)")
 
     # ─────────────────────────────────────────────────────────────────────
     # PART A: The Amdahl Ceiling

--- a/labs/vol1/lab_13_model_serving.py
+++ b/labs/vol1/lab_13_model_serving.py
@@ -275,13 +275,9 @@ def _(mo):
     )
     return (partC_ctx, partC_gpus, partC_model, partC_prec, partD_pred)
 
+# ─── widget cell: extracted from tabs cell body (#1332 polish) ────
 @app.cell(hide_code=True)
-def _(
-    mo, partA_pred, partA_rho, partA_slo,
-    partA_svc, partB_arr, partB_batch, partB_pred,
-    partB_slo, partC_ctx, partC_gpus, partC_model,
-    partC_prec, partC_pred, partD_pred,
-):
+def _(mo):
     partD_model = mo.ui.dropdown(options={"7B": 7, "13B": 13, "70B": 70}, value="70B",
                                   label="Model size")
     partD_stor = mo.ui.dropdown(
@@ -289,6 +285,17 @@ def _(
         value="NVMe SSD", label="Storage type")
     partD_pcie = mo.ui.dropdown(options={"PCIe Gen4": "gen4", "PCIe Gen5": "gen5"},
                                  value="PCIe Gen5", label="Interconnect")
+    return (partD_model, partD_pcie, partD_stor)
+
+
+@app.cell(hide_code=True)
+def _(
+    mo, partA_pred, partA_rho, partA_slo,
+    partA_svc, partB_arr, partB_batch, partB_pred,
+    partB_slo, partC_ctx, partC_gpus, partC_model,
+    partC_prec, partC_pred, partD_pred, partD_model,
+    partD_pcie, partD_stor,
+):
 
     # ═════════════════════════════════════════════════════════════════════════
     # PART A — The Tail Latency Explosion

--- a/labs/vol1/lab_14_ml_ops.py
+++ b/labs/vol1/lab_14_ml_ops.py
@@ -244,18 +244,25 @@ def _(mo):
     )
     return (partC_cloud_cost, partC_drift_cost, partC_edge_cost, partD_pred)
 
+# ─── widget cell: extracted from tabs cell body (#1332 polish) ────
 @app.cell(hide_code=True)
-def _(
-    mo, partA_drift_rate, partA_pred, partA_weeks,
-    partB_drift_cost, partB_pred, partB_retrain_cost, partC_cloud_cost,
-    partC_drift_cost, partC_edge_cost, partC_pred, partD_pred,
-):
+def _(mo):
     partD_missed = mo.ui.slider(start=1, stop=6, value=3, step=1,
                                  label="Missed retraining cycles")
     partD_downstream = mo.ui.slider(start=0, stop=5, value=2, step=1,
                                      label="Dependent downstream models")
     partD_base_loss = mo.ui.slider(start=1.0, stop=5.0, value=2.0, step=0.5,
                                     label="Accuracy loss per missed cycle (pp)")
+    return (partD_base_loss, partD_downstream, partD_missed)
+
+
+@app.cell(hide_code=True)
+def _(
+    mo, partA_drift_rate, partA_pred, partA_weeks,
+    partB_drift_cost, partB_pred, partB_retrain_cost, partC_cloud_cost,
+    partC_drift_cost, partC_edge_cost, partC_pred, partD_pred,
+    partD_base_loss, partD_downstream, partD_missed,
+):
 
     # ═════════════════════════════════════════════════════════════════════════
     # PART A — PSI Drift Detection

--- a/labs/vol1/lab_15_responsible_engr.py
+++ b/labs/vol1/lab_15_responsible_engr.py
@@ -247,12 +247,9 @@ def _(mo):
     )
     return (partC_features, partC_method, partD_pred)
 
+# ─── widget cell: extracted from tabs cell body (#1332 polish) ────
 @app.cell(hide_code=True)
-def _(
-    mo, partA_base_a, partA_base_b, partA_pred,
-    partA_threshold, partB_method, partB_pred, partB_target_gap,
-    partC_features, partC_method, partC_pred, partD_pred,
-):
+def _(mo):
     partD_retrain_freq = mo.ui.dropdown(
         options={"Weekly": 52, "Monthly": 12, "Quarterly": 4, "Once": 1},
         value="Weekly", label="Retraining frequency")
@@ -262,6 +259,16 @@ def _(
         options={"Clean (hydro, 20 gCO2/kWh)": 20, "Mixed (400 gCO2/kWh)": 400,
                  "Coal-heavy (800 gCO2/kWh)": 800},
         value="Mixed (400 gCO2/kWh)", label="Grid carbon intensity")
+    return (partD_explain_pct, partD_grid_mix, partD_retrain_freq)
+
+
+@app.cell(hide_code=True)
+def _(
+    mo, partA_base_a, partA_base_b, partA_pred,
+    partA_threshold, partB_method, partB_pred, partB_target_gap,
+    partC_features, partC_method, partC_pred, partD_pred,
+    partD_explain_pct, partD_grid_mix, partD_retrain_freq,
+):
 
     # ═════════════════════════════════════════════════════════════════════════
     # PART A — The Fairness Illusion

--- a/labs/vol1/lab_16_ml_conclusion.py
+++ b/labs/vol1/lab_16_ml_conclusion.py
@@ -289,14 +289,9 @@ def _(mo):
     )
     return (partD_inference, partD_logging, partD_optimize, partD_postprocess, partD_preprocess, partD_speedup, partE_pred)
 
+# ─── widget cell: extracted from tabs cell body (#1332 polish) ────
 @app.cell(hide_code=True)
-def _(
-    mo, partA_batch, partA_model, partA_prec,
-    partA_pred, partB_monitoring, partB_months, partB_pred,
-    partB_quant, partC_pred, partD_inference, partD_logging,
-    partD_optimize, partD_postprocess, partD_pred, partD_preprocess,
-    partD_speedup, partE_pred,
-):
+def _(mo):
     partE_int4 = mo.ui.checkbox(label="INT4 Quantization", value=False)
     partE_pruning = mo.ui.checkbox(label="Structured Pruning (50%)", value=False)
     partE_distill = mo.ui.checkbox(label="Knowledge Distillation", value=False)
@@ -304,6 +299,18 @@ def _(
     partE_shap = mo.ui.checkbox(label="SHAP Explanations", value=False)
     partE_ctx = mo.ui.slider(start=2048, stop=131072, value=32768, step=2048,
                               label="Context length (tokens)")
+    return (partE_ctx, partE_distill, partE_int4, partE_pruning, partE_retrain, partE_shap)
+
+
+@app.cell(hide_code=True)
+def _(
+    mo, partA_batch, partA_model, partA_prec,
+    partA_pred, partB_monitoring, partB_months, partB_pred,
+    partB_quant, partC_pred, partD_inference, partD_logging,
+    partD_optimize, partD_postprocess, partD_pred, partD_preprocess,
+    partD_speedup, partE_pred, partE_ctx, partE_distill,
+    partE_int4, partE_pruning, partE_retrain, partE_shap,
+):
 
     # ═════════════════════════════════════════════════════════════════════════
     # PART A — The Cost of a Token

--- a/labs/vol2/lab_02_compute_infra.py
+++ b/labs/vol2/lab_02_compute_infra.py
@@ -335,16 +335,22 @@ def _(mo):
     )
     return (pD_gpus, pD_model_b, pD_zero, pE_pred)
 
+# ─── widget cell: extracted from tabs cell body (#1332 polish) ────
+@app.cell(hide_code=True)
+def _(mo):
+    pE_n_gpus = mo.ui.slider(start=100, stop=5000, value=1000, step=100, label="GPU count")
+    pE_util = mo.ui.slider(start=30, stop=90, value=70, step=5, label="Utilization (%)")
+    pE_pue = mo.ui.slider(start=1.06, stop=1.60, value=1.12, step=0.02, label="PUE")
+    return (pE_n_gpus, pE_pue, pE_util)
+
+
 @app.cell(hide_code=True)
 def _(
     mo, pA_batch, pA_model, pA_pred,
     pB_hw, pB_pred, pC_pred, pC_size,
     pD_gpus, pD_model_b, pD_pred, pD_zero,
-    pE_pred,
+    pE_pred, pE_n_gpus, pE_pue, pE_util,
 ):
-    pE_n_gpus = mo.ui.slider(start=100, stop=5000, value=1000, step=100, label="GPU count")
-    pE_util = mo.ui.slider(start=30, stop=90, value=70, step=5, label="Utilization (%)")
-    pE_pue = mo.ui.slider(start=1.06, stop=1.60, value=1.12, step=0.02, label="PUE")
 
     # ═════════════════════════════════════════════════════════════════════════
     # PART A: THE MEMORY WALL

--- a/labs/vol2/lab_03_communication.py
+++ b/labs/vol2/lab_03_communication.py
@@ -318,17 +318,24 @@ def _(mo):
     )
     return (pD_bw, pD_comp, pE_pred)
 
+# ─── widget cell: extracted from tabs cell body (#1332 polish) ────
+@app.cell(hide_code=True)
+def _(mo):
+    pE_hier = mo.ui.checkbox(label="Hierarchical AllReduce")
+    pE_fp16 = mo.ui.checkbox(label="FP16 gradients")
+    pE_bucket = mo.ui.checkbox(label="Bucket fusion")
+    pE_overlap = mo.ui.checkbox(label="Backward overlap")
+    return (pE_bucket, pE_fp16, pE_hier, pE_overlap)
+
+
 @app.cell(hide_code=True)
 def _(
     mo, pA_gpus, pA_model, pA_prec,
     pA_pred, pB_msg_exp, pB_n_gpus, pB_pred,
     pC_gpus_per_node, pC_oversub, pC_pred, pC_topo,
     pD_bw, pD_comp, pD_pred, pE_pred,
+    pE_bucket, pE_fp16, pE_hier, pE_overlap,
 ):
-    pE_hier = mo.ui.checkbox(label="Hierarchical AllReduce")
-    pE_fp16 = mo.ui.checkbox(label="FP16 gradients")
-    pE_bucket = mo.ui.checkbox(label="Bucket fusion")
-    pE_overlap = mo.ui.checkbox(label="Backward overlap")
 
     # ═════════════════════════════════════════════════════════════════════════
     # PART A: THE NETWORK TIME BUDGET

--- a/labs/vol2/lab_04_data_storage.py
+++ b/labs/vol2/lab_04_data_storage.py
@@ -295,16 +295,23 @@ def _(mo):
     )
     return (pD_compute, pD_io, pD_prefetch, pE_pred)
 
+# ─── widget cell: extracted from tabs cell body (#1332 polish) ────
+@app.cell(hide_code=True)
+def _(mo):
+    pE_mtbf = mo.ui.slider(start=1, stop=24, value=5, step=1, label="Cluster MTBF (hours)")
+    pE_write = mo.ui.slider(start=30, stop=300, value=120, step=10, label="Checkpoint write time (s)")
+    pE_interval = mo.ui.slider(start=1, stop=120, value=30, step=1, label="Checkpoint interval (min)")
+    return (pE_interval, pE_mtbf, pE_write)
+
+
 @app.cell(hide_code=True)
 def _(
     mo, pA_gen, pA_pred, pB_gpus,
     pB_pred, pB_target, pC_pred, pC_shards,
     pC_workers, pD_compute, pD_io, pD_pred,
-    pD_prefetch, pE_pred,
+    pD_prefetch, pE_pred, pE_interval, pE_mtbf,
+    pE_write,
 ):
-    pE_mtbf = mo.ui.slider(start=1, stop=24, value=5, step=1, label="Cluster MTBF (hours)")
-    pE_write = mo.ui.slider(start=30, stop=300, value=120, step=10, label="Checkpoint write time (s)")
-    pE_interval = mo.ui.slider(start=1, stop=120, value=30, step=1, label="Checkpoint interval (min)")
 
     # ═════════════════════════════════════════════════════════════════════════
     # PART A: THE STORAGE-COMPUTE CHASM


### PR DESCRIPTION
## what

two follow-ups to the #1332 sweep, now closing out everything concrete in Peter's report.

### 1. lab_02 Part A options now match the hardware registry

the scenario claimed "6x compute increase" and marked option D (<1.1x speedup) correct. actual `mlsysim.Hardware`:

|  | A100 | H100 | ratio |
|-|-|-|-|
| compute (TFLOPS) | 312 | 989 | **3.17x** |
| memory BW (GB/s) | 2039 | 3350 | **1.64x** |

at AI=5 both GPUs are deeply memory-bound so the speedup collapses to the BW ratio (1.64x, not <1.1x). peter observed exactly this in #1332: ''Latency improvement value / speedup calculations are a bit mismatched. Selecting 1.1x above leads to a correct 1.64 result below.''

aligned to reality:
- scenario: ''6x compute increase'' -> ''3x compute increase''
- option A: ''~6x'' -> ''~3x (proportional to compute increase)''
- option C: ''~1.5x (modest improvement)'' -> ''~1.6x (approximately the BW ratio)'' [**CORRECT**]
- option D: kept as ''<1.1x'' for the ''compute is totally wasted'' distractor
- feedback callout, ledger `memory_wall_correct` check, key-takeaway text, roofline ''ideal Nx'' annotation all updated
- pedagogy preserved: ''compute upgrade is wasted for memory-bound workloads'', now with numbers that actually compute

### 2. extracted 42 widgets from tabs cells into their own widget cells

every `mo.ui.*` still defined inside a tabs cell body got moved into a new `@app.cell` immediately before it, with the widget name added to the tabs cell signature. 16 labs, 42 widgets. this is what @asgalon asked for in lab_02 (''move partD_data_size and partD_wireless one cell up'') extended to every lab that had the same shape.

done via a mechanical codemod (lived at /tmp/extract_tabs_widgets.py, not committed - single-shot utility).

## audit results

| stage | offending labs | unreturned widgets |
|-|-|-|
| before #1386 | 17 | 175 |
| after #1386 | 0 real (16 'tabs-cell internal') | 42 |
| this PR | 0 | 0 |

## test plan

- [x] `labs/tests/test_static.py` + `test_engine.py`: 825 passed 4 skipped 1 xfailed
- [x] `marimo check` on lab_05, lab_10, lab_16, vol2/lab_03: exit 0
- [x] audit script: 0 offending labs
- [ ] CI green on this pr

addresses remaining #1332 items. the browser smoke from #1374 will continue to guard against regressions.