### PR TITLE
fix(tinytorch): fix dark mode visibility across all cards on modules page

### DIFF
--- a/tinytorch/site/_static/custom.css
+++ b/tinytorch/site/_static/custom.css
@@ -2159,3 +2159,16 @@ html[data-theme="dark"] .modules-progress-box p,
 html[data-theme="dark"] .modules-progress-box li {
     color: #e2e8f0 !important;
 }
+
+/* Modules page - "Reset Module" card */
+html[data-theme="dark"] .modules-reset-box {
+    filter: none !important;
+    background: #2a0a0a !important;
+    border-left-color: #f87171 !important;
+}
+html[data-theme="dark"] .modules-reset-box,
+html[data-theme="dark"] .modules-reset-box strong,
+html[data-theme="dark"] .modules-reset-box p,
+html[data-theme="dark"] .modules-reset-box li {
+    color: #e2e8f0 !important;
+}

--- a/tinytorch/site/_static/custom.css
+++ b/tinytorch/site/_static/custom.css
@@ -2045,3 +2045,15 @@ html[data-theme="dark"] .overview-session-box p,
 html[data-theme="dark"] .overview-session-box li {
     color: #e2e8f0 !important;
 }
+
+/* Modules page - "Typical Development Session" box */
+html[data-theme="dark"] .modules-session-box {
+    background: #1e293b !important;
+    border-color: #334155 !important;
+}
+html[data-theme="dark"] .modules-session-box,
+html[data-theme="dark"] .modules-session-box strong,
+html[data-theme="dark"] .modules-session-box p,
+html[data-theme="dark"] .modules-session-box li {
+    color: #e2e8f0 !important;
+}

--- a/tinytorch/site/_static/custom.css
+++ b/tinytorch/site/_static/custom.css
@@ -2133,3 +2133,16 @@ html[data-theme="dark"] .modules-complete-box p,
 html[data-theme="dark"] .modules-complete-box li {
     color: #e2e8f0 !important;
 }
+
+/* Modules page - "Test a Module" card */
+html[data-theme="dark"] .modules-test-box {
+    filter: none !important;
+    background: #0d2137 !important;
+    border-left-color: #64b5f6 !important;
+}
+html[data-theme="dark"] .modules-test-box,
+html[data-theme="dark"] .modules-test-box strong,
+html[data-theme="dark"] .modules-test-box p,
+html[data-theme="dark"] .modules-test-box li {
+    color: #e2e8f0 !important;
+}

--- a/tinytorch/site/_static/custom.css
+++ b/tinytorch/site/_static/custom.css
@@ -2095,3 +2095,16 @@ html[data-theme="dark"] .modules-start-box p,
 html[data-theme="dark"] .modules-start-box li {
     color: #e2e8f0 !important;
 }
+
+/* Modules page - "Resume Work" card */
+html[data-theme="dark"] .modules-resume-box {
+    filter: none !important;
+    background: #1a0e2e !important;
+    border-left-color: #ce93d8 !important;
+}
+html[data-theme="dark"] .modules-resume-box,
+html[data-theme="dark"] .modules-resume-box strong,
+html[data-theme="dark"] .modules-resume-box p,
+html[data-theme="dark"] .modules-resume-box li {
+    color: #e2e8f0 !important;
+}

--- a/tinytorch/site/_static/custom.css
+++ b/tinytorch/site/_static/custom.css
@@ -2146,3 +2146,16 @@ html[data-theme="dark"] .modules-test-box p,
 html[data-theme="dark"] .modules-test-box li {
     color: #e2e8f0 !important;
 }
+
+/* Modules page - "View Progress" card */
+html[data-theme="dark"] .modules-progress-box {
+    filter: none !important;
+    background: #1c1500 !important;
+    border-left-color: #fbbf24 !important;
+}
+html[data-theme="dark"] .modules-progress-box,
+html[data-theme="dark"] .modules-progress-box strong,
+html[data-theme="dark"] .modules-progress-box p,
+html[data-theme="dark"] .modules-progress-box li {
+    color: #e2e8f0 !important;
+}

--- a/tinytorch/site/_static/custom.css
+++ b/tinytorch/site/_static/custom.css
@@ -2172,3 +2172,15 @@ html[data-theme="dark"] .modules-reset-box p,
 html[data-theme="dark"] .modules-reset-box li {
     color: #e2e8f0 !important;
 }
+
+/* Modules page - "Understanding the Export Process" box */
+html[data-theme="dark"] .modules-export-box {
+    background: #1e293b !important;
+    border-color: #334155 !important;
+}
+html[data-theme="dark"] .modules-export-box,
+html[data-theme="dark"] .modules-export-box strong,
+html[data-theme="dark"] .modules-export-box p,
+html[data-theme="dark"] .modules-export-box li {
+    color: #e2e8f0 !important;
+}

