### PR TITLE
feat: add announcement bars to all remaining Quarto sites

### DIFF
--- a/instructors/_quarto.yml
+++ b/instructors/_quarto.yml
@@ -99,6 +99,7 @@ website:
 
 metadata-files:
   - ../shared/config/navbar-common.yml
+  - config/announcement.yml
 
 format:
   html:

--- a/instructors/config/announcement.yml
+++ b/instructors/config/announcement.yml
@@ -1,0 +1,17 @@
+# =============================================================================
+# ANNOUNCEMENT BAR CONFIGURATION - INSTRUCTOR HUB
+# =============================================================================
+# This file contains the announcement bar configuration for the instructors site.
+# It's included via metadata-files in _quarto.yml
+# =============================================================================
+
+website:
+  announcement:
+    icon: megaphone
+    dismissable: true
+    type: primary
+    position: below-navbar
+    content: |
+      👩‍🏫 **Instructor Hub:** Course materials, slides, and grading tools for ML Systems.<br>
+      📚 **Textbook:** Read the ML Systems book. [Vol I →](https://mlsysbook.ai/vol1/) · [Vol II →](https://mlsysbook.ai/vol2/)<br>
+      🔥 **TinyTorch:** Hands-on framework labs for your course. [Explore →](https://mlsysbook.ai/tinytorch)

--- a/site/_quarto.yml
+++ b/site/_quarto.yml
@@ -44,6 +44,7 @@ website:
 metadata-files:
   - ../shared/config/navbar-common.yml
   - ../shared/config/footer-site.yml
+  - config/announcement.yml
 
 format:
   html:

--- a/site/config/announcement.yml
+++ b/site/config/announcement.yml
@@ -1,0 +1,17 @@
+# =============================================================================
+# ANNOUNCEMENT BAR CONFIGURATION - MAIN LANDING PAGE
+# =============================================================================
+# This file contains the announcement bar configuration for the landing site.
+# It's included via metadata-files in _quarto.yml
+# =============================================================================
+
+website:
+  announcement:
+    icon: megaphone
+    dismissable: true
+    type: primary
+    position: below-navbar
+    content: |
+      🎉 **NEW: Two volumes!** [Vol I: Introduction →](https://mlsysbook.ai/vol1/) · [Vol II: Advanced →](https://mlsysbook.ai/vol2/) — open access, free forever.<br>
+      🔥 **TinyTorch:** Build your own ML framework from scratch. [Start →](https://mlsysbook.ai/tinytorch)<br>
+      📦 **Hardware Kits:** Arduino, Seeed & Raspberry Pi labs. [Explore →](https://mlsysbook.ai/kits)

--- a/slides/_quarto.yml
+++ b/slides/_quarto.yml
@@ -98,6 +98,7 @@ website:
 
 metadata-files:
   - ../shared/config/navbar-common.yml
+  - config/announcement.yml
 
 format:
   html:

--- a/slides/config/announcement.yml
+++ b/slides/config/announcement.yml
@@ -1,0 +1,17 @@
+# =============================================================================
+# ANNOUNCEMENT BAR CONFIGURATION - LECTURE SLIDES
+# =============================================================================
+# This file contains the announcement bar configuration for the slides site.
+# It's included via metadata-files in _quarto.yml
+# =============================================================================
+
+website:
+  announcement:
+    icon: megaphone
+    dismissable: true
+    type: primary
+    position: below-navbar
+    content: |
+      🎓 **Lecture Slides:** Ready-to-use slide decks for ML Systems courses.<br>
+      📚 **Textbook:** Read the ML Systems book. [Vol I →](https://mlsysbook.ai/vol1/) · [Vol II →](https://mlsysbook.ai/vol2/)<br>
+      👩‍🏫 **Instructor Hub:** Full course materials and grading tools. [Visit →](https://mlsysbook.ai/instructors)


### PR DESCRIPTION
Adds consistent announcement bars to the 3 sites that were missing them (main landing page, instructors, slides). All 7 Quarto sites now have matching configuration.