### PR TITLE
fix(shared): centralize font loading + fix mlsysim carousel

### DIFF
--- a/book/quarto/config/_quarto-html-vol1.yml
+++ b/book/quarto/config/_quarto-html-vol1.yml
@@ -192,17 +192,14 @@ format:
     number-sections: false
     number-depth: 3
     include-in-header:
-      text: |
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-        <link rel="preconnect" href="https://fonts.googleapis.com">
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-        <link rel="manifest" href="/site.webmanifest">
-        <link rel="apple-touch-icon" href="/assets/images/icons/favicon.png">
-        <meta name="theme-color" content="#A51C30">
-        <script type="module" src="/tools/scripts/socratiQ/bundle.js" defer></script>
-        <script src="/assets/scripts/sidebar-auto-collapse.js" defer></script>
-        <script src="/assets/scripts/version-link.js" defer></script>
+      - file: ../../shared/config/site-head.html
+      - text: |
+          <link rel="manifest" href="/site.webmanifest">
+          <link rel="apple-touch-icon" href="/assets/images/icons/favicon.png">
+          <meta name="theme-color" content="#A51C30">
+          <script type="module" src="/tools/scripts/socratiQ/bundle.js" defer></script>
+          <script src="/assets/scripts/sidebar-auto-collapse.js" defer></script>
+          <script src="/assets/scripts/version-link.js" defer></script>
         <script src="/assets/scripts/subscribe-modal.js" defer></script>
     citeproc: true
 

--- a/book/quarto/config/_quarto-html-vol2.yml
+++ b/book/quarto/config/_quarto-html-vol2.yml
@@ -200,17 +200,14 @@ format:
     number-sections: false
     number-depth: 3
     include-in-header:
-      text: |
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-        <link rel="preconnect" href="https://fonts.googleapis.com">
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-        <link rel="manifest" href="/site.webmanifest">
-        <link rel="apple-touch-icon" href="/assets/images/icons/favicon.png">
-        <meta name="theme-color" content="#1F407A">
-        <script type="module" src="/tools/scripts/socratiQ/bundle.js" defer></script>
-        <script src="/assets/scripts/sidebar-auto-collapse.js" defer></script>
-        <script src="/assets/scripts/version-link.js" defer></script>
+      - file: ../../shared/config/site-head.html
+      - text: |
+          <link rel="manifest" href="/site.webmanifest">
+          <link rel="apple-touch-icon" href="/assets/images/icons/favicon.png">
+          <meta name="theme-color" content="#1F407A">
+          <script type="module" src="/tools/scripts/socratiQ/bundle.js" defer></script>
+          <script src="/assets/scripts/sidebar-auto-collapse.js" defer></script>
+          <script src="/assets/scripts/version-link.js" defer></script>
         <script src="/assets/scripts/subscribe-modal.js" defer></script>
     citeproc: true
 

--- a/instructors/_quarto.yml
+++ b/instructors/_quarto.yml
@@ -117,10 +117,7 @@ format:
     code-copy: true
     anchor-sections: true
     include-in-header:
-      - text: |
-          <link rel="preconnect" href="https://fonts.googleapis.com">
-          <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-          <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+      - file: ../shared/config/site-head.html
 
 execute:
   freeze: auto

--- a/kits/config/_quarto-html.yml
+++ b/kits/config/_quarto-html.yml
@@ -159,10 +159,8 @@ format:
     link-external-newwindow: true
     anchor-sections: true
     include-in-header:
+      - file: ../shared/config/site-head.html
       - text: |
-          <link rel="preconnect" href="https://fonts.googleapis.com">
-          <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-          <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
           <link rel="manifest" href="/site.webmanifest">
           <link rel="apple-touch-icon" href="/assets/images/favicon.png">
           <meta name="theme-color" content="#148F77">

--- a/labs/config/_quarto-html.yml
+++ b/labs/config/_quarto-html.yml
@@ -208,10 +208,8 @@ format:
     link-external-newwindow: true
     anchor-sections: true
     include-in-header:
+      - file: ../shared/config/site-head.html
       - text: |
-          <link rel="preconnect" href="https://fonts.googleapis.com">
-          <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-          <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
           <link rel="manifest" href="/site.webmanifest">
           <link rel="apple-touch-icon" href="/assets/images/favicon.png">
           <meta name="theme-color" content="#7D3C98">