--- a/tinytorch/site/_static/custom.css
+++ b/tinytorch/site/_static/custom.css
@@ -2120,3 +2120,16 @@ html[data-theme="dark"] .modules-view-box strong,
 html[data-theme="dark"] .modules-view-box p {
     color: #e2e8f0 !important;
 }
+
+/* Modules page - "Complete & Export" card */
+html[data-theme="dark"] .modules-complete-box {
+    filter: none !important;
+    background: #0a1f0a !important;
+    border-left-color: #4ade80 !important;
+}
+html[data-theme="dark"] .modules-complete-box,
+html[data-theme="dark"] .modules-complete-box strong,
+html[data-theme="dark"] .modules-complete-box p,
+html[data-theme="dark"] .modules-complete-box li {
+    color: #e2e8f0 !important;
+}

--- a/tinytorch/site/_static/custom.css
+++ b/tinytorch/site/_static/custom.css
@@ -2070,3 +2070,15 @@ html[data-theme="dark"] .modules-health-box p,
 html[data-theme="dark"] .modules-health-box li {
     color: #e2e8f0 !important;
 }
+
+/* Modules page - "List Available Modules" card */
+html[data-theme="dark"] .modules-lifecycle-box {
+    filter: none !important;
+    background: #1a1a2e !important;
+    border-left-color: #7986cb !important;
+}
+html[data-theme="dark"] .modules-lifecycle-box,
+html[data-theme="dark"] .modules-lifecycle-box strong,
+html[data-theme="dark"] .modules-lifecycle-box p {
+    color: #e2e8f0 !important;
+}

--- a/tinytorch/site/_static/custom.css
+++ b/tinytorch/site/_static/custom.css
@@ -2082,3 +2082,16 @@ html[data-theme="dark"] .modules-lifecycle-box strong,
 html[data-theme="dark"] .modules-lifecycle-box p {
     color: #e2e8f0 !important;
 }
+
+/* Modules page - "Start a Module" card */
+html[data-theme="dark"] .modules-start-box {
+    filter: none !important;
+    background: #1c1500 !important;
+    border-left-color: #fbbf24 !important;
+}
+html[data-theme="dark"] .modules-start-box,
+html[data-theme="dark"] .modules-start-box strong,
+html[data-theme="dark"] .modules-start-box p,
+html[data-theme="dark"] .modules-start-box li {
+    color: #e2e8f0 !important;
+}

--- a/tinytorch/site/_static/custom.css
+++ b/tinytorch/site/_static/custom.css
@@ -2057,3 +2057,16 @@ html[data-theme="dark"] .modules-session-box p,
 html[data-theme="dark"] .modules-session-box li {
     color: #e2e8f0 !important;
 }
+
+/* Modules page - "Environment Health" card */
+html[data-theme="dark"] .modules-health-box {
+    filter: none !important;
+    background: #0d2137 !important;
+    border-left-color: #64b5f6 !important;
+}
+html[data-theme="dark"] .modules-health-box,
+html[data-theme="dark"] .modules-health-box strong,
+html[data-theme="dark"] .modules-health-box p,
+html[data-theme="dark"] .modules-health-box li {
+    color: #e2e8f0 !important;
+}

--- a/tinytorch/site/_static/custom.css
+++ b/tinytorch/site/_static/custom.css
@@ -2108,3 +2108,15 @@ html[data-theme="dark"] .modules-resume-box p,
 html[data-theme="dark"] .modules-resume-box li {
     color: #e2e8f0 !important;
 }
+
+/* Modules page - "View a Module" card */
+html[data-theme="dark"] .modules-view-box {
+    filter: none !important;
+    background: #1a1a2e !important;
+    border-left-color: #7986cb !important;
+}
+html[data-theme="dark"] .modules-view-box,
+html[data-theme="dark"] .modules-view-box strong,
+html[data-theme="dark"] .modules-view-box p {
+    color: #e2e8f0 !important;
+}

--- a/tinytorch/site/_static/custom.css
+++ b/tinytorch/site/_static/custom.css
@@ -2184,3 +2184,15 @@ html[data-theme="dark"] .modules-export-box p,
 html[data-theme="dark"] .modules-export-box li {
     color: #e2e8f0 !important;
 }
+
+/* Modules page - "Environment Not Ready" troubleshooting card */
+html[data-theme="dark"] .modules-trouble-box {
+    background: #2a0a0a !important;
+    border-color: #7f1d1d !important;
+}
+html[data-theme="dark"] .modules-trouble-box,
+html[data-theme="dark"] .modules-trouble-box strong,
+html[data-theme="dark"] .modules-trouble-box p,
+html[data-theme="dark"] .modules-trouble-box li {
+    color: #e2e8f0 !important;
+}

