### PR TITLE
test(tinytorch): PyTorch-compat test coverage for Tensor API additions

### DIFF
--- a/tinytorch/src/01_tensor/01_tensor.py
+++ b/tinytorch/src/01_tensor/01_tensor.py
@@ -291,6 +291,8 @@ class Tensor:
         HINT: Use np.array(data, dtype=np.float32) to convert data to NumPy array
         """
         ### BEGIN SOLUTION
+        if isinstance(data, (list, tuple)) and len(data) > 0 and isinstance(data[0], Tensor):
+            data = np.stack([t.data for t in data])
         self.data = np.array(data, dtype=np.float32)
         self.shape = self.data.shape
         self.size = self.data.size
@@ -331,7 +333,28 @@ class Tensor:
 
     def contiguous(self):
         """Return a contiguous copy of the tensor data (PyTorch-compatible)."""
-        return Tensor(self.data.copy())
+        return Tensor(np.ascontiguousarray(self.data))
+
+    def view(self, *shape):
+        """Alias for reshape, matching PyTorch's Tensor.view() for contiguous tensors."""
+        return self.reshape(*shape)
+
+    def masked_fill(self, mask, value):
+        """Fill positions where mask is True with value, matching PyTorch's masked_fill.
+
+        Used in transformer attention to set padding positions to -inf before softmax.
+
+        Args:
+            mask:  A Tensor or numpy array of booleans, same shape as self (or broadcastable).
+            value: Scalar fill value (e.g. float('-inf') for attention masking).
+
+        Returns:
+            New Tensor with masked positions replaced by value.
+        """
+        mask_array = mask.data.astype(bool) if isinstance(mask, Tensor) else np.asarray(mask, dtype=bool)
+        result = self.data.copy()
+        result[mask_array] = value
+        return Tensor(result)
 
     def __add__(self, other):
         """Add two tensors element-wise with broadcasting support.

--- a/tinytorch/tests/01_tensor/test_tensor_core.py
+++ b/tinytorch/tests/01_tensor/test_tensor_core.py
@@ -469,5 +469,90 @@ class TestTensorBroadcasting:
         )
 
 
+class TestTensorPyTorchCompat:
+    """
+    Tests for PyTorch-compatible API additions (issue #1298).
+
+    WHY THESE MATTER: Students transitioning from PyTorch hit AttributeError
+    when calling .ndim, .numel(), .view(), .contiguous(), or .masked_fill()
+    on TinyTorch tensors. These additions make the two APIs interchangeable
+    for the patterns that appear in transformer training pipelines.
+    """
+
+    def test_ndim(self):
+        """ndim matches len(shape) for tensors of every rank."""
+        assert Tensor(5.0).ndim == 0
+        assert Tensor([1, 2, 3]).ndim == 1
+        assert Tensor([[1, 2], [3, 4]]).ndim == 2
+        assert Tensor([[[1]]]).ndim == 3
+
+    def test_numel(self):
+        """numel() returns total element count, same as .size."""
+        t = Tensor([[1, 2, 3], [4, 5, 6]])
+        assert t.numel() == 6
+        assert t.numel() == t.size
+
+    def test_view_same_as_reshape(self):
+        """view() is a reshape alias and produces the correct shape and data."""
+        t = Tensor([1, 2, 3, 4, 5, 6])
+        v = t.view(2, 3)
+        assert v.shape == (2, 3)
+        assert np.array_equal(v.data, t.reshape(2, 3).data)
+
+    def test_view_with_minus_one(self):
+        """view() passes -1 inference through to reshape."""
+        t = Tensor([1, 2, 3, 4, 5, 6])
+        v = t.view(3, -1)
+        assert v.shape == (3, 2)
+
+    def test_contiguous_returns_correct_data(self):
+        """contiguous() returns a new Tensor with identical values."""
+        t = Tensor([[1, 2, 3], [4, 5, 6]])
+        c = t.contiguous()
+        assert c.shape == t.shape
+        assert np.array_equal(c.data, t.data)
+
+    def test_contiguous_is_c_contiguous(self):
+        """contiguous() guarantees C-order memory layout."""
+        t = Tensor([[1, 2, 3], [4, 5, 6]])
+        transposed = t.transpose()
+        c = transposed.contiguous()
+        assert c.data.flags["C_CONTIGUOUS"]
+
+    def test_masked_fill_basic(self):
+        """masked_fill replaces True positions with the fill value."""
+        t = Tensor([[1.0, 2.0, 3.0]])
+        mask = Tensor([[0.0, 1.0, 0.0]])
+        result = t.masked_fill(mask, -1.0)
+        expected = np.array([[1.0, -1.0, 3.0]], dtype=np.float32)
+        assert np.array_equal(result.data, expected)
+
+    def test_masked_fill_attention_pattern(self):
+        """masked_fill with -inf matches the attention mask pattern in transformers."""
+        scores = Tensor([[1.0, 2.0, 3.0, 4.0]])
+        pad_mask = Tensor([[0.0, 0.0, 1.0, 1.0]])
+        masked = scores.masked_fill(pad_mask, float("-inf"))
+        assert np.isfinite(masked.data[0, 0])
+        assert np.isfinite(masked.data[0, 1])
+        assert masked.data[0, 2] == float("-inf")
+        assert masked.data[0, 3] == float("-inf")
+
+    def test_masked_fill_does_not_mutate_original(self):
+        """masked_fill returns a new tensor without modifying the original."""
+        t = Tensor([[1.0, 2.0, 3.0]])
+        mask = Tensor([[1.0, 0.0, 1.0]])
+        _ = t.masked_fill(mask, 0.0)
+        assert np.array_equal(t.data, np.array([[1.0, 2.0, 3.0]], dtype=np.float32))
+
+    def test_tensor_from_tensor_list(self):
+        """Tensor([t1, t2]) stacks tensors along a new leading dimension."""
+        t1 = Tensor([1.0, 2.0, 3.0])
+        t2 = Tensor([4.0, 5.0, 6.0])
+        stacked = Tensor([t1, t2])
+        assert stacked.shape == (2, 3)
+        assert np.array_equal(stacked.data[0], t1.data)
+        assert np.array_equal(stacked.data[1], t2.data)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Adds `TestTensorPyTorchCompat`, 10 focused tests covering the PyTorch-compatible Tensor methods that landed in #1391 and the subsequent merge window (view, masked_fill, Tensor stacking).

Also syncs `src/01_tensor/01_tensor.py` with the exported package: `view()`, `masked_fill()`, and Tensor stacking were present in `core/tensor.py` but missing from the source file, causing CI failures.

Closes #1298.

**Why these tests matter:** students porting PyTorch training loops to TinyTorch will call these methods constantly. Without explicit coverage, a refactor could silently break the behavioral contracts. The -inf attention-mask pattern in `masked_fill` is especially tricky: it produces no exception, just wrong softmax output.

Each test targets one specific contract:

| Test | What it pins |
|---|---|
| `test_ndim` | ndim matches len(shape) for rank 0-3 |
| `test_numel` | numel() == .size |
| `test_view_same_as_reshape` | view() is a reshape alias |
| `test_view_with_minus_one` | -1 inference passes through |
| `test_contiguous_returns_correct_data` | values preserved |
| `test_contiguous_is_c_contiguous` | C-order layout guaranteed |
| `test_masked_fill_basic` | True positions replaced |
| `test_masked_fill_attention_pattern` | -inf pattern for transformers |
| `test_masked_fill_does_not_mutate_original` | no in-place side effects |
| `test_tensor_from_tensor_list` | Tensor([t1, t2]) stacking |

## Test plan

- [x] `pytest tinytorch/tests/01_tensor/test_tensor_core.py::TestTensorPyTorchCompat -v` all 10 pass
- [x] Full test file runs clean with no regressions in existing test classes