--- a/mlsysim/docs/config/_quarto-html.yml
+++ b/mlsysim/docs/config/_quarto-html.yml
@@ -230,10 +230,8 @@ format:
     link-external-newwindow: false
     anchor-sections: true
     include-in-header:
+      - file: ../../shared/config/site-head.html
       - text: |
-          <link rel="preconnect" href="https://fonts.googleapis.com">
-          <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-          <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
           <meta name="theme-color" content="#0284C7">
     include-after-body:
       - text: |

--- a/mlsysim/docs/index.qmd
+++ b/mlsysim/docs/index.qmd
@@ -211,6 +211,7 @@ Reason about ML workloads --- from microcontrollers to GPU clusters --- without 
 </div>
 </div>
 </div>
+<script src="styles/landing.js" defer></script>
 ```
 
 

--- a/mlsysim/docs/styles/landing.css
+++ b/mlsysim/docs/styles/landing.css
@@ -849,3 +849,153 @@ a.im-tutorial-card-link:hover .im-tutorial-card h4 {
   background: #0c1322;
   border: 1px solid #1e293b;
 }
+
+/* ---------- INTERACTIVE SHOWCASE CAROUSEL ---------- */
+.im-carousel {
+  max-width: 600px;
+  margin: 0 auto;
+  position: relative;
+}
+
+.im-carousel-track {
+  position: relative;
+  min-height: 360px;
+  overflow: visible;
+}
+
+/* Slides */
+.im-slide {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transform: translateX(30px);
+  pointer-events: none;
+  transition: opacity 0.45s ease, transform 0.45s ease;
+  padding: 0 3.5rem;
+}
+
+.im-slide-active {
+  opacity: 1;
+  transform: translateX(0);
+  pointer-events: auto;
+}
+
+.im-slide-label {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #38bdf8;
+  letter-spacing: 0.01em;
+  margin-bottom: 0.75rem;
+  text-align: center;
+}
+
+.im-slide-viz {
+  width: 100%;
+  max-width: 440px;
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid rgba(56, 189, 248, 0.12);
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+  backdrop-filter: blur(8px);
+  margin-bottom: 0.75rem;
+}
+
+.im-slide-viz svg {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.im-slide-caption {
+  font-size: 0.85rem;
+  color: #94a3b8;
+  text-align: center;
+  line-height: 1.5;
+  max-width: 400px;
+}
+
+/* Arrow buttons */
+.im-arrow {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 10;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 50%;
+  color: #94a3b8;
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  backdrop-filter: blur(4px);
+  padding: 0;
+}
+
+.im-arrow:hover {
+  background: rgba(56, 189, 248, 0.15);
+  border-color: rgba(56, 189, 248, 0.4);
+  color: #38bdf8;
+  transform: translateY(-50%) scale(1.08);
+}
+
+.im-arrow:active {
+  transform: translateY(-50%) scale(0.95);
+}
+
+.im-arrow-prev { left: 0; }
+.im-arrow-next { right: 0; }
+
+/* Dot navigation */
+.im-carousel-dots {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-top: 1rem;
+  padding-bottom: 0.5rem;
+}
+
+.im-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.15);
+  cursor: pointer;
+  padding: 0;
+  transition: all 0.25s ease;
+}
+
+.im-dot:hover {
+  background: rgba(56, 189, 248, 0.4);
+}
+
+.im-dot-active {
+  background: #38bdf8;
+  width: 24px;
+  border-radius: 4px;
+}
+
+/* Responsive carousel */
+@media (max-width: 768px) {
+  .im-carousel { max-width: 100%; }
+  .im-slide { padding: 0 2.5rem; }
+  .im-arrow { width: 34px; height: 34px; font-size: 1.1rem; }
+  .im-arrow-prev { left: -4px; }
+  .im-arrow-next { right: -4px; }
+}
+
+@media (max-width: 480px) {
+  .im-slide { padding: 0 2rem; }
+  .im-arrow { width: 30px; height: 30px; font-size: 1rem; }
+  .im-carousel-track { min-height: 300px; }
+}

--- a/mlsysim/docs/styles/landing.js
+++ b/mlsysim/docs/styles/landing.js
@@ -1,10 +1,11 @@
 // =============================================================================
-// MLSYSIM LANDING PAGE — Copy Button
+// MLSYSIM LANDING PAGE — Copy Button + Carousel
 // =============================================================================
 
 (function () {
   "use strict";
 
+  // ---- Copy install command ----
   window.copyInstall = function () {
     var cmd = document.querySelector("code.im-cmd");
     if (!cmd) return;
@@ -17,4 +18,70 @@
       }
     });
   };
+
+  // ---- Carousel ----
+  document.addEventListener("DOMContentLoaded", function () {
+    var track = document.querySelector(".im-carousel-track");
+    if (!track) return;
+
+    var slides = track.querySelectorAll(".im-slide");
+    var dots = document.querySelectorAll(".im-dot");
+    var prevBtn = track.querySelector(".im-arrow-prev");
+    var nextBtn = track.querySelector(".im-arrow-next");
+    var current = 0;
+    var total = slides.length;
+    var autoTimer = null;
+    var AUTO_INTERVAL = 6000;
+
+    function goTo(idx) {
+      idx = ((idx % total) + total) % total;  // wrap around
+      slides[current].classList.remove("im-slide-active");
+      dots[current].classList.remove("im-dot-active");
+      current = idx;
+      slides[current].classList.add("im-slide-active");
+      dots[current].classList.add("im-dot-active");
+    }
+
+    function next() { goTo(current + 1); }
+    function prev() { goTo(current - 1); }
+
+    function resetAuto() {
+      clearInterval(autoTimer);
+      autoTimer = setInterval(next, AUTO_INTERVAL);
+    }
+
+    // Arrow buttons
+    if (prevBtn) {
+      prevBtn.addEventListener("click", function (e) {
+        e.preventDefault();
+        prev();
+        resetAuto();
+      });
+    }
+    if (nextBtn) {
+      nextBtn.addEventListener("click", function (e) {
+        e.preventDefault();
+        next();
+        resetAuto();
+      });
+    }
+
+    // Dot buttons
+    dots.forEach(function (dot) {
+      dot.addEventListener("click", function () {
+        var idx = parseInt(this.getAttribute("data-slide"), 10);
+        goTo(idx);
+        resetAuto();
+      });
+    });
+
+    // Keyboard navigation
+    document.addEventListener("keydown", function (e) {
+      if (e.key === "ArrowLeft") { prev(); resetAuto(); }
+      if (e.key === "ArrowRight") { next(); resetAuto(); }
+    });
+
+    // Start auto-rotation
+    autoTimer = setInterval(next, AUTO_INTERVAL);
+  });
 })();

--- a/slides/_quarto.yml
+++ b/slides/_quarto.yml
@@ -114,7 +114,4 @@ format:
     toc: true
     css: styles.css
     include-in-header:
-      - text: |
-          <link rel="preconnect" href="https://fonts.googleapis.com">
-          <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-          <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+      - file: ../shared/config/site-head.html

--- a/tinytorch/site-quarto/_quarto.yml
+++ b/tinytorch/site-quarto/_quarto.yml
@@ -220,10 +220,8 @@ format:
     mermaid:
       theme: default
     include-in-header:
+      - file: ../../shared/config/site-head.html
       - text: |
-          <link rel="preconnect" href="https://fonts.googleapis.com">
-          <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-          <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
           <link rel="apple-touch-icon" href="/assets/images/logos/logo-tinytorch.png">
           <meta name="theme-color" content="#D4740C">
     include-after-body:


### PR DESCRIPTION
## Summary

- **Centralize font loading**: Replace inline Google Fonts `<link>` tags in all 8 site `_quarto.yml` configs with a single `- file: shared/config/site-head.html` reference. Fonts (Inter 400-800, JetBrains Mono) and Font Awesome are now inherited from one shared file instead of duplicated across every config.
- **Add missing Inter weight 800** to the configs (was already in `site-head.html` but missing from individual configs).
- **Fix MLSys·im landing-page carousel**: add CSS + JS for arrows, dots, slides, auto-rotation, and keyboard navigation. The `< >` buttons were previously non-functional.

## Files touched

11 files across `book/`, `instructors/`, `kits/`, `labs/`, `mlsysim/docs/`, `slides/`, and `tinytorch/`.

## Provenance

Cherry-picked from `69f330b2d` on the post-merge `review/mlsysim-release-0.1.0` branch (the original commit landed there by accident after PR #1397 was already merged). The original is preserved on that branch as a backup; this PR is the canonical landing path into `dev`.