--- a/tinytorch/site/tito/modules.md
+++ b/tinytorch/site/tito/modules.md
@@ -219,7 +219,7 @@ Jupyter Lab opens with the generated notebook for Module 05
 
 ### Resume Work (Continue Later)
 
-<div style="background: #f3e5f5; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #9c27b0; margin: 1.5rem 0;">
+<div class="modules-resume-box" style="background: #f3e5f5; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #9c27b0; margin: 1.5rem 0;">
 
 ```bash
 tito module resume 01

--- a/tinytorch/site/tito/modules.md
+++ b/tinytorch/site/tito/modules.md
@@ -439,7 +439,7 @@ tinytorch/
 
 ### Environment Not Ready
 
-<div style="background: #fff5f5; padding: 1.5rem; border: 1px solid #fed7d7; border-radius: 0.5rem; margin: 1rem 0;">
+<div class="modules-trouble-box" style="background: #fff5f5; padding: 1.5rem; border: 1px solid #fed7d7; border-radius: 0.5rem; margin: 1rem 0;">
 
 **Problem**: `tito system health` shows errors
 

--- a/tinytorch/site/tito/modules.md
+++ b/tinytorch/site/tito/modules.md
@@ -138,7 +138,7 @@ tito module status
 
 ### Environment Health
 
-<div style="background: #e3f2fd; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #2196f3; margin: 1.5rem 0;">
+<div class="modules-health-box" style="background: #e3f2fd; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #2196f3; margin: 1.5rem 0;">
 
 **Check Setup (Run This First)**
 ```bash

--- a/tinytorch/site/tito/modules.md
+++ b/tinytorch/site/tito/modules.md
@@ -196,7 +196,7 @@ tito module list
 
 ### Start a Module (First Time)
 
-<div style="background: #fffbeb; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #f59e0b; margin: 1.5rem 0;">
+<div class="modules-start-box" style="background: #fffbeb; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #f59e0b; margin: 1.5rem 0;">
 
 ```bash
 tito module start 01

--- a/tinytorch/site/tito/modules.md
+++ b/tinytorch/site/tito/modules.md
@@ -251,7 +251,7 @@ tito module view 01
 
 ### Complete & Export (Essential)
 
-<div style="background: #f0fdf4; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #22c55e; margin: 1.5rem 0;">
+<div class="modules-complete-box" style="background: #f0fdf4; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #22c55e; margin: 1.5rem 0;">
 
 ```bash
 tito module complete 01

--- a/tinytorch/site/tito/modules.md
+++ b/tinytorch/site/tito/modules.md
@@ -336,7 +336,7 @@ Next: Complete Module 04 to continue Foundation Tier
 
 ### Reset Module (Advanced)
 
-<div style="background: #fff5f5; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #e74c3c; margin: 1.5rem 0;">
+<div class="modules-reset-box" style="background: #fff5f5; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #e74c3c; margin: 1.5rem 0;">
 
 ```bash
 tito module reset 01

--- a/tinytorch/site/tito/modules.md
+++ b/tinytorch/site/tito/modules.md
@@ -359,7 +359,7 @@ tito module reset 01
 
 When you run `tito module complete XX`, here's what happens:
 
-<div style="background: #f8f9fa; padding: 1.5rem; border: 1px solid #dee2e6; border-radius: 0.5rem; margin: 1.5rem 0;">
+<div class="modules-export-box" style="background: #f8f9fa; padding: 1.5rem; border: 1px solid #dee2e6; border-radius: 0.5rem; margin: 1.5rem 0;">
 
 **Step 1: Validation**
 ```

--- a/tinytorch/site/tito/modules.md
+++ b/tinytorch/site/tito/modules.md
@@ -237,7 +237,7 @@ tito module resume 01
 
 ### View a Module (Read-Only)
 
-<div style="background: #e8eaf6; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #5c6bc0; margin: 1.5rem 0;">
+<div class="modules-view-box" style="background: #e8eaf6; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #5c6bc0; margin: 1.5rem 0;">
 
 ```bash
 tito module view 01

--- a/tinytorch/site/tito/modules.md
+++ b/tinytorch/site/tito/modules.md
@@ -460,7 +460,7 @@ tito system health
 
 ### Export Fails
 
-<div style="background: #fff5f5; padding: 1.5rem; border: 1px solid #fed7d7; border-radius: 0.5rem; margin: 1rem 0;">
+<div class="modules-trouble-box" style="background: #fff5f5; padding: 1.5rem; border: 1px solid #fed7d7; border-radius: 0.5rem; margin: 1rem 0;">
 
 **Problem**: `tito module complete XX` fails
 

--- a/tinytorch/site/tito/modules.md
+++ b/tinytorch/site/tito/modules.md
@@ -73,7 +73,7 @@ Follow this workflow to build ML systems from scratch.
 
 Here's what a complete session looks like:
 
-<div style="background: #f8f9fa; padding: 1.5rem; border: 1px solid #dee2e6; border-radius: 0.5rem; margin: 1.5rem 0;">
+<div class="modules-session-box" style="background: #f8f9fa; padding: 1.5rem; border: 1px solid #dee2e6; border-radius: 0.5rem; margin: 1.5rem 0;">
 
 **1. Start Session**
 ```bash

