### PR TITLE
fix: announcement bar + sidebar consistency

### DIFF
--- a/tinytorch/site-quarto/config/announcement.yml
+++ b/tinytorch/site-quarto/config/announcement.yml
@@ -1,7 +1,17 @@
-# TinyTorch announcement bar configuration
-# Managed via Quarto's built-in announcement feature
+# =============================================================================
+# ANNOUNCEMENT BAR CONFIGURATION - TINYTORCH
+# =============================================================================
+# This file contains the announcement bar configuration for the TinyTorch site.
+# It's included via metadata-files in _quarto.yml
+# =============================================================================
+
 website:
   announcement:
-    content: "Preview Release — TinyTorch is functional but still being refined. Classroom ready Summer 2026."
-    type: warning
+    icon: megaphone
     dismissable: true
+    type: primary
+    position: below-navbar
+    content: |
+      🔥 **TinyTorch:** Build your own ML framework from scratch. Classroom ready 2026.<br>
+      📚 **Textbook:** Read the ML Systems book. [Explore →](https://mlsysbook.ai/vol1/)<br>
+      📦 **Hardware Kits:** Arduino, Seeed & Raspberry Pi labs. [Explore →](https://mlsysbook.ai/kits)


### PR DESCRIPTION
Match TinyTorch announcement bar with other Quarto sites (type: primary, position: below-navbar, multi-line with icon). Also enables sidebar on landing page and fixes raw markdown.