### PR TITLE
fix(epub): stop sidenote filter from injecting LaTeX into EPUB output

### DIFF
--- a/book/quarto/filters/sidenote.lua
+++ b/book/quarto/filters/sidenote.lua
@@ -1,6 +1,10 @@
 function Note (note)
-  -- Only process for latex, pdf, or epub formats
-  if quarto.doc.is_format("latex") or quarto.doc.is_format("pdf") or quarto.doc.is_format("epub") then
+  -- Only convert footnotes to sidenotes for PDF/LaTeX output.
+  -- ePub is HTML-based: pandoc.RawInline('latex', ...) nodes are ignored by
+  -- the EPUB renderer, so the surrounding \sidenote{} delimiters are stripped
+  -- while the note body is emitted inline — causing the sidenote text to
+  -- appear embedded in the running prose (see issue #1333).
+  if quarto.doc.is_format("latex") or quarto.doc.is_format("pdf") then
     -- For PDF/LaTeX, convert footnote to sidenote for margin placement
     -- Requires sidenotes package (loaded in header-includes.tex)
     -- Fallback to \footnote is defined in header-includes.tex if package fails
@@ -22,6 +26,6 @@ function Note (note)
     table.insert(sidenote_content, pandoc.RawInline('latex', '}'))
     return sidenote_content
   end
-  -- For other formats, return the content unchanged
+  -- For ePub and all other formats, let Pandoc render footnotes normally.
   return nil
 end


### PR DESCRIPTION
Fixes #1333

## Problem

The `sidenote.lua` filter matched on `epub` alongside `latex`/`pdf`:

```lua
if quarto.doc.is_format("latex") or quarto.doc.is_format("pdf") or quarto.doc.is_format("epub") then
```

Because ePub uses HTML internally, the `pandoc.RawInline('latex', ...)` nodes that wrap `\sidenote{…}` are silently dropped by the EPUB renderer. The footnote body (between the delimiters) is emitted inline, causing sidenote/footnote text to appear embedded in the running prose rather than as proper footnotes.

Example from the issue report: `"1 milliwatt**The 1 mW Threshold**"` — where `The 1 mW Threshold` is sidenote content that leaked into the main paragraph.

## Solution

Remove `epub` from the format guard. For EPUB output, `return nil` lets Pandoc's default footnote renderer take over, placing footnote content correctly at the end of the chapter.

```lua
-- Before
if quarto.doc.is_format("latex") or quarto.doc.is_format("pdf") or quarto.doc.is_format("epub") then

-- After
if quarto.doc.is_format("latex") or quarto.doc.is_format("pdf") then
```

## Testing

The fix can be verified by building the EPUB output and checking that footnotes no longer appear inline in the body text. The PDF/LaTeX sidenote behavior is unchanged.