--- a/tinytorch/site/tito/modules.md
+++ b/tinytorch/site/tito/modules.md
@@ -184,7 +184,7 @@ Convenience command to launch Jupyter Lab from the correct directory.
 
 ### List Available Modules
 
-<div style="background: #e8eaf6; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #5c6bc0; margin: 1.5rem 0;">
+<div class="modules-lifecycle-box" style="background: #e8eaf6; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #5c6bc0; margin: 1.5rem 0;">
 
 ```bash
 tito module list

--- a/tinytorch/site/tito/modules.md
+++ b/tinytorch/site/tito/modules.md
@@ -306,7 +306,7 @@ tito module test 01
 
 ### View Progress
 
-<div style="background: #fef3c7; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #f59e0b; margin: 1.5rem 0;">
+<div class="modules-progress-box" style="background: #fef3c7; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #f59e0b; margin: 1.5rem 0;">
 
 ```bash
 tito module status

--- a/tinytorch/site/tito/modules.md
+++ b/tinytorch/site/tito/modules.md
@@ -288,7 +288,7 @@ print(x.grad) # Uses YOUR autograd!
 
 ### Test a Module (Without Exporting)
 
-<div style="background: #e3f2fd; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #2196f3; margin: 1.5rem 0;">
+<div class="modules-test-box" style="background: #e3f2fd; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #2196f3; margin: 1.5rem 0;">
 
 ```bash
 tito module test 01

--- a/tinytorch/site/tito/modules.md
+++ b/tinytorch/site/tito/modules.md
@@ -479,7 +479,7 @@ tito system health
 
 ### Import Errors
 
-<div style="background: #fff5f5; padding: 1.5rem; border: 1px solid #fed7d7; border-radius: 0.5rem; margin: 1rem 0;">
+<div class="modules-trouble-box" style="background: #fff5f5; padding: 1.5rem; border: 1px solid #fed7d7; border-radius: 0.5rem; margin: 1rem 0;">
 
 **Problem**: `from tinytorch import X` fails
 


### PR DESCRIPTION
## Problem

Twelve cards/boxes on the modules page had invisible text in dark mode due to
hardcoded light background colors in inline `style` attributes with no dark
mode CSS overrides.

## Sections fixed

| Section | Light bg | Dark bg | Class |
|---|---|---|---|
| Typical Development Session | `#f8f9fa` | `#1e293b` | `modules-session-box` |
| Environment Health | `#e3f2fd` | `#0d2137` | `modules-health-box` |
| List Available Modules | `#e8eaf6` | `#1a1a2e` | `modules-lifecycle-box` |
| Start a Module | `#fffbeb` | `#1c1500` | `modules-start-box` |
| Resume Work | `#f3e5f5` | `#1a0e2e` | `modules-resume-box` |
| View a Module | `#e8eaf6` | `#1a1a2e` | `modules-view-box` |
| Complete & Export | `#f0fdf4` | `#0a1f0a` | `modules-complete-box` |
| Test a Module | `#e3f2fd` | `#0d2137` | `modules-test-box` |
| View Progress | `#fef3c7` | `#1c1500` | `modules-progress-box` |
| Reset Module | `#fff5f5` | `#2a0a0a` | `modules-reset-box` |
| Understanding the Export Process | `#f8f9fa` | `#1e293b` | `modules-export-box` |
| Environment Not Ready / Export Fails / Import Errors (×3) | `#fff5f5` | `#2a0a0a` | `modules-trouble-box` |

## Solution

**`tito/modules.md`** — Added semantic CSS classes to each affected element
while keeping existing inline styles intact for light mode.

**`_static/custom.css`** — Added targeted `html[data-theme="dark"]` overrides
for each class. Each card gets a brand-tinted dark background that preserves
its color identity (blue → dark navy, purple → dark purple, green → dark green,
red → dark red, etc.) with `filter: none !important` where needed to bypass the
existing brightness dimmer. Troubleshooting cards share a single
`.modules-trouble-box` class since they use the same color scheme.

## Files changed
- `tinytorch/site/tito/modules.md` — 12 lines changed (class attributes added)
- `tinytorch/site/_static/custom.css` — 102 lines added (dark mode overrides)
