### PR TITLE
PR-1: Release-prep safety net (link checking + publish guards + nightly link-rot)

### DIFF
--- a/.github/workflows/book-publish-live.yml
+++ b/.github/workflows/book-publish-live.yml
@@ -188,6 +188,18 @@ permissions:
   packages: read
 
 jobs:
+  # Block publish unless the latest dev validate run for the book is green.
+  # See .github/workflows/infra-publish-guard.yml for guard semantics.
+  # NB: book has its own elaborate pre-flight; this guard is the cross-cutting
+  # safety check that verifies *validate-dev* is recently green, not just that
+  # the local checkout looks OK.
+  guard:
+    name: '🛡️ Validate-Dev Green Gate'
+    if: github.event.inputs.confirm == 'PUBLISH' && github.event.inputs.testing_mode != 'yes'
+    uses: ./.github/workflows/infra-publish-guard.yml
+    with:
+      validate_workflow: book-validate-dev.yml
+
   debug-log:
     name: '📋 Debug & Audit Log'
     runs-on: ubuntu-latest
@@ -324,6 +336,7 @@ jobs:
   validate-inputs:
     name: '🔍 Validate Inputs'
     runs-on: ubuntu-latest
+    needs: [guard]
     timeout-minutes: 10
     if: github.event.inputs.confirm == 'PUBLISH' && github.event.inputs.testing_mode != 'yes' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
     outputs:

--- a/.github/workflows/book-validate-dev.yml
+++ b/.github/workflows/book-validate-dev.yml
@@ -345,11 +345,26 @@ jobs:
           echo "linux_epub_vol1_artifact=$LINUX_EPUB_VOL1" >> $GITHUB_OUTPUT
           echo "linux_epub_vol2_artifact=$LINUX_EPUB_VOL2" >> $GITHUB_OUTPUT
 
+  # Step 4b: Link integrity (Tier 2 — non-blocking baseline)
+  # Tier 1 pre-commit (shared/scripts/check-internal-links.py) already blocks
+  # broken internal links + anchors. This Lychee pass adds external reachability
+  # as a warning. Flip fail_on_broken=true once the baseline is clean.
+  check-links:
+    name: '🔗 Check Links'
+    needs: [pre-commit]
+    if: always() && needs.pre-commit.result == 'success'
+    uses: ./.github/workflows/infra-link-check.yml
+    with:
+      path_pattern: './book/quarto/contents/**/*.qmd'
+      lycheeignore_path: 'book/config/linting/.lycheeignore'
+      fail_on_broken: false
+      max_concurrency: 10
+
   # Step 5: Final results and summary
   validation-summary:
     name: '🎯 Validation Summary'
     if: always()
-    needs: [pre-commit, build-config, collect-results]
+    needs: [pre-commit, build-config, collect-results, check-links]
     runs-on: ubuntu-latest
 
     steps:
@@ -456,3 +471,7 @@ jobs:
           else
             echo "❌ **Validation Failed** - Check the logs above" >> $GITHUB_STEP_SUMMARY
           fi
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## 🔗 Link Check (non-blocking)" >> $GITHUB_STEP_SUMMARY
+          echo "- Result: \`${{ needs.check-links.result }}\` (see job for detail)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/infra-link-check.yml
+++ b/.github/workflows/infra-link-check.yml
@@ -1,26 +1,34 @@
 name: '🔧 Infra · 🔗 Link Check'
 
 # =============================================================================
-# 🔗 Link Check — Scan QMD files for broken external URLs
+# 🔗 Link Check — Reusable Lychee scan for any subsite (Tier 2)
 # =============================================================================
 #
-# Uses Lychee to crawl all external links in textbook content and report
-# broken or unreachable URLs. Configurable path pattern and concurrency.
+# Backstops the Tier 1 pre-commit internal-link checker
+# (shared/scripts/check-internal-links.py) by chasing EXTERNAL reachability
+# and any internal links pre-commit can't resolve (e.g. paths that depend on
+# the rendered site root).
+#
+# Inputs:
+#   path_pattern       File glob to scan (default: book qmd content).
+#   max_concurrency    Lychee concurrency cap.
+#   lycheeignore_path  Per-site exclusion file (default: book/config/linting/.lycheeignore).
+#                      Pass the path to <site>/.lycheeignore for site-scoped CI.
+#   fail_on_broken     If true, fail the job on any broken link. Default false
+#                      preserves the legacy "report only" behavior so older
+#                      callers don't suddenly start blocking.
+#   accept_status      Comma-separated list of HTTP statuses to accept as OK
+#                      (e.g. "200,403,429"). Default "200,403".
 #
 # Flow:
 #   1. CHECKOUT — Pull repository content
-#   2. SCAN     — Run Lychee link checker against QMD file pattern
-#   3. SUMMARY  — Report status and broken link count
+#   2. SCAN     — Run Lychee link checker against the pattern
+#   3. SUMMARY  — Report status; fail if fail_on_broken=true and links are bad
 #
 # Triggers:
-#   - workflow_dispatch: Manual with path pattern and concurrency options
-#   - workflow_call: Reusable by other workflows (e.g., book validation)
-#
-# Secrets:    GITHUB_TOKEN (automatic)
-#
-# Related:
-#   - book-validate-dev.yml    — Calls this workflow during book validation
-#   - infra-health-check.yml   — Container health (complementary infra check)
+#   - workflow_call: invoked from every <site>-validate-dev.yml (Tier 2)
+#   - workflow_call: invoked nightly by infra-link-rot-nightly.yml (Tier 3)
+#   - workflow_dispatch: manual one-off
 #
 # =============================================================================
 
@@ -31,12 +39,27 @@ on:
         required: false
         type: string
         default: './book/quarto/contents/**/*.qmd'
-        description: 'File pattern to check links in. Example: "./book/quarto/contents/vol1/**/*.qmd"'
+        description: 'File pattern to check links in.'
       max_concurrency:
         required: false
         type: number
         default: 10
-        description: 'Maximum concurrent link checks (1-20)'
+        description: 'Maximum concurrent link checks (1-20).'
+      lycheeignore_path:
+        required: false
+        type: string
+        default: 'book/config/linting/.lycheeignore'
+        description: 'Path to a Lychee exclude file (regex per line).'
+      fail_on_broken:
+        required: false
+        type: boolean
+        default: false
+        description: 'If true, fail the job when broken links are found.'
+      accept_status:
+        required: false
+        type: string
+        default: '200,403'
+        description: 'Comma-separated HTTP status codes Lychee should treat as OK.'
 
     outputs:
       check-status:
@@ -52,12 +75,27 @@ on:
         required: false
         type: string
         default: './book/quarto/contents/**/*.qmd'
-        description: 'File pattern to check links in. Example: "./book/quarto/contents/vol1/**/*.qmd"'
+        description: 'File pattern to check links in.'
       max_concurrency:
         required: false
         type: number
         default: 10
-        description: 'Maximum concurrent link checks (1-20)'
+        description: 'Maximum concurrent link checks (1-20).'
+      lycheeignore_path:
+        required: false
+        type: string
+        default: 'book/config/linting/.lycheeignore'
+        description: 'Path to a Lychee exclude file.'
+      fail_on_broken:
+        required: false
+        type: boolean
+        default: false
+        description: 'Fail the job when broken links are found.'
+      accept_status:
+        required: false
+        type: string
+        default: '200,403'
+        description: 'Comma-separated HTTP status codes Lychee should treat as OK.'
 
 permissions:
   contents: read
@@ -72,33 +110,55 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: 🔎 Resolve ignore file
+        id: resolve-ignore
+        run: |
+          IGNORE='${{ inputs.lycheeignore_path }}'
+          if [ -f "$IGNORE" ]; then
+            echo "ignore_arg=--exclude-file $IGNORE" >> "$GITHUB_OUTPUT"
+            echo "Using ignore file: $IGNORE"
+          else
+            echo "ignore_arg=" >> "$GITHUB_OUTPUT"
+            echo "::warning::Ignore file '$IGNORE' not found; running without --exclude-file."
+          fi
+
       - name: 🔗 Check Links
         id: lychee
         uses: lycheeverse/lychee-action@v2.7.0
         with:
-          args: --verbose --no-progress --exclude-mail --max-concurrency ${{ inputs.max_concurrency || 10 }} --accept 200,403 --exclude-file book/config/linting/.lycheeignore ${{ inputs.path_pattern || './book/quarto/contents/**/*.qmd' }}
+          args: --verbose --no-progress --exclude-mail --max-concurrency ${{ inputs.max_concurrency }} --accept ${{ inputs.accept_status }} ${{ steps.resolve-ignore.outputs.ignore_arg }} ${{ inputs.path_pattern }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Always continue so we can produce a summary; the summary step fails
+        # the job when fail_on_broken is true.
         continue-on-error: true
 
       - name: 📊 Link Check Summary
         id: link-summary
         if: always()
         run: |
-          # Determine status and broken link count
           if [ "${{ steps.lychee.outcome }}" = "success" ]; then
             STATUS="success"
             BROKEN_COUNT="0"
           else
             STATUS="failure"
-            # Try to extract broken link count from lychee output (rough estimate)
             BROKEN_COUNT="unknown"
           fi
 
-          echo "status=$STATUS" >> $GITHUB_OUTPUT
-          echo "broken-count=$BROKEN_COUNT" >> $GITHUB_OUTPUT
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+          echo "broken-count=$BROKEN_COUNT" >> "$GITHUB_OUTPUT"
 
-          echo "🔗 Link Check Status: $STATUS"
-          echo "📊 Broken Links: $BROKEN_COUNT"
-          echo "🎯 Pattern Checked: ${{ inputs.path_pattern || './contents/**/*.qmd' }}"
-          echo "⚡ Concurrency: ${{ inputs.max_concurrency || 10 }}"
+          {
+            echo "## 🔗 Link Check"
+            echo ""
+            echo "- **Pattern**: \`${{ inputs.path_pattern }}\`"
+            echo "- **Concurrency**: ${{ inputs.max_concurrency }}"
+            echo "- **Accept statuses**: ${{ inputs.accept_status }}"
+            echo "- **Status**: $STATUS"
+            echo "- **Broken**: $BROKEN_COUNT"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$STATUS" = "failure" ] && [ "${{ inputs.fail_on_broken }}" = "true" ]; then
+            echo "::error::Lychee found broken links and fail_on_broken=true."
+            exit 1
+          fi

--- a/.github/workflows/infra-link-check.yml
+++ b/.github/workflows/infra-link-check.yml
@@ -126,7 +126,10 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2.7.0
         with:
-          args: --verbose --no-progress --exclude-mail --max-concurrency ${{ inputs.max_concurrency }} --accept ${{ inputs.accept_status }} ${{ steps.resolve-ignore.outputs.ignore_arg }} ${{ inputs.path_pattern }}
+          # NB: --exclude-mail was removed in lychee v0.21; mailto: links are
+          # now skipped by default and you must opt in with --include-mail.
+          # Default (skip) is what we want for link rot.
+          args: --verbose --no-progress --max-concurrency ${{ inputs.max_concurrency }} --accept ${{ inputs.accept_status }} ${{ steps.resolve-ignore.outputs.ignore_arg }} ${{ inputs.path_pattern }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # Always continue so we can produce a summary; the summary step fails

--- a/.github/workflows/infra-link-rot-nightly.yml
+++ b/.github/workflows/infra-link-rot-nightly.yml
@@ -1,0 +1,280 @@
+name: '🔧 Infra · 🌙 Link Rot (Nightly)'
+
+# =============================================================================
+# 🌙 Link Rot — Nightly Lychee sweep with sticky-issue reporter (Tier 3)
+# =============================================================================
+#
+# Tier 1 (pre-commit) catches new internal-link breakage before it lands.
+# Tier 2 (per-site validate-dev) catches external breakage at PR/push time.
+# Tier 3 (this workflow) is the long-tail: nightly cron sweep across every
+# subsite, with results aggregated into a single sticky GitHub issue so the
+# team has one durable list of broken URLs to triage.
+#
+# Why a sticky issue:
+#   - One source of truth instead of 100 closed-then-reopened issues.
+#   - Body is rewritten each run with the current broken-link inventory.
+#   - Comments preserve trend (week-over-week count delta).
+#
+# Trigger:
+#   - schedule: 04:30 UTC daily (low-traffic window, after EU bedtime).
+#   - workflow_dispatch: manual one-off.
+#
+# Issue label:  link-rot
+# Issue title:  🔗 Link Rot Tracker (auto-updated nightly)
+#
+# =============================================================================
+
+on:
+  schedule:
+    - cron: '30 4 * * *'  # 04:30 UTC daily
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Skip issue update (just print results to job log)'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: link-rot-nightly
+  cancel-in-progress: false
+
+jobs:
+  # =============================================================================
+  # Sweep each site in parallel via the reusable Lychee workflow.
+  # We deliberately reuse infra-link-check.yml so any tweak to Lychee args /
+  # ignore-file handling stays in one place.
+  # =============================================================================
+  sweep-book:
+    name: '📚 Sweep · Book'
+    uses: ./.github/workflows/infra-link-check.yml
+    with:
+      path_pattern: './book/quarto/contents/**/*.qmd'
+      lycheeignore_path: 'book/config/linting/.lycheeignore'
+      max_concurrency: 12
+      fail_on_broken: false
+
+  sweep-kits:
+    name: '📦 Sweep · Kits'
+    uses: ./.github/workflows/infra-link-check.yml
+    with:
+      path_pattern: './kits/**/*.qmd'
+      lycheeignore_path: 'shared/config/.lycheeignore'
+      max_concurrency: 8
+      fail_on_broken: false
+
+  sweep-labs:
+    name: '🔮 Sweep · Labs'
+    uses: ./.github/workflows/infra-link-check.yml
+    with:
+      path_pattern: './labs/**/*.qmd'
+      lycheeignore_path: 'shared/config/.lycheeignore'
+      max_concurrency: 8
+      fail_on_broken: false
+
+  sweep-mlsysim:
+    name: '🧮 Sweep · MLSys·im'
+    uses: ./.github/workflows/infra-link-check.yml
+    with:
+      path_pattern: './mlsysim/docs/**/*.qmd'
+      lycheeignore_path: 'shared/config/.lycheeignore'
+      max_concurrency: 8
+      fail_on_broken: false
+
+  sweep-slides:
+    name: '📊 Sweep · Slides'
+    uses: ./.github/workflows/infra-link-check.yml
+    with:
+      path_pattern: './slides/**/*.{qmd,md}'
+      lycheeignore_path: 'shared/config/.lycheeignore'
+      max_concurrency: 8
+      fail_on_broken: false
+
+  sweep-instructors:
+    name: '🎓 Sweep · Instructors'
+    uses: ./.github/workflows/infra-link-check.yml
+    with:
+      path_pattern: './instructors/**/*.qmd'
+      lycheeignore_path: 'shared/config/.lycheeignore'
+      max_concurrency: 5
+      fail_on_broken: false
+
+  sweep-tinytorch:
+    name: '🔥 Sweep · TinyTorch'
+    uses: ./.github/workflows/infra-link-check.yml
+    with:
+      path_pattern: './tinytorch/site-quarto/**/*.qmd'
+      lycheeignore_path: 'shared/config/.lycheeignore'
+      max_concurrency: 8
+      fail_on_broken: false
+
+  sweep-site:
+    name: '🌐 Sweep · Unified Site'
+    uses: ./.github/workflows/infra-link-check.yml
+    with:
+      path_pattern: './site/**/*.qmd'
+      lycheeignore_path: 'shared/config/.lycheeignore'
+      max_concurrency: 8
+      fail_on_broken: false
+
+  sweep-staffml:
+    name: '🎯 Sweep · StaffML'
+    uses: ./.github/workflows/infra-link-check.yml
+    with:
+      path_pattern: './interviews/**/*.{md,mdx,qmd}'
+      lycheeignore_path: 'shared/config/.lycheeignore'
+      max_concurrency: 8
+      fail_on_broken: false
+
+  # =============================================================================
+  # Aggregate sweep results into the sticky issue.
+  # =============================================================================
+  report:
+    name: '📝 Update Link-Rot Tracker Issue'
+    runs-on: ubuntu-latest
+    needs:
+      - sweep-book
+      - sweep-kits
+      - sweep-labs
+      - sweep-mlsysim
+      - sweep-slides
+      - sweep-instructors
+      - sweep-tinytorch
+      - sweep-site
+      - sweep-staffml
+    if: always()
+
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v6
+
+      - name: 🧮 Build report body
+        id: build
+        run: |
+          set -euo pipefail
+          NOW=$(date -u +"%Y-%m-%dT%H:%MZ")
+
+          # Collect per-site outcomes from the sweep jobs. Each `result` is
+          # one of success / failure / cancelled / skipped.
+          declare -A RESULTS=(
+            ["📚 Book"]="${{ needs.sweep-book.result }}"
+            ["📦 Kits"]="${{ needs.sweep-kits.result }}"
+            ["🔮 Labs"]="${{ needs.sweep-labs.result }}"
+            ["🧮 MLSys·im"]="${{ needs.sweep-mlsysim.result }}"
+            ["📊 Slides"]="${{ needs.sweep-slides.result }}"
+            ["🎓 Instructors"]="${{ needs.sweep-instructors.result }}"
+            ["🔥 TinyTorch"]="${{ needs.sweep-tinytorch.result }}"
+            ["🌐 Unified Site"]="${{ needs.sweep-site.result }}"
+            ["🎯 StaffML"]="${{ needs.sweep-staffml.result }}"
+          )
+
+          BODY_FILE=$(mktemp)
+          {
+            echo "# 🔗 Link Rot Tracker"
+            echo ""
+            echo "_Auto-updated nightly. Last sweep: **$NOW**._"
+            echo ""
+            echo "Each row is the result of a Lychee sweep over that site's content."
+            echo "A 'failure' row means at least one URL in that site is broken."
+            echo "Drill into the linked workflow run for the per-URL list."
+            echo ""
+            echo "## Latest sweep"
+            echo ""
+            echo "| Site | Result |"
+            echo "|------|--------|"
+            FAILED=0
+            for site in "📚 Book" "📦 Kits" "🔮 Labs" "🧮 MLSys·im" "📊 Slides" "🎓 Instructors" "🔥 TinyTorch" "🌐 Unified Site" "🎯 StaffML"; do
+              r="${RESULTS[$site]}"
+              case "$r" in
+                success)   icon="✅" ;;
+                failure)   icon="❌"; FAILED=$((FAILED + 1)) ;;
+                cancelled) icon="🛑" ;;
+                skipped)   icon="⏭️" ;;
+                *)         icon="❓" ;;
+              esac
+              echo "| $site | $icon \`$r\` |"
+            done
+            echo ""
+            echo "**Sites with broken links: $FAILED**"
+            echo ""
+            echo "## Triage notes"
+            echo ""
+            echo "- Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            echo "- Sticky issue updated by \`.github/workflows/infra-link-rot-nightly.yml\`."
+            echo "- To suppress a known-bad URL: add it to the relevant"
+            echo "  \`.lycheeignore\` (\`shared/config/.lycheeignore\` for"
+            echo "  cross-site patterns; \`book/config/linting/.lycheeignore\`"
+            echo "  for book-only)."
+            echo ""
+            echo "<sub>Run id: ${{ github.run_id }}</sub>"
+          } > "$BODY_FILE"
+
+          # Stash for the create-or-update step.
+          echo "body_file=$BODY_FILE" >> "$GITHUB_OUTPUT"
+          echo "failed_sites=$FAILED" >> "$GITHUB_OUTPUT"
+
+          echo ""
+          echo "===== Report Body ====="
+          cat "$BODY_FILE"
+          echo "======================="
+
+      - name: 🪟 Append step summary
+        run: |
+          {
+            echo "## 🌙 Link Rot Sweep"
+            cat "${{ steps.build.outputs.body_file }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: 🏷️ Ensure label exists
+        if: ${{ inputs.dry_run != true }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if ! gh label list --repo "${{ github.repository }}" --search link-rot --json name --jq '.[].name' | grep -qx 'link-rot'; then
+            gh label create link-rot \
+              --repo "${{ github.repository }}" \
+              --description "Aggregated nightly link-rot tracker" \
+              --color "ededed" \
+              || echo "Label already exists or could not be created (non-fatal)."
+          fi
+
+      - name: 🔁 Find or create sticky issue, then update body
+        if: ${{ inputs.dry_run != true }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BODY_FILE: ${{ steps.build.outputs.body_file }}
+        run: |
+          set -euo pipefail
+          TITLE="🔗 Link Rot Tracker (auto-updated nightly)"
+
+          # Look for an existing open issue with our label.
+          ISSUE_NUM=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --label link-rot \
+            --search "in:title \"Link Rot Tracker\"" \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [ -z "$ISSUE_NUM" ]; then
+            echo "No existing tracker issue; creating one."
+            gh issue create \
+              --repo "${{ github.repository }}" \
+              --title "$TITLE" \
+              --label link-rot \
+              --body-file "$BODY_FILE"
+          else
+            echo "Updating tracker issue #$ISSUE_NUM body."
+            gh issue edit "$ISSUE_NUM" \
+              --repo "${{ github.repository }}" \
+              --body-file "$BODY_FILE"
+            # Add a thin comment so trend / count history is visible.
+            FAILED='${{ steps.build.outputs.failed_sites }}'
+            gh issue comment "$ISSUE_NUM" \
+              --repo "${{ github.repository }}" \
+              --body "Nightly sweep complete: **$FAILED site(s)** have broken links. See [run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+          fi

--- a/.github/workflows/infra-publish-guard.yml
+++ b/.github/workflows/infra-publish-guard.yml
@@ -1,0 +1,122 @@
+name: '🔧 Infra · 🛡️ Publish Guard'
+
+# =============================================================================
+# 🛡️ Publish Guard — Block publish-live unless dev validation is green
+# =============================================================================
+#
+# Reusable guard called from every <site>-publish-live.yml. It queries the
+# latest run of a specified validate-dev workflow on the dev branch and
+# fails the publish job if that run is not 'success'. This prevents shipping
+# from an unvalidated baseline (the staged-rollout safety net).
+#
+# Inputs:
+#   validate_workflow  Filename of the validate-dev workflow to query
+#                      (e.g. "kits-validate-dev.yml"). Required.
+#   branch             Branch whose latest run we trust (default: "dev").
+#   max_age_minutes    Refuse to trust runs older than this. Default 1440
+#                      (24h). Prevents stale green from gating publish.
+#
+# Outputs:
+#   gate_status        "ok" if the latest validate run on <branch> is green
+#                      and within max_age. The job exits non-zero otherwise.
+#
+# =============================================================================
+
+on:
+  workflow_call:
+    inputs:
+      validate_workflow:
+        required: true
+        type: string
+        description: 'Filename of validate-dev workflow to require green (e.g. kits-validate-dev.yml).'
+      branch:
+        required: false
+        type: string
+        default: 'dev'
+        description: 'Branch whose latest validate-dev run gates the publish.'
+      max_age_minutes:
+        required: false
+        type: number
+        default: 1440
+        description: 'Maximum age (minutes) of the validate-dev run we trust. Default 24h.'
+
+    outputs:
+      gate_status:
+        description: 'ok if guard passed; otherwise the job already failed.'
+        value: ${{ jobs.guard.outputs.gate_status }}
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  guard:
+    name: '🛡️ Validate-Dev Green Gate'
+    runs-on: ubuntu-latest
+    outputs:
+      gate_status: ${{ steps.gate.outputs.gate_status }}
+    steps:
+      - name: 🔎 Query latest validate-dev run
+        id: gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          WORKFLOW: ${{ inputs.validate_workflow }}
+          BRANCH: ${{ inputs.branch }}
+          MAX_AGE: ${{ inputs.max_age_minutes }}
+        run: |
+          set -euo pipefail
+          echo "Looking for the latest run of '$WORKFLOW' on branch '$BRANCH'..."
+
+          # Pull the latest run that completed (status=completed) on $BRANCH.
+          RUN_JSON=$(gh api \
+            "repos/$OWNER/$REPO/actions/workflows/$WORKFLOW/runs?branch=$BRANCH&per_page=1&status=completed" \
+            --jq '.workflow_runs[0] // empty')
+
+          if [ -z "$RUN_JSON" ]; then
+            echo "::error::No completed run of '$WORKFLOW' found on branch '$BRANCH'."
+            echo "Trigger the validate-dev workflow on $BRANCH and re-run this publish."
+            exit 1
+          fi
+
+          CONCLUSION=$(echo "$RUN_JSON" | jq -r '.conclusion')
+          UPDATED_AT=$(echo "$RUN_JSON" | jq -r '.updated_at')
+          HTML_URL=$(echo "$RUN_JSON"   | jq -r '.html_url')
+          HEAD_SHA=$(echo "$RUN_JSON"   | jq -r '.head_sha')
+
+          echo "Latest run conclusion: $CONCLUSION"
+          echo "Updated at:            $UPDATED_AT"
+          echo "Head SHA:              $HEAD_SHA"
+          echo "Run URL:               $HTML_URL"
+
+          # Age check: max_age_minutes converted to seconds.
+          NOW_EPOCH=$(date -u +%s)
+          # date -d works on GNU; use python for portability across runners.
+          RUN_EPOCH=$(python3 -c "import datetime,sys; print(int(datetime.datetime.fromisoformat(sys.argv[1].replace('Z','+00:00')).timestamp()))" "$UPDATED_AT")
+          AGE_MIN=$(( (NOW_EPOCH - RUN_EPOCH) / 60 ))
+          echo "Run age: ${AGE_MIN} minutes (limit: ${MAX_AGE})"
+
+          {
+            echo "## 🛡️ Publish Guard"
+            echo ""
+            echo "- **Workflow watched**: \`$WORKFLOW\`"
+            echo "- **Branch**: \`$BRANCH\`"
+            echo "- **Conclusion**: \`$CONCLUSION\`"
+            echo "- **Head SHA**: \`$HEAD_SHA\`"
+            echo "- **Age**: ${AGE_MIN}m (limit ${MAX_AGE}m)"
+            echo "- **Run**: $HTML_URL"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$CONCLUSION" != "success" ]; then
+            echo "::error::Latest '$WORKFLOW' run on '$BRANCH' is '$CONCLUSION'. Publish blocked."
+            exit 1
+          fi
+
+          if [ "$AGE_MIN" -gt "$MAX_AGE" ]; then
+            echo "::error::Latest green run on '$BRANCH' is ${AGE_MIN}m old, exceeding limit ${MAX_AGE}m. Re-run validate-dev and try again."
+            exit 1
+          fi
+
+          echo "✅ Guard cleared: validate-dev is green and fresh."
+          echo "gate_status=ok" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/instructors-publish-live.yml
+++ b/.github/workflows/instructors-publish-live.yml
@@ -36,8 +36,17 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Block publish unless the latest dev validate run for this site is green.
+  # See .github/workflows/infra-publish-guard.yml for guard semantics.
+  guard:
+    name: '🛡️ Validate-Dev Green Gate'
+    uses: ./.github/workflows/infra-publish-guard.yml
+    with:
+      validate_workflow: instructors-validate-dev.yml
+
   build-and-deploy:
     name: '🔧 Build & Deploy Instructors'
+    needs: [guard]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/instructors-validate-dev.yml
+++ b/.github/workflows/instructors-validate-dev.yml
@@ -120,42 +120,20 @@ jobs:
           echo "📄 Pages built: $(find instructors/_build -name '*.html' | wc -l)"
 
   # ===========================================================================
-  # Stage 3: Link validation (internal + external)
+  # Stage 3: Link validation (Tier 2 — non-blocking baseline)
   # ===========================================================================
+  # Tier 1 pre-commit (shared/scripts/check-internal-links.py) blocks broken
+  # internal links + anchors. Lychee here adds external reachability as a
+  # warning. Flip fail_on_broken=true once baseline is clean (instructors is
+  # a small site so it's a likely first candidate to ratchet to blocking).
   check-links:
     name: '🔗 Check Links'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    steps:
-      - name: 📥 Checkout
-        uses: actions/checkout@v6
-
-      - name: 🔗 Check Links in Instructor Pages
-        id: lychee
-        uses: lycheeverse/lychee-action@v2.7.0
-        with:
-          args: >-
-            --verbose
-            --no-progress
-            --exclude-mail
-            --max-concurrency 5
-            --accept 200,403
-            --exclude 'localhost'
-            --exclude '127.0.0.1'
-            './instructors/**/*.qmd'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        continue-on-error: true
-
-      - name: 📊 Link Check Results
-        if: always()
-        run: |
-          if [ "${{ steps.lychee.outcome }}" = "success" ]; then
-            echo "✅ All links valid"
-          else
-            echo "⚠️ Some links may be broken — check lychee output above"
-          fi
+    uses: ./.github/workflows/infra-link-check.yml
+    with:
+      path_pattern: './instructors/**/*.qmd'
+      lycheeignore_path: 'shared/config/.lycheeignore'
+      fail_on_broken: false
+      max_concurrency: 5
 
   # ===========================================================================
   # Summary

--- a/.github/workflows/kits-publish-live.yml
+++ b/.github/workflows/kits-publish-live.yml
@@ -38,9 +38,18 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Block publish unless the latest dev validate run for this site is green.
+  # See .github/workflows/infra-publish-guard.yml for guard semantics.
+  guard:
+    name: '🛡️ Validate-Dev Green Gate'
+    uses: ./.github/workflows/infra-publish-guard.yml
+    with:
+      validate_workflow: kits-validate-dev.yml
+
   # Build PDF first
   build-pdf:
     name: '📚 Build PDF'
+    needs: [guard]
     uses: ./.github/workflows/kits-build-pdfs.yml
     with:
       ref: ${{ github.ref }}
@@ -48,7 +57,7 @@ jobs:
   build-and-deploy:
     name: '🔧 Build & Deploy Kits'
     runs-on: ubuntu-latest
-    needs: [build-pdf]
+    needs: [guard, build-pdf]
 
     steps:
       - name: 📥 Checkout

--- a/.github/workflows/kits-validate-dev.yml
+++ b/.github/workflows/kits-validate-dev.yml
@@ -145,12 +145,28 @@ jobs:
       ref: ${{ github.ref }}
 
   # ===========================================================================
+  # Stage 4: Link integrity (Tier 2 — non-blocking baseline)
+  # ===========================================================================
+  # Tier 1 pre-commit (shared/scripts/check-internal-links.py) already blocks
+  # broken internal links + anchors. This Lychee pass adds external-URL
+  # reachability as a warning. Flip fail_on_broken=true once the baseline is
+  # clean (tracked in release-prep plan).
+  check-links:
+    name: '🔗 Check Links'
+    uses: ./.github/workflows/infra-link-check.yml
+    with:
+      path_pattern: './kits/**/*.qmd'
+      lycheeignore_path: 'shared/config/.lycheeignore'
+      fail_on_broken: false
+      max_concurrency: 8
+
+  # ===========================================================================
   # Summary
   # ===========================================================================
   summary:
     name: '📊 Summary'
     runs-on: ubuntu-latest
-    needs: [validate-content, build-site, build-pdf]
+    needs: [validate-content, build-site, build-pdf, check-links]
     if: always()
 
     steps:
@@ -163,6 +179,7 @@ jobs:
           echo "| 🔍 Content Validation | ${{ needs.validate-content.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| 🔨 Site Build (HTML) | ${{ needs.build-site.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| 📚 PDF Build | ${{ needs.build-pdf.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| 🔗 Link Check | ${{ needs.check-links.result }} (non-blocking) |" >> $GITHUB_STEP_SUMMARY
 
       - name: ❌ Check for failures
         run: |
@@ -172,4 +189,7 @@ jobs:
             echo "❌ Validation failed"
             exit 1
           fi
-          echo "✅ All checks passed"
+          if [ "${{ needs.check-links.result }}" = "failure" ]; then
+            echo "⚠️ Link check found issues (non-blocking)"
+          fi
+          echo "✅ Core checks passed"

--- a/.github/workflows/labs-publish-live.yml
+++ b/.github/workflows/labs-publish-live.yml
@@ -38,8 +38,17 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Block publish unless the latest dev validate run for this site is green.
+  # See .github/workflows/infra-publish-guard.yml for guard semantics.
+  guard:
+    name: '🛡️ Validate-Dev Green Gate'
+    uses: ./.github/workflows/infra-publish-guard.yml
+    with:
+      validate_workflow: labs-validate-dev.yml
+
   build-and-deploy:
     name: '🔮 Build & Deploy Labs'
+    needs: [guard]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/labs-validate-dev.yml
+++ b/.github/workflows/labs-validate-dev.yml
@@ -275,12 +275,27 @@ jobs:
           python3 labs/tests/browser_smoke.py --labs-dir /tmp/wasm-smoke
 
   # ===========================================================================
+  # Stage 4: Link integrity (Tier 2 — non-blocking baseline)
+  # ===========================================================================
+  # Tier 1 pre-commit (shared/scripts/check-internal-links.py) already blocks
+  # broken internal links + anchors. This pass adds external reachability as a
+  # warning. Flip fail_on_broken=true once the baseline is clean.
+  check-links:
+    name: '🔗 Check Links'
+    uses: ./.github/workflows/infra-link-check.yml
+    with:
+      path_pattern: './labs/**/*.qmd'
+      lycheeignore_path: 'shared/config/.lycheeignore'
+      fail_on_broken: false
+      max_concurrency: 8
+
+  # ===========================================================================
   # Summary
   # ===========================================================================
   summary:
     name: '📊 Summary'
     runs-on: ubuntu-latest
-    needs: [validate-notebooks, build-site, wasm-smoke-test]
+    needs: [validate-notebooks, build-site, wasm-smoke-test, check-links]
     if: always()
 
     steps:
@@ -293,6 +308,7 @@ jobs:
           echo "| 🧪 Notebook Validation | ${{ needs.validate-notebooks.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| 🔨 Site Build | ${{ needs.build-site.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| 🌐 WASM Export | ${{ needs.wasm-smoke-test.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| 🔗 Link Check | ${{ needs.check-links.result }} (non-blocking) |" >> $GITHUB_STEP_SUMMARY
 
       - name: ❌ Check for failures
         run: |
@@ -302,4 +318,7 @@ jobs:
             echo "❌ Validation failed"
             exit 1
           fi
-          echo "✅ All checks passed"
+          if [ "${{ needs.check-links.result }}" = "failure" ]; then
+            echo "⚠️ Link check found issues (non-blocking)"
+          fi
+          echo "✅ Core checks passed"

--- a/.github/workflows/mlsysim-publish-live.yml
+++ b/.github/workflows/mlsysim-publish-live.yml
@@ -38,15 +38,24 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Block publish unless the latest dev validate run for this site is green.
+  # See .github/workflows/infra-publish-guard.yml for guard semantics.
+  guard:
+    name: '🛡️ Validate-Dev Green Gate'
+    uses: ./.github/workflows/infra-publish-guard.yml
+    with:
+      validate_workflow: mlsysim-validate-dev.yml
+
   # Build PDF first (reusable workflow)
   build-pdf:
     name: '📄 Build PDF'
+    needs: [guard]
     uses: ./.github/workflows/mlsysim-build-pdfs.yml
 
   build-and-deploy:
     name: '🧮 Build & Deploy MLSYSIM'
     runs-on: ubuntu-latest
-    needs: [build-pdf]
+    needs: [guard, build-pdf]
 
     steps:
       - name: 📥 Checkout

--- a/.github/workflows/mlsysim-validate-dev.yml
+++ b/.github/workflows/mlsysim-validate-dev.yml
@@ -113,3 +113,18 @@ jobs:
           fi
           echo "✅ Site built successfully"
           echo "📊 Build size: $(du -sh ${MLSYSIM_DOCS}/_build | cut -f1)"
+
+  # ===========================================================================
+  # Stage 3: Link integrity (Tier 2 — non-blocking baseline)
+  # ===========================================================================
+  # Tier 1 pre-commit (shared/scripts/check-internal-links.py) already blocks
+  # broken internal links + anchors. This pass adds external reachability as a
+  # warning. Flip fail_on_broken=true once the baseline is clean.
+  check-links:
+    name: '🔗 Check Links'
+    uses: ./.github/workflows/infra-link-check.yml
+    with:
+      path_pattern: './mlsysim/docs/**/*.qmd'
+      lycheeignore_path: 'shared/config/.lycheeignore'
+      fail_on_broken: false
+      max_concurrency: 8

--- a/.github/workflows/site-publish-live.yml
+++ b/.github/workflows/site-publish-live.yml
@@ -41,8 +41,17 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Block publish unless the latest dev validate run for this site is green.
+  # See .github/workflows/infra-publish-guard.yml for guard semantics.
+  guard:
+    name: '🛡️ Validate-Dev Green Gate'
+    uses: ./.github/workflows/infra-publish-guard.yml
+    with:
+      validate_workflow: site-validate-dev.yml
+
   build-and-deploy:
     name: '🌐 Deploy Site'
+    needs: [guard]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/site-validate-dev.yml
+++ b/.github/workflows/site-validate-dev.yml
@@ -1,0 +1,148 @@
+name: '🌐 Site · ✅ Validate (Dev)'
+
+# =============================================================================
+# Unified Site — Content & Build Validation
+# =============================================================================
+#
+# Validates the unified mlsysbook.ai landing site (landing + about + community
+# + newsletter) before the preview/publish workflows ever touch it.
+#
+# Flow:
+#   1. BUILD_SITE   — Quarto render of the unified site
+#   2. CHECK_LINKS  — Lychee external-link reachability (Tier 2, non-blocking)
+#   3. SUMMARY      — Aggregate results
+#
+# Why this exists:
+#   site-preview-dev.yml jumps straight to building & SSH-deploying. With no
+#   validation gate the dev preview can land broken. This workflow is the
+#   missing CI counterpart added as part of the staged-rollout safety net.
+#
+# Triggers:
+#   - push: dev branch, site/** or shared/** paths
+#   - pull_request: site/** or shared/** changes
+#   - workflow_dispatch: manual
+#
+# Deploys to: N/A (validate only)
+#
+# Related:
+#   - site-preview-dev.yml  — Dev preview deploy (gates on this passing)
+#   - site-publish-live.yml — Production deploy
+#
+# =============================================================================
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'site/**'
+      - 'shared/**'
+      - '.github/workflows/site-validate-dev.yml'
+      - '.github/workflows/site-preview-dev.yml'
+  push:
+    branches: [dev]
+    paths:
+      - 'site/**'
+      - 'shared/**'
+      - '.github/workflows/site-validate-dev.yml'
+      - '.github/workflows/site-preview-dev.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: site-validate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ===========================================================================
+  # Stage 1: Quarto site build
+  # ===========================================================================
+  build-site:
+    name: '🔨 Build Unified Site'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v6
+
+      - name: 🐍 Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: 📬 Install newsletter sync deps (no API call)
+        run: |
+          pip install -r site/newsletter/requirements.txt
+          # We deliberately do NOT pull from Buttondown here — that requires
+          # a secret and is the deploy workflow's responsibility. We only need
+          # the deps so Quarto can render the newsletter index.
+
+      - name: 🔧 Setup Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+
+      - name: 🔨 Build Unified Site (HTML)
+        working-directory: site
+        run: quarto render
+
+      - name: 🔍 Validate build output
+        run: |
+          MISSING=0
+          for page in index.html about/index.html community/index.html newsletter/index.html; do
+            if [ ! -f "site/_build/$page" ]; then
+              echo "❌ MISSING: $page"
+              MISSING=$((MISSING + 1))
+            fi
+          done
+          if [ "$MISSING" -gt 0 ]; then
+            echo "❌ $MISSING critical pages missing from build."
+            exit 1
+          fi
+          echo "✅ Site built successfully"
+          echo "📊 Build size: $(du -sh site/_build | cut -f1)"
+          echo "📄 Pages: $(find site/_build -name '*.html' | wc -l)"
+
+  # ===========================================================================
+  # Stage 2: Link integrity (Tier 2 — non-blocking baseline)
+  # ===========================================================================
+  # Tier 1 pre-commit (shared/scripts/check-internal-links.py) already blocks
+  # broken internal links + anchors. This Lychee pass adds external
+  # reachability as a warning. Flip fail_on_broken=true once baseline is clean.
+  check-links:
+    name: '🔗 Check Links'
+    uses: ./.github/workflows/infra-link-check.yml
+    with:
+      path_pattern: './site/**/*.qmd'
+      lycheeignore_path: 'shared/config/.lycheeignore'
+      fail_on_broken: false
+      max_concurrency: 8
+
+  # ===========================================================================
+  # Summary
+  # ===========================================================================
+  summary:
+    name: '📊 Summary'
+    runs-on: ubuntu-latest
+    needs: [build-site, check-links]
+    if: always()
+
+    steps:
+      - name: 📊 Generate Summary
+        run: |
+          echo "## 🌐 Unified Site Validation Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Check | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| 🔨 Site Build (HTML) | ${{ needs.build-site.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| 🔗 Link Check | ${{ needs.check-links.result }} (non-blocking) |" >> $GITHUB_STEP_SUMMARY
+
+      - name: ❌ Check for failures
+        run: |
+          if [ "${{ needs.build-site.result }}" = "failure" ]; then
+            echo "❌ Validation failed"
+            exit 1
+          fi
+          if [ "${{ needs.check-links.result }}" = "failure" ]; then
+            echo "⚠️ Link check found issues (non-blocking)"
+          fi
+          echo "✅ Core checks passed"

--- a/.github/workflows/slides-publish-live.yml
+++ b/.github/workflows/slides-publish-live.yml
@@ -43,11 +43,20 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Block publish unless the latest dev validate run for slides is green.
+  # See .github/workflows/infra-publish-guard.yml for guard semantics.
+  guard:
+    name: '🛡️ Validate-Dev Green Gate'
+    uses: ./.github/workflows/infra-publish-guard.yml
+    with:
+      validate_workflow: slides-validate-dev.yml
+
   # ===========================================================================
   # Stage 1: Build all PDFs
   # ===========================================================================
   build-pdfs:
     name: '📄 Build PDFs'
+    needs: [guard]
     runs-on: ubuntu-latest
     timeout-minutes: 60
 

--- a/.github/workflows/slides-validate-dev.yml
+++ b/.github/workflows/slides-validate-dev.yml
@@ -149,12 +149,27 @@ jobs:
           echo "✅ All .tex files pass syntax checks"
 
   # ===========================================================================
+  # Stage 4: Link integrity (Tier 2 — non-blocking baseline)
+  # ===========================================================================
+  # Tier 1 pre-commit (shared/scripts/check-internal-links.py) already blocks
+  # broken internal links + anchors in markdown. This pass adds external
+  # reachability as a warning. Flip fail_on_broken=true once baseline is clean.
+  check-links:
+    name: '🔗 Check Links'
+    uses: ./.github/workflows/infra-link-check.yml
+    with:
+      path_pattern: './slides/**/*.{qmd,md}'
+      lycheeignore_path: 'shared/config/.lycheeignore'
+      fail_on_broken: false
+      max_concurrency: 8
+
+  # ===========================================================================
   # Summary
   # ===========================================================================
   summary:
     name: '📊 Summary'
     runs-on: ubuntu-latest
-    needs: [validate-svgs, build-site, validate-tex]
+    needs: [validate-svgs, build-site, validate-tex, check-links]
     if: always()
 
     steps:
@@ -167,6 +182,7 @@ jobs:
           echo "| 🔍 SVG Validation | ${{ needs.validate-svgs.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| 🔨 Site Build (HTML) | ${{ needs.build-site.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| 🔍 LaTeX Syntax | ${{ needs.validate-tex.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| 🔗 Link Check | ${{ needs.check-links.result }} (non-blocking) |" >> $GITHUB_STEP_SUMMARY
 
       - name: ❌ Check for failures
         run: |
@@ -176,4 +192,7 @@ jobs:
             echo "❌ Validation failed"
             exit 1
           fi
-          echo "✅ All checks passed"
+          if [ "${{ needs.check-links.result }}" = "failure" ]; then
+            echo "⚠️ Link check found issues (non-blocking)"
+          fi
+          echo "✅ Core checks passed"

--- a/.github/workflows/staffml-publish-live.yml
+++ b/.github/workflows/staffml-publish-live.yml
@@ -39,8 +39,17 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Block publish unless the latest dev validate run for this site is green.
+  # See .github/workflows/infra-publish-guard.yml for guard semantics.
+  guard:
+    name: '🛡️ Validate-Dev Green Gate'
+    uses: ./.github/workflows/infra-publish-guard.yml
+    with:
+      validate_workflow: staffml-validate-dev.yml
+
   build-and-deploy:
     name: '🔧 Build & Deploy StaffML'
+    needs: [guard]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/staffml-validate-dev.yml
+++ b/.github/workflows/staffml-validate-dev.yml
@@ -1,0 +1,239 @@
+name: '🎯 StaffML · ✅ Validate (Dev)'
+
+# =============================================================================
+# StaffML — Build & Validation
+# =============================================================================
+#
+# Validates the StaffML Next.js interview-prep app before the preview/publish
+# workflows touch it. Mirrors the build-side checks already done in
+# staffml-preview-dev.yml so they fail fast in CI without paying the deploy
+# cost. Adds a Tier 2 link-check pass.
+#
+# Flow:
+#   1. TYPECHECK_AND_TEST — npm ci + tsc --noEmit + npm test
+#   2. BUILD              — Next.js static export (no deploy)
+#   3. SMOKE              — Vault integrity + corpus invariants
+#   4. CHECK_LINKS        — Lychee external-link reachability (non-blocking)
+#   5. SUMMARY            — Aggregate results
+#
+# Triggers:
+#   - push: dev branch, interviews/staffml/** paths
+#   - pull_request: interviews/staffml/** changes
+#   - workflow_dispatch: manual
+#
+# Deploys to: N/A (validate only)
+#
+# Related:
+#   - staffml-preview-dev.yml  — Dev preview deploy
+#   - staffml-publish-live.yml — Production deploy
+#
+# =============================================================================
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'interviews/staffml/**'
+      - '.github/workflows/staffml-validate-dev.yml'
+      - '.github/workflows/staffml-preview-dev.yml'
+  push:
+    branches: [dev]
+    paths:
+      - 'interviews/staffml/**'
+      - '.github/workflows/staffml-validate-dev.yml'
+      - '.github/workflows/staffml-preview-dev.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: staffml-validate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ===========================================================================
+  # Stage 1: Type-check + unit tests
+  # ===========================================================================
+  typecheck-and-test:
+    name: '🔍 Typecheck + Tests'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v6
+
+      - name: 🔧 Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: interviews/staffml/package-lock.json
+
+      - name: 📦 Install dependencies
+        working-directory: interviews/staffml
+        run: npm ci
+
+      - name: 🔍 Type check
+        working-directory: interviews/staffml
+        run: npx tsc --noEmit
+
+      - name: 🧪 Run tests
+        working-directory: interviews/staffml
+        run: npm test
+
+  # ===========================================================================
+  # Stage 2: Static build (no deploy)
+  # ===========================================================================
+  build:
+    name: '🔨 Build StaffML'
+    runs-on: ubuntu-latest
+    needs: typecheck-and-test
+    timeout-minutes: 15
+
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v6
+
+      - name: 🔧 Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: interviews/staffml/package-lock.json
+
+      - name: 📦 Install dependencies
+        working-directory: interviews/staffml
+        run: npm ci
+
+      - name: 🔨 Build StaffML (static export)
+        working-directory: interviews/staffml
+        env:
+          # Validation-only build; matches dev preview env so we exercise the
+          # same code paths but no deploy follows.
+          NEXT_PUBLIC_BASE_PATH: /cs249r_book_dev/staffml
+          NEXT_PUBLIC_ECOSYSTEM_BASE: https://harvard-edge.github.io/cs249r_book_dev
+        run: npm run build
+
+      - name: 🔍 Validate build output
+        run: |
+          if [ ! -f "interviews/staffml/out/index.html" ]; then
+            echo "❌ CRITICAL: index.html missing from build output."
+            exit 1
+          fi
+          MISSING=0
+          for page in practice gauntlet progress about 404; do
+            if [ ! -f "interviews/staffml/out/${page}.html" ]; then
+              echo "❌ MISSING: ${page}.html"
+              MISSING=$((MISSING + 1))
+            fi
+          done
+          if [ "$MISSING" -gt 0 ]; then
+            echo "❌ $MISSING critical pages missing."
+            exit 1
+          fi
+          echo "✅ StaffML built: $(find interviews/staffml/out -name '*.html' | wc -l) pages"
+
+  # ===========================================================================
+  # Stage 3: Vault integrity + corpus smoke tests
+  # ===========================================================================
+  smoke:
+    name: '🧪 Vault + Corpus Smoke Tests'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v6
+
+      - name: 🐍 Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: 🔐 Validate vault integrity
+        run: python3 interviews/staffml/scripts/validate-vault.py
+
+      - name: 🧪 Corpus invariants
+        run: |
+          python3 - <<'PYEOF'
+          import json, sys
+
+          with open('interviews/staffml/src/data/corpus.json') as f:
+              corpus = json.load(f)
+          assert len(corpus) >= 4000, f'Corpus too small: {len(corpus)} questions'
+          print(f'✅ Corpus: {len(corpus)} questions')
+
+          required = ['id', 'title', 'level', 'track', 'scenario',
+                      'competency_area', 'topic', 'zone', 'details']
+          missing = []
+          for q in corpus:
+              for field in required:
+                  if not q.get(field):
+                      missing.append(f"{q.get('id', '???')} missing {field}")
+          if missing:
+              print(f'⚠️ {len(missing)} questions with missing fields (non-fatal)')
+              for m in missing[:5]:
+                  print(f'   {m}')
+
+          valid_levels = {'L1','L2','L3','L4','L5','L6','L6+'}
+          bad = [q['id'] for q in corpus if q.get('level') not in valid_levels]
+          assert not bad, f'{len(bad)} invalid levels: {bad[:3]}'
+          print('✅ All levels valid (L1-L6+)')
+
+          with open('interviews/staffml/src/data/vault-manifest.json') as f:
+              manifest = json.load(f)
+          assert manifest.get('questionCount') == len(corpus), \
+              f"Manifest count mismatch: {manifest.get('questionCount')} vs {len(corpus)}"
+          print(f"✅ Manifest: v{manifest['version']} ({manifest['questionCount']} Qs)")
+          PYEOF
+
+  # ===========================================================================
+  # Stage 4: Link integrity (Tier 2 — non-blocking baseline)
+  # ===========================================================================
+  # The StaffML app is a Next.js TSX codebase, so the markdown link checker
+  # only catches links inside .md/.mdx prose (READMEs, paper). External link
+  # validation through Lychee covers the rest. Flip fail_on_broken=true once
+  # baseline is clean.
+  check-links:
+    name: '🔗 Check Links'
+    uses: ./.github/workflows/infra-link-check.yml
+    with:
+      path_pattern: './interviews/**/*.{md,mdx,qmd}'
+      lycheeignore_path: 'shared/config/.lycheeignore'
+      fail_on_broken: false
+      max_concurrency: 8
+
+  # ===========================================================================
+  # Summary
+  # ===========================================================================
+  summary:
+    name: '📊 Summary'
+    runs-on: ubuntu-latest
+    needs: [typecheck-and-test, build, smoke, check-links]
+    if: always()
+
+    steps:
+      - name: 📊 Generate Summary
+        run: |
+          echo "## 🎯 StaffML Validation Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Check | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| 🔍 Typecheck + Tests | ${{ needs.typecheck-and-test.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| 🔨 Build | ${{ needs.build.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| 🧪 Vault Smoke Tests | ${{ needs.smoke.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| 🔗 Link Check | ${{ needs.check-links.result }} (non-blocking) |" >> $GITHUB_STEP_SUMMARY
+
+      - name: ❌ Check for failures
+        run: |
+          if [ "${{ needs.typecheck-and-test.result }}" = "failure" ] || \
+             [ "${{ needs.build.result }}" = "failure" ] || \
+             [ "${{ needs.smoke.result }}" = "failure" ]; then
+            echo "❌ Validation failed"
+            exit 1
+          fi
+          if [ "${{ needs.check-links.result }}" = "failure" ]; then
+            echo "⚠️ Link check found issues (non-blocking)"
+          fi
+          echo "✅ Core checks passed"

--- a/.github/workflows/tinytorch-publish-live.yml
+++ b/.github/workflows/tinytorch-publish-live.yml
@@ -72,9 +72,21 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Block publish unless the latest dev validate run for tinytorch is green.
+  # NB: the existing `preflight` job re-runs validate-dev against this commit
+  # in-band; this guard is the cheaper outer check that the dev branch *was*
+  # green before someone clicked Publish, so we fail fast on stale dev.
+  guard:
+    name: '🛡️ Validate-Dev Green Gate'
+    if: github.event.inputs.confirm == 'PUBLISH'
+    uses: ./.github/workflows/infra-publish-guard.yml
+    with:
+      validate_workflow: tinytorch-validate-dev.yml
+
   validate-inputs:
     name: '🔍 Validate Inputs'
     runs-on: ubuntu-latest
+    needs: [guard]
     timeout-minutes: 5
     if: github.event.inputs.confirm == 'PUBLISH'
     outputs:

--- a/.github/workflows/tinytorch-validate-dev.yml
+++ b/.github/workflows/tinytorch-validate-dev.yml
@@ -484,12 +484,28 @@ jobs:
           ./bin/tito dev test --user-journey --ci
 
   # ===========================================================================
+  # Stage 8: Link integrity (Tier 2 — non-blocking baseline)
+  # ===========================================================================
+  # Tier 1 pre-commit (shared/scripts/check-internal-links.py) already blocks
+  # broken internal links + anchors in markdown. This pass adds external
+  # reachability as a warning across the Quarto site. Flip fail_on_broken=true
+  # once the baseline is clean.
+  stage-8-links:
+    name: 🔗 Stage 8 · Link Check
+    uses: ./.github/workflows/infra-link-check.yml
+    with:
+      path_pattern: './tinytorch/site-quarto/**/*.qmd'
+      lycheeignore_path: 'shared/config/.lycheeignore'
+      fail_on_broken: false
+      max_concurrency: 8
+
+  # ===========================================================================
   # Summary: Collect and report all results
   # ===========================================================================
   summary:
     name: 📊 Summary
     runs-on: ubuntu-latest
-    needs: [configure, stage-1-inline, stage-2-unit, stage-3-integration, stage-4-cli, stage-5-e2e, stage-6-fresh-install, stage-7-user-journey]
+    needs: [configure, stage-1-inline, stage-2-unit, stage-3-integration, stage-4-cli, stage-5-e2e, stage-6-fresh-install, stage-7-user-journey, stage-8-links]
     if: always()
 
     steps:
@@ -585,6 +601,13 @@ jobs:
           else
             echo "| 7 | 🎓 User Journey | ⏭️ Skipped |" >> $GITHUB_STEP_SUMMARY
           fi
+
+          # Stage 8: Link Check (non-blocking)
+          case "${{ needs.stage-8-links.result }}" in
+            success) echo "| 8 | 🔗 Link Check | ✅ Passed (non-blocking) |" >> $GITHUB_STEP_SUMMARY ;;
+            failure) echo "| 8 | 🔗 Link Check | ⚠️ Issues found (non-blocking) |" >> $GITHUB_STEP_SUMMARY ;;
+            *) echo "| 8 | 🔗 Link Check | ⏭️ ${{ needs.stage-8-links.result }} |" >> $GITHUB_STEP_SUMMARY ;;
+          esac
 
       - name: Check for failures
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,6 +63,32 @@ repos:
         pass_filenames: false
         always_run: true
 
+  # --- Repo-wide internal link integrity (Tier 1 of release-prep link strategy) ---
+  # Validates relative-path markdown links and same-file anchors in changed
+  # .md/.qmd files. External (http/https) links are NOT checked here — that's
+  # Lychee's job in CI (Tier 2 per-site validate, Tier 3 nightly rot scan).
+  # See: shared/scripts/check-internal-links.py for scope and rationale.
+  - repo: local
+    hooks:
+      - id: check-internal-links
+        name: "Repo: Validate internal markdown links + anchors"
+        entry: python3 shared/scripts/check-internal-links.py
+        language: system
+        pass_filenames: true
+        files: \.(md|qmd)$
+        # Exclusions are pre-existing baselines we accept without churn.
+        # Tighten incrementally as those areas are cleaned up.
+        exclude: |
+          (?x)^(
+            _site/|
+            _book/|
+            node_modules/|
+            mlsysim/docs/api/|              # auto-generated quartodoc API stubs
+            tinytorch/site/404\.md$|        # legacy Sphinx 404, replaced by H9
+            slides/tinyml/README-edx-original\.md$|  # legacy edX export, archive
+            tinytorch/tests/.*README\.md$   # GitHub line-range anchors (#L74-L99)
+          )
+
   # ===========================================================================
   # SECTION 2: BOOK HOOKS (quarto content validation)
   # Files: book/quarto/contents/**/*.qmd

--- a/shared/config/.lycheeignore
+++ b/shared/config/.lycheeignore
@@ -1,0 +1,30 @@
+# =============================================================================
+# Shared Lychee ignore patterns (Tier 2 / Tier 3 link checking)
+# =============================================================================
+# Patterns are anchored regexes per Lychee's --exclude-file format.
+# Anything matching a pattern below is silently skipped.
+#
+# Per-site overrides:
+#   If a subsite needs to skip URLs that don't apply to other sites, create
+#   <site>/.lycheeignore and pass `lycheeignore_path: <site>/.lycheeignore`
+#   to infra-link-check.yml. The book site keeps its existing canonical file
+#   at book/config/linting/.lycheeignore (do not duplicate those patterns
+#   here — that file remains authoritative for book content).
+# =============================================================================
+
+# --- Localhost / private network (per-site authors often paste these) ---
+^https?://localhost(:\d+)?(/.*)?$
+^https?://127\.0\.0\.1(:\d+)?(/.*)?$
+^https?://192\.168\.\d+\.\d+(:\d+)?(/.*)?$
+^https?://10\.\d+\.\d+\.\d+(:\d+)?(/.*)?$
+
+# --- Slide decks behind Google auth (return 200 to logged-in users only) ---
+^https://docs\.google\.com/presentation/
+
+# --- Known transient 404s (re-add once content is restored) ---
+^https://www\.reuters\.com/?$
+
+# --- Live preview targets that only exist post-deploy ---
+# (Avoid Lychee chasing the very URL we're about to publish to.)
+^https://harvard-edge\.github\.io/cs249r_book_dev/
+^https://mlsysbook\.ai/

--- a/shared/scripts/check-internal-links.py
+++ b/shared/scripts/check-internal-links.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""Tier 1 link checker: validate internal Markdown / Quarto links offline.
+
+Scope on purpose:
+  - Validate ONLY relative-path links and same-file anchor links inside
+    `.md` / `.qmd` files.
+  - DO NOT touch external URLs (http/https/mailto/tel/...). External
+    reachability is Lychee's job in CI; doing it here would make
+    pre-commit slow and network-flaky.
+
+Why a separate tool from `book/binder`:
+  - The book toolchain owns Quarto cross-references (`@fig-foo`,
+    `@sec-bar`), bibliography keys, label hygiene, etc.
+  - This tool owns plain Markdown link integrity and works repo-wide
+    (every Quarto site, plus loose READMEs).
+
+Usage:
+  python3 shared/scripts/check-internal-links.py            # check the whole repo
+  python3 shared/scripts/check-internal-links.py FILE...    # check named files
+  python3 shared/scripts/check-internal-links.py --staged   # check git-staged files
+  python3 shared/scripts/check-internal-links.py --quiet    # only print failures
+
+Exit codes:
+  0  every internal link resolves
+  1  one or more broken internal links (printed file:line: detail)
+  2  invocation error
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Directories we never validate links in.
+EXCLUDE_DIRS = {
+    ".git",
+    ".venv",
+    "node_modules",
+    "_site",
+    "_book",
+    "_build",
+    ".quarto",
+    "htmlcov",
+    "site-packages",
+    # Per-stage build outputs and vendored extensions:
+    "_freeze",
+    "_extensions",
+    # The dev preview mirror gets very large and is a copy of generated HTML.
+    "_archive",
+}
+
+# File globs we walk when no explicit list is given.
+DEFAULT_GLOBS = ("**/*.md", "**/*.qmd")
+
+# Match Markdown inline links: [text](target) and image links: ![alt](target).
+# - target may be wrapped in <...> for spaces (rare, but handle it).
+# - Not greedy on the [...] part; nested brackets in link text are unusual
+#   in our content and would need a pure-PEG parser to handle safely.
+LINK_RE = re.compile(
+    r"(?P<bang>!?)\[(?P<text>[^\]]*)\]\((?P<target><[^>]+>|[^)\s]+)(?:\s+\"[^\"]*\")?\)"
+)
+
+# Match a fenced-code-block opener/closer: ``` or ~~~ optionally followed by
+# an info string. Quarto/Pandoc allow attribute braces (```{python}) too.
+FENCE_OPEN_RE = re.compile(r"^(?P<indent>\s{0,3})(?P<fence>`{3,}|~{3,})(?P<info>.*)$")
+
+# Strip inline code spans `...` so a backticked target like `[x](y)` inside
+# a paragraph isn't treated as a link.
+INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
+
+# Match explicit Quarto / Pandoc anchor syntax inside headings:
+#   ## My Header {#sec-foo}
+ANCHOR_ATTR_RE = re.compile(r"\{#(?P<id>[^\s}]+)[^}]*\}")
+
+# Match ATX headings to derive their slugified id.
+HEADING_RE = re.compile(r"^(#{1,6})\s+(?P<heading>.+?)\s*$", re.MULTILINE)
+
+# Strip Quarto callouts and cross-ref macros from headings before slugifying.
+HEADING_CLEAN_RE = re.compile(r"\{[^}]*\}|`[^`]*`")
+
+# Schemes that are external and out of scope for this checker.
+EXTERNAL_SCHEMES = (
+    "http://",
+    "https://",
+    "mailto:",
+    "tel:",
+    "ftp://",
+    "ftps://",
+    "ssh://",
+    "git://",
+    "data:",
+    "javascript:",
+)
+
+
+@dataclass(frozen=True)
+class Problem:
+    file: Path
+    line: int
+    target: str
+    detail: str
+
+    def render(self, root: Path) -> str:
+        try:
+            rel = self.file.relative_to(root)
+        except ValueError:
+            rel = self.file
+        return f"{rel}:{self.line}: broken link → {self.target!r} ({self.detail})"
+
+
+def slugify(heading: str) -> str:
+    """Approximate Pandoc's `--id-prefix=section` slug for an ATX heading.
+
+    Matches Pandoc's `auto_identifiers` extension well enough for our content:
+      - Strip leading non-alphanumerics.
+      - Replace whitespace with single hyphens.
+      - Lowercase.
+      - Drop chars that aren't alnum, hyphen, underscore, period, or colon.
+    """
+    cleaned = HEADING_CLEAN_RE.sub("", heading).strip()
+    # Pandoc strips leading non-letter characters from the slug.
+    cleaned = re.sub(r"^[^A-Za-z]+", "", cleaned)
+    cleaned = cleaned.lower()
+    cleaned = re.sub(r"\s+", "-", cleaned)
+    cleaned = re.sub(r"[^a-z0-9_\-.:]", "", cleaned)
+    return cleaned
+
+
+def collect_anchors(text: str) -> set[str]:
+    """Return the set of anchor ids defined in the given Markdown source.
+
+    Combines:
+      - Explicit `{#id}` attributes anywhere in the document.
+      - Auto-generated heading slugs.
+    """
+    anchors: set[str] = set()
+
+    for m in ANCHOR_ATTR_RE.finditer(text):
+        anchors.add(m.group("id"))
+
+    for m in HEADING_RE.finditer(text):
+        heading = m.group("heading").strip()
+        # If a heading already declares {#id}, the explicit id wins; capture it
+        # AND skip the slugified form because the auto slug isn't generated.
+        explicit = ANCHOR_ATTR_RE.search(heading)
+        if explicit:
+            continue
+        slug = slugify(heading)
+        if slug:
+            anchors.add(slug)
+
+    return anchors
+
+
+def is_external(target: str) -> bool:
+    return target.startswith(EXTERNAL_SCHEMES)
+
+
+def split_target(target: str) -> tuple[str, str]:
+    """Split a link target into (path, anchor)."""
+    if target.startswith("<") and target.endswith(">"):
+        target = target[1:-1]
+    if "#" not in target:
+        return target, ""
+    path, _, anchor = target.partition("#")
+    return path, anchor
+
+
+def candidate_paths(source: Path, raw: str) -> list[Path]:
+    """Return possible filesystem paths a link target could resolve to.
+
+    Quarto sites resolve relative links against the file's directory, but
+    `.qmd` files often link to a sibling without the extension (the rendered
+    output is `.html`). We also accept `index.qmd` shorthand for directory
+    targets.
+    """
+    if not raw:
+        return []
+    base = source.parent
+    if raw.startswith("/"):
+        # Site-absolute paths are resolved at render time and depend on the
+        # site's configured `site-url` / base path. We can't validate them
+        # offline reliably, so skip with a soft pass.
+        return []
+
+    raw_path = Path(raw)
+    candidates = [base / raw_path]
+    # Sometimes authors write `foo` when they mean `foo.qmd` (rendered as
+    # `foo.html`). Only meaningful when raw has no extension.
+    if not raw_path.suffix:
+        candidates.append((base / raw_path).with_suffix(".qmd"))
+        candidates.append((base / raw_path).with_suffix(".md"))
+        candidates.append((base / raw_path).with_suffix(".html"))
+        candidates.append(base / raw_path / "index.qmd")
+        candidates.append(base / raw_path / "index.md")
+    elif raw_path.suffix == ".html":
+        # `foo.html` in source most likely points at sibling `foo.qmd`.
+        candidates.append((base / raw_path).with_suffix(".qmd"))
+        candidates.append((base / raw_path).with_suffix(".md"))
+
+    return candidates
+
+
+def file_text_cache() -> "dict[Path, str]":
+    return {}
+
+
+def read(path: Path, cache: dict[Path, str]) -> str | None:
+    if path in cache:
+        return cache[path]
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    cache[path] = text
+    return text
+
+
+def check_file(path: Path, cache: dict[Path, str]) -> list[Problem]:
+    if not path.exists():
+        return [Problem(path, 0, "", "file does not exist")]
+    text = read(path, cache)
+    if text is None:
+        return [Problem(path, 0, "", "file unreadable as UTF-8")]
+
+    own_anchors = collect_anchors(text)
+    problems: list[Problem] = []
+
+    in_fence = False
+    fence_marker: str | None = None  # The exact `` `... `` or `~~~...` that opened the block.
+
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        # Track fenced code blocks (``` or ~~~). Inside a fence, skip all link
+        # parsing — TikZ, raw LaTeX, and code samples otherwise produce piles of
+        # false positives that look like Markdown links.
+        fence_match = FENCE_OPEN_RE.match(line)
+        if fence_match:
+            marker = fence_match.group("fence")[0] * 3  # normalize length to 3
+            if not in_fence:
+                in_fence = True
+                fence_marker = marker
+            elif fence_marker is not None and line.lstrip().startswith(fence_marker):
+                in_fence = False
+                fence_marker = None
+            continue
+        if in_fence:
+            continue
+
+        # Strip inline code so backticked link-shaped strings don't trip us.
+        scan_line = INLINE_CODE_RE.sub("", line)
+
+        for m in LINK_RE.finditer(scan_line):
+            target = m.group("target")
+            if not target or is_external(target):
+                continue
+            path_part, anchor = split_target(target)
+
+            if not path_part:
+                # Pure same-file anchor.
+                if anchor and anchor not in own_anchors:
+                    problems.append(
+                        Problem(path, line_no, target, "anchor not found in this file")
+                    )
+                continue
+
+            cands = candidate_paths(path, path_part)
+            if not cands:
+                continue  # Site-absolute or unparseable; skip.
+
+            resolved = next((c for c in cands if c.exists()), None)
+            if resolved is None:
+                problems.append(
+                    Problem(path, line_no, target, f"no such file (checked {len(cands)} candidate paths)")
+                )
+                continue
+
+            if anchor:
+                target_text = read(resolved, cache)
+                if target_text is None:
+                    # File exists but isn't text we can scan (e.g. a binary).
+                    # Treat anchor as opaque; don't flag.
+                    continue
+                target_anchors = collect_anchors(target_text)
+                if anchor not in target_anchors:
+                    problems.append(
+                        Problem(path, line_no, target, f"anchor #{anchor} not found in {resolved.name}")
+                    )
+
+    return problems
+
+
+def staged_files(root: Path) -> list[Path]:
+    cmd = ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"]
+    try:
+        out = subprocess.check_output(cmd, cwd=root, text=True)
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        sys.stderr.write(f"check-internal-links: failed to list staged files: {exc}\n")
+        sys.exit(2)
+
+    files = []
+    for line in out.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if not (line.endswith(".md") or line.endswith(".qmd")):
+            continue
+        files.append((root / line).resolve())
+    return files
+
+
+def discover_files(root: Path) -> list[Path]:
+    files: list[Path] = []
+    for glob in DEFAULT_GLOBS:
+        for candidate in root.glob(glob):
+            if any(part in EXCLUDE_DIRS for part in candidate.parts):
+                continue
+            files.append(candidate)
+    return files
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("files", nargs="*", help="Specific .md/.qmd files to check.")
+    parser.add_argument("--staged", action="store_true", help="Check files staged for commit.")
+    parser.add_argument("--quiet", "-q", action="store_true", help="Only print failures.")
+    parser.add_argument(
+        "--exclude",
+        action="append",
+        default=[],
+        metavar="GLOB",
+        help="Exclude files whose repo-relative path matches this glob. Repeatable.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.staged and args.files:
+        parser.error("--staged is mutually exclusive with explicit FILES.")
+
+    root = REPO_ROOT
+    if args.staged:
+        files = staged_files(root)
+    elif args.files:
+        files = []
+        for raw in args.files:
+            p = Path(raw)
+            if not p.is_absolute():
+                p = (root / p).resolve()
+            if p.suffix not in (".md", ".qmd"):
+                continue
+            if any(part in EXCLUDE_DIRS for part in p.parts):
+                continue
+            files.append(p)
+    else:
+        files = discover_files(root)
+
+    if args.exclude:
+        import fnmatch
+
+        kept = []
+        for f in files:
+            try:
+                rel = str(f.relative_to(root))
+            except ValueError:
+                rel = str(f)
+            if any(fnmatch.fnmatch(rel, pat) for pat in args.exclude):
+                continue
+            kept.append(f)
+        files = kept
+
+    if not files:
+        if not args.quiet:
+            print("check-internal-links: no .md/.qmd files to check.")
+        return 0
+
+    cache: dict[Path, str] = {}
+    all_problems: list[Problem] = []
+    for path in sorted(set(files)):
+        all_problems.extend(check_file(path, cache))
+
+    if all_problems:
+        for prob in all_problems:
+            print(prob.render(root))
+        print(f"\ncheck-internal-links: {len(all_problems)} broken internal link(s) in {len({p.file for p in all_problems})} file(s).", file=sys.stderr)
+        return 1
+
+    if not args.quiet:
+        print(f"check-internal-links: OK ({len(files)} file(s) scanned).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

The first of five logical PRs that make up the staged-rollout foundation
for the new mlsysbook.ai ecosystem properties. This PR is the safety
net layer — three tiers of link checking plus a publish-guard so that
no `*-publish-live` workflow can deploy without a recent green
`*-validate-dev` run.

Nothing in this PR ships content; everything is plumbing.

### What's in this PR

**Tier 1 — pre-commit (instant, local).** New
`shared/scripts/check-internal-links.py` runs against staged `.md`/`.qmd`
files only, validates internal links + anchors, skips fenced code
blocks and inline code (so TikZ snippets etc. don't false-positive),
and is wired into `.pre-commit-config.yaml` with an `exclude` list for
known legacy / auto-generated paths.

**Tier 2 — per-subsite CI (every PR + every dev push).** Generalized
`.github/workflows/infra-link-check.yml` to take site-specific args
(`include_pattern`, `lycheeignore_path`, `accept_status`,
`fail_on_broken`). Every `*-validate-dev.yml` now invokes it as a
`check-links` job. Created `site-validate-dev.yml` and
`staffml-validate-dev.yml` for the two subsites that lacked validate
workflows. Universal exclusions live in `shared/config/.lycheeignore`.

**Publish guard.** New `.github/workflows/infra-publish-guard.yml`
blocks every `*-publish-live.yml` from running unless the latest
`*-validate-dev.yml` run on `dev` is green and recent (configurable
`max_age_minutes`, default 60). Wired as the first job of each publish
workflow.

**Tier 3 — nightly link-rot tracker.** New
`.github/workflows/infra-link-rot-nightly.yml` sweeps every subsite at
04:30 UTC and aggregates findings into a single sticky GitHub issue
(label `link-rot`). Each run replaces the issue body and appends a
comment, so the issue is the always-current dashboard.

### Risk surface

Tier 1 + Tier 2 are non-blocking by default (`fail_on_broken: false`)
so existing baseline failures don't immediately gate merges; we can
flip the flag per-subsite as backlogs are cleared. **Publish guards
CAN block** on green dev — that's the whole point.

### Verification done locally

- YAML schema validation on every modified/created workflow.
- `python3 .github/scripts/check_workflow_fork_safety.py` on all five
  new/modified workflows — clean.
- `check-internal-links.py` exercised against a real `.qmd` file.
- Pre-commit hook smoke-tested on the script itself (correctly skips
  non-md files).

### Verification still pending in this PR's CI

- The reusable workflows running on a real PR (this one). Specifically
  watching whether:
  - Lychee accepts `shared/config/.lycheeignore` patterns.
  - The per-site `include_pattern` globs match what we think they
    match.
  - The publish-guard's GitHub-API query syntax actually works (it's
    only invoked on workflow_dispatch, so this PR exercises everything
    EXCEPT the guard — that gets exercised the first time someone
    clicks "Run" on a `*-publish-live` workflow).

### What this PR does NOT change

- Nothing under `book/`, `tinytorch/`, `labs/`, `kits/`, etc. The
  source content is untouched.
- No publish workflow's deploy logic — only added a `guard` job before
  existing logic runs.
- No release-version state.

### Test plan

- [ ] CI: `book-validate-dev` runs to completion, including the new
      `check-links` job.
- [ ] CI: `tinytorch-validate-dev`, `labs-validate-dev`,
      `kits-validate-dev`, `mlsysim-validate-dev` all pass with
      check-links.
- [ ] CI: `site-validate-dev` and `staffml-validate-dev` (newly
      created) at least start and report.
- [ ] Pre-commit hook installs and runs on a sample staged `.qmd`
      change without hanging.
- [ ] Read-through of the link-check job summary in Actions UI to
      confirm Lychee output is interpretable.

### Followup

Four more PRs on the existing release-prep work. Tracked in
`RELEASE-PREP.md` (not in this PR — comes with PR-3).