### PR TITLE
PR-2: Visual polish (announcement bars, theme persistence, dev-mirror fix, audit script)

### DIFF
--- a/.github/scripts/rewrite-dev-urls.sh
+++ b/.github/scripts/rewrite-dev-urls.sh
@@ -38,17 +38,38 @@ declare -A SUBSITES=(
 )
 
 # ── Compute prefix ────────────────────────────────────────────────────────────
-# Content at the dev root needs no "../" prefix; subsites need "../" to reach siblings.
+# PREFIX is the number of "../" hops needed to climb from the *current build
+# location* on dev back to the dev site root. It depends on how deep the
+# subsite lives on dev, NOT on the mlsysbook.ai key. e.g. vol1 lives at
+# /book/vol1/ on dev → 2 hops → PREFIX="../../". This was previously hard-
+# coded to "../" which broke nested subsites (vol1, vol2) — every cross-site
+# link, including the navbar title-href, landed one level too shallow.
+#
+# SELF_PREFIX is "./" — a self-link rewrites to the current dir.
+SELF_PREFIX="./"
 if [[ "$SUBSITE" == "root" ]]; then
   PREFIX=""
-  SELF_PREFIX="./"
 else
-  PREFIX="../"
-  SELF_PREFIX="./"
+  # Note: under `set -u`, indexing an associative array with a missing key
+  # triggers an unbound-variable error in some bash builds. Probe with the
+  # `key in array` test instead of parameter-expansion default.
+  found=0
+  for k in "${!SUBSITES[@]}"; do
+    [[ "$k" == "$SUBSITE" ]] && { found=1; break; }
+  done
+  if [[ "$found" -eq 0 ]]; then
+    echo "❌ Unknown subsite '$SUBSITE'. Add it to SUBSITES in rewrite-dev-urls.sh." >&2
+    exit 1
+  fi
+  SELF_DEV_PATH="${SUBSITES[$SUBSITE]}"
+  # Depth = number of path segments in the dev-side path (book/vol1 → 2).
+  DEPTH=$(awk -F/ '{print NF}' <<< "$SELF_DEV_PATH")
+  PREFIX=""
+  for ((i = 0; i < DEPTH; i++)); do PREFIX+="../"; done
 fi
 
 # ── Rewrite ───────────────────────────────────────────────────────────────────
-echo "🔗 Rewriting mlsysbook.ai URLs for dev site (subsite=$SUBSITE)..."
+echo "🔗 Rewriting mlsysbook.ai URLs for dev site (subsite=$SUBSITE, prefix='$PREFIX')..."
 
 FIND_DEPTH=""
 if [[ "$SHALLOW" == "--shallow" ]]; then
@@ -58,14 +79,17 @@ fi
 find "$BUILD_DIR" $FIND_DEPTH -name "*.html" -type f | while read -r f; do
   for key in "${!SUBSITES[@]}"; do
     dev_path="${SUBSITES[$key]}"
-    if [[ "$SUBSITE" != "root" && "$dev_path" == "$SUBSITE" ]]; then
-      # Self-links: mlsysbook.ai/slides/ → ./ (when building slides)
+    # Self-link match is by mlsysbook.ai key, not dev_path. Previously this
+    # compared dev_path to SUBSITE which silently failed for nested subsites.
+    if [[ "$SUBSITE" != "root" && "$key" == "$SUBSITE" ]]; then
+      # Self-links: mlsysbook.ai/<key>/ → ./ (when building <key>)
       sed -i "s|https://mlsysbook.ai/${key}/|${SELF_PREFIX}|g" "$f"
     else
       sed -i "s|https://mlsysbook.ai/${key}/|${PREFIX}${dev_path}/|g" "$f"
     fi
   done
-  # Catch-all: any remaining mlsysbook.ai/ base URL → dev root
+  # Catch-all: any remaining mlsysbook.ai/ base URL → dev root.
+  # (Used by the navbar title-href and footer site links.)
   if [[ "$SUBSITE" == "root" ]]; then
     sed -i 's|https://mlsysbook.ai/|./|g' "$f"
   else

--- a/book/quarto/config/_quarto-html-vol1.yml
+++ b/book/quarto/config/_quarto-html-vol1.yml
@@ -224,6 +224,6 @@ metadata-files:
   - config/shared/html/filters.yml
   - config/shared/html/filter-metadata.yml
   - config/shared/vol1/filter-metadata-paths.yml
-  - config/shared/html/announcement.yml
+  - config/shared/html/announcement-vol1.yml
   - ../../shared/config/navbar-common.yml
   - config/shared/html/footer-common.yml

--- a/book/quarto/config/_quarto-html-vol2.yml
+++ b/book/quarto/config/_quarto-html-vol2.yml
@@ -227,6 +227,6 @@ metadata-files:
   - config/shared/html/filters.yml
   - config/shared/html/filter-metadata.yml
   - config/shared/vol2/filter-metadata-paths.yml
-  - config/shared/html/announcement.yml
+  - config/shared/html/announcement-vol2.yml
   - ../../shared/config/navbar-common.yml
   - config/shared/html/footer-common.yml

--- a/book/quarto/config/shared/html/announcement-vol1.yml
+++ b/book/quarto/config/shared/html/announcement-vol1.yml
@@ -1,0 +1,24 @@
+# =============================================================================
+# ANNOUNCEMENT BAR — Volume I (Foundations)
+# =============================================================================
+# Audience: students + instructors meeting the textbook for the first time.
+# Color:    inherits Harvard Crimson via $accent (set in theme-harvard.scss
+#           and consumed by .announcement / .alert-primary in _base-styles.scss).
+#           Do NOT hard-code colors here — let the theme drive it so a brand
+#           change in shared/styles/_brand.scss propagates automatically.
+#
+# To edit Vol II's bar (ETH-blue tint, scale-focused copy):
+#   book/quarto/config/shared/html/announcement-vol2.yml
+# =============================================================================
+
+website:
+  announcement:
+    icon: megaphone
+    dismissable: true
+    type: primary
+    position: below-navbar
+    content: |
+      🎉 **NEW: Two volumes!** [Vol I: Foundations](https://mlsysbook.ai/vol1/) · [Vol II: At Scale](https://mlsysbook.ai/vol2/) — open access, free forever.<br>
+      🔥 **TinyTorch:** Build your own ML framework from scratch. [Start →](https://mlsysbook.ai/tinytorch/)<br>
+      📦 **Hardware Kits:** Arduino, Seeed & Raspberry Pi labs. [Explore →](https://mlsysbook.ai/kits/)<br>
+      📬 **Newsletter:** ML Systems insights & updates. [Subscribe →](#subscribe)

--- a/book/quarto/config/shared/html/announcement-vol2.yml
+++ b/book/quarto/config/shared/html/announcement-vol2.yml
@@ -1,0 +1,24 @@
+# =============================================================================
+# ANNOUNCEMENT BAR — Volume II (At Scale)
+# =============================================================================
+# Audience: practitioners and advanced students reading the scale volume.
+# Color:    inherits ETH Blue via $accent (set in theme-eth.scss and consumed
+#           by .announcement / .alert-primary in _base-styles.scss). The bar
+#           therefore renders as a soft ETH-blue tint with an ETH-blue accent
+#           border — visually distinct from Vol I's crimson bar.
+#           Do NOT hard-code colors here — keep the theme as the single source.
+#
+# Sibling: book/quarto/config/shared/html/announcement-vol1.yml
+# =============================================================================
+
+website:
+  announcement:
+    icon: megaphone
+    dismissable: true
+    type: primary
+    position: below-navbar
+    content: |
+      🚀 **NEW: Volume II — At Scale.** Distributed training, fleet operations, and responsible deployment. [Start reading →](https://mlsysbook.ai/vol2/)<br>
+      📘 **First time here?** Start with [Volume I: Foundations](https://mlsysbook.ai/vol1/) — open access, free forever.<br>
+      🔥 **Build alongside the book:** [TinyTorch](https://mlsysbook.ai/tinytorch/) · [Hardware Kits](https://mlsysbook.ai/kits/) · [MLSys·im](https://mlsysbook.ai/mlsysim/)<br>
+      📬 **Newsletter:** ML Systems insights & updates. [Subscribe →](#subscribe)

--- a/book/quarto/config/shared/html/announcement.yml
+++ b/book/quarto/config/shared/html/announcement.yml
@@ -1,17 +1,16 @@
 # =============================================================================
-# ANNOUNCEMENT BAR CONFIGURATION - PRODUCTION
+# DEPRECATED — split into announcement-vol1.yml + announcement-vol2.yml
 # =============================================================================
-# This file contains announcement bar configuration for HTML site builds.
+# This file is kept as a no-op so old references (if any) don't 404 the
+# include resolver. Do not add new content here. Edit the volume-specific
+# file instead so the per-volume tint and copy stay correct.
+#
+#   Vol I (Crimson):  book/quarto/config/shared/html/announcement-vol1.yml
+#   Vol II (ETH Blue): book/quarto/config/shared/html/announcement-vol2.yml
+#
+# Once both volumes have shipped under mlsysbook.ai/vol{1,2}/ and we are
+# confident no external metadata reference remains, this file can be
+# removed entirely.
 # =============================================================================
 
-website:
-  announcement:
-    icon: megaphone
-    dismissable: true
-    type: primary
-    position: below-navbar
-    content: |
-      🎉 **NEW: Two volumes!** [Vol I: Introduction](https://mlsysbook.ai/vol1/) · [Vol II: Advanced](https://mlsysbook.ai/vol2/) — open access, free forever.<br>
-      🔥 **TinyTorch:** Build your own ML framework from scratch. [Start →](https://mlsysbook.ai/tinytorch)<br>
-      📦 **Hardware Kits:** Arduino, Seeed & Raspberry Pi labs. [Explore →](https://mlsysbook.ai/kits)<br>
-      📬 **Newsletter:** ML Systems insights & updates. [Subscribe →](#subscribe)
+website: {}

--- a/interviews/staffml/public/theme-bootstrap.js
+++ b/interviews/staffml/public/theme-bootstrap.js
@@ -8,14 +8,32 @@
 // Lives in /public so it ships as a same-origin static asset, which lets us
 // drop 'unsafe-inline' from the document CSP without losing the theme
 // bootstrap. See src/app/layout.tsx for the matching <script> tag.
+//
+// Cross-site interop:
+//   The Quarto-built ecosystem subsites (book, labs, kits, slides, ...)
+//   persist the user's choice under the localStorage key
+//   `quarto-color-scheme`. We read that key as a secondary source when
+//   StaffML has no preference of its own, so a user who toggled dark mode
+//   on the book lands here in dark mode on first visit.
+//
+//   The matching write-back lives in the StaffML theme toggle (see
+//   src/components/Providers.tsx / theme hook) — when the user toggles
+//   here we mirror the choice into `quarto-color-scheme`, so navigating
+//   onward to the book inherits the StaffML choice.
 (function () {
-  try {
-    var t = localStorage.getItem("staffml_theme");
-    if (t !== "light" && t !== "dark") t = "dark";
-    document.documentElement.dataset.theme = t;
-  } catch (_) {
-    // localStorage may be unavailable (privacy mode, sandboxed iframe).
-    // Fall back to the dark default that matches the SSR markup.
-    document.documentElement.dataset.theme = "dark";
+  function pick() {
+    try {
+      var t = localStorage.getItem("staffml_theme");
+      if (t === "light" || t === "dark") return t;
+      // Fall back to the ecosystem-shared key set by Quarto sites.
+      var q = localStorage.getItem("quarto-color-scheme");
+      if (q === "light" || q === "dark") return q;
+    } catch (_) {
+      /* localStorage unavailable (privacy mode, sandboxed iframe). */
+    }
+    // SSR markup is rendered with `data-theme="dark"`, so default to dark
+    // here too — keeps first paint consistent.
+    return "dark";
   }
+  document.documentElement.dataset.theme = pick();
 })();

--- a/interviews/staffml/src/components/ThemeProvider.tsx
+++ b/interviews/staffml/src/components/ThemeProvider.tsx
@@ -18,10 +18,20 @@ export function useTheme() {
   return useContext(ThemeContext);
 }
 
+// Cross-site interop with the Quarto-built ecosystem: those subsites store
+// the user's choice under `quarto-color-scheme`. We mirror in both
+// directions so a user toggling on the book lands in dark mode here, and
+// vice versa. Keep the key string in sync with shared/scripts/theme-persist.js
+// and shared/config/site-head.html.
+const QUARTO_KEY = "quarto-color-scheme";
+
 function getInitialTheme(): Theme {
   if (typeof window === "undefined") return "dark";
   const stored = localStorage.getItem("staffml_theme") as Theme | null;
   if (stored === "light" || stored === "dark") return stored;
+  // Secondary source: pick up the choice last set on a sibling subsite.
+  const fromQuarto = localStorage.getItem(QUARTO_KEY) as Theme | null;
+  if (fromQuarto === "light" || fromQuarto === "dark") return fromQuarto;
   // Dark is the site-wide default. OS preference is intentionally NOT
   // honored — users can opt into light via the theme toggle.
   return "dark";
@@ -42,7 +52,14 @@ export default function ThemeProvider({ children }: { children: React.ReactNode 
     setTheme((prev) => {
       const next = prev === "dark" ? "light" : "dark";
       document.documentElement.dataset.theme = next;
-      localStorage.setItem("staffml_theme", next);
+      try {
+        localStorage.setItem("staffml_theme", next);
+        // Mirror to the ecosystem-shared key so Quarto subsites (book,
+        // labs, kits, slides, ...) inherit the choice on next nav.
+        localStorage.setItem(QUARTO_KEY, next);
+      } catch (_) {
+        /* localStorage unavailable; in-memory state still updates. */
+      }
       return next;
     });
   }, []);

--- a/shared/config/site-head.html
+++ b/shared/config/site-head.html
@@ -1,6 +1,52 @@
 <!-- Shared head includes — MLSysBook ecosystem -->
 
 <!--
+  theme-persist (inline, sync) — applies stored color-scheme before first paint.
+  Inlined deliberately: runs before any other <script>, no extra round-trip,
+  and avoids per-subsite asset path differences. Canonical source:
+  shared/scripts/theme-persist.js (kept identical for documentation/testability).
+  If you change one, mirror the change to the other.
+-->
+<script>
+(function () {
+  'use strict';
+  var STORAGE_KEY = 'quarto-color-scheme';
+  function preferredScheme() {
+    try {
+      var stored = window.localStorage.getItem(STORAGE_KEY);
+      if (stored === 'dark' || stored === 'light') return stored;
+    } catch (e) {}
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      return 'dark';
+    }
+    return 'light';
+  }
+  function apply(scheme) {
+    var html = document.documentElement;
+    if (!html) return;
+    html.setAttribute('data-bs-theme', scheme);
+    html.setAttribute('data-quarto-color-scheme', scheme);
+    html.style.colorScheme = scheme;
+  }
+  apply(preferredScheme());
+  window.addEventListener('storage', function (ev) {
+    if (ev.key !== STORAGE_KEY) return;
+    var next = ev.newValue;
+    if (next !== 'dark' && next !== 'light') return;
+    apply(next);
+  });
+  if (window.matchMedia) {
+    try {
+      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function (ev) {
+        try { if (window.localStorage.getItem(STORAGE_KEY)) return; } catch (e) {}
+        apply(ev.matches ? 'dark' : 'light');
+      });
+    } catch (e) {}
+  }
+})();
+</script>
+
+<!--
   Build-stamp styling. Tiny, neutral, dark-mode aware. The actual stamp text
   is injected by shared/scripts/inject-build-stamp.sh into footer markup
   containing the literal `<!-- MLSB_BUILD_STAMP -->` token.

--- a/shared/scripts/site-audit.mjs
+++ b/shared/scripts/site-audit.mjs
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+/* =============================================================================
+ * site-audit.mjs — release-prep visual / structural QA across all subsites
+ * =============================================================================
+ *
+ * One Playwright-driven audit script that the release-prep plan needs three
+ * times over (sidebar present + visible, dark-mode renders cleanly, no
+ * broken images / scripts). Implemented as a single CLI with subcommands so
+ * the shared boilerplate (browser launch, URL list, output dirs, screenshot
+ * naming) stays in one place.
+ *
+ * Subcommands
+ * -----------
+ *   sidebar    Assert every site URL exposes a populated, visible <#quarto-sidebar>.
+ *              Skips URLs known to be sidebar-less (landing pages, StaffML).
+ *
+ *   darkmode   Toggle dark mode, scroll the page top→bottom, and screenshot
+ *              into _audit/darkmode/<host>/<path>.png. Manual review surfaces
+ *              "half-themed" widgets that CSS lints can't find.
+ *
+ *   assets     Listen for failed network requests (images, scripts, fonts)
+ *              and report any 4xx/5xx or DNS failures. Catches broken
+ *              <img src> embeds (TinyTorch PDF viewer, Vol II cover) and
+ *              missing fonts/styles before they hit production.
+ *
+ * Usage
+ * -----
+ *   node shared/scripts/site-audit.mjs <subcommand> [--target dev|live|local] \
+ *        [--only <substring>] [--out _audit]
+ *
+ * Examples:
+ *   node shared/scripts/site-audit.mjs sidebar  --target dev
+ *   node shared/scripts/site-audit.mjs darkmode --target dev --only vol2
+ *   node shared/scripts/site-audit.mjs assets   --target live
+ *
+ * Requirements
+ * ------------
+ *   npm install --save-dev playwright
+ *   npx playwright install chromium
+ *
+ * The script intentionally reports issues to stdout AND exits non-zero so
+ * it can be wired into CI. Until baselines are clean we run it as
+ * non-blocking — same staged philosophy as the Lychee link checks.
+ * ============================================================================= */
+
+import { chromium } from "playwright";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import process from "node:process";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ──────────────────────────────────────────────────────────────────────────
+// Site map. Each entry is [logical-name, dev-path, live-path, has-sidebar?].
+// Keep this list in sync with .github/scripts/rewrite-dev-urls.sh: any new
+// subsite needs to appear in both places (audit coverage + URL rewriting).
+// ──────────────────────────────────────────────────────────────────────────
+const SITES = [
+  ["landing",     "",                "",                false],
+  ["vol1",        "book/vol1/",      "vol1/",           true],
+  ["vol2",        "book/vol2/",      "vol2/",           true],
+  ["tinytorch",   "tinytorch/",      "tinytorch/",      true],
+  ["kits",        "kits/",           "kits/",           true],
+  ["labs",        "labs/",           "labs/",           true],
+  ["mlsysim",     "mlsysim/",        "mlsysim/",        true],
+  ["slides",      "slides/",         "slides/",         false],
+  ["instructors", "instructors/",    "instructors/",    true],
+  ["staffml",     "staffml/",        "staffml/",        false],
+];
+
+const TARGETS = {
+  dev:   "https://harvard-edge.github.io/cs249r_book_dev/",
+  live:  "https://mlsysbook.ai/",
+  local: "http://127.0.0.1:8000/", // for `python -m http.server` on _site/
+};
+
+// ──────────────────────────────────────────────────────────────────────────
+// CLI parsing — keep dependency-free; the audits already pull in Playwright.
+// ──────────────────────────────────────────────────────────────────────────
+function parseArgs(argv) {
+  const [cmd, ...rest] = argv.slice(2);
+  const opts = { target: "dev", only: null, out: "_audit" };
+  for (let i = 0; i < rest.length; i++) {
+    const arg = rest[i];
+    if (arg === "--target") opts.target = rest[++i];
+    else if (arg === "--only") opts.only = rest[++i];
+    else if (arg === "--out") opts.out = rest[++i];
+    else if (arg === "--help" || arg === "-h") opts.help = true;
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  return { cmd, opts };
+}
+
+function help() {
+  console.log(
+    "Usage: node shared/scripts/site-audit.mjs <sidebar|darkmode|assets> " +
+      "[--target dev|live|local] [--only <substring>] [--out _audit]"
+  );
+}
+
+function siteUrls({ target, only }) {
+  const base = TARGETS[target];
+  if (!base) throw new Error(`Unknown --target: ${target}`);
+  const path = (entry) => (target === "live" ? entry[2] : entry[1]);
+  const filtered = only ? SITES.filter((s) => s[0].includes(only) || path(s).includes(only)) : SITES;
+  return filtered.map((entry) => ({
+    name: entry[0],
+    url: base + path(entry),
+    hasSidebar: entry[3],
+  }));
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// SIDEBAR — assert every Quarto subsite renders a non-empty visible sidebar.
+// ──────────────────────────────────────────────────────────────────────────
+async function auditSidebar(page, site) {
+  const failures = [];
+  if (!site.hasSidebar) return failures;
+  await page.goto(site.url, { waitUntil: "domcontentloaded", timeout: 30000 });
+  // Quarto sidebars use #quarto-sidebar; some templates use .sidebar-navigation.
+  const exists = await page.$("#quarto-sidebar, .sidebar-navigation");
+  if (!exists) {
+    failures.push(`${site.name}: no sidebar element found`);
+    return failures;
+  }
+  const visible = await exists.isVisible();
+  if (!visible) failures.push(`${site.name}: sidebar element present but hidden`);
+  const links = await exists.$$("a");
+  if (links.length < 3) {
+    failures.push(`${site.name}: sidebar has <3 links (likely empty)`);
+  }
+  return failures;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// DARKMODE — flip to dark, scroll, screenshot. Reviewer eyeballs results.
+// ──────────────────────────────────────────────────────────────────────────
+async function auditDarkmode(page, site, outDir) {
+  await page.goto(site.url, { waitUntil: "domcontentloaded", timeout: 30000 });
+  await page.evaluate(() => {
+    try {
+      localStorage.setItem("quarto-color-scheme", "dark");
+      localStorage.setItem("staffml_theme", "dark");
+    } catch (e) {}
+    document.documentElement.setAttribute("data-bs-theme", "dark");
+    document.documentElement.setAttribute("data-quarto-color-scheme", "dark");
+    document.documentElement.dataset.theme = "dark";
+  });
+  await page.waitForTimeout(500);
+  // Scroll to bottom in chunks so lazy-loaded content renders before capture.
+  const height = await page.evaluate(() => document.body.scrollHeight);
+  for (let y = 0; y < height; y += 800) {
+    await page.evaluate((y) => window.scrollTo(0, y), y);
+    await page.waitForTimeout(150);
+  }
+  await page.evaluate(() => window.scrollTo(0, 0));
+  const file = join(outDir, `${site.name}.png`);
+  await page.screenshot({ path: file, fullPage: true });
+  return [`${site.name}: dark-mode screenshot → ${file}`];
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// ASSETS — capture failed network requests and surface them per page.
+// ──────────────────────────────────────────────────────────────────────────
+async function auditAssets(context, site) {
+  const failures = [];
+  const page = await context.newPage();
+  page.on("requestfailed", (req) => {
+    failures.push(`${site.name}: ${req.method()} ${req.url()} (${req.failure()?.errorText || "failed"})`);
+  });
+  page.on("response", (res) => {
+    if (res.status() >= 400) {
+      failures.push(`${site.name}: ${res.status()} ${res.url()}`);
+    }
+  });
+  try {
+    await page.goto(site.url, { waitUntil: "networkidle", timeout: 45000 });
+  } catch (e) {
+    failures.push(`${site.name}: navigation error — ${e.message}`);
+  } finally {
+    await page.close();
+  }
+  return failures;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Entry point.
+// ──────────────────────────────────────────────────────────────────────────
+async function main() {
+  const { cmd, opts } = parseArgs(process.argv);
+  if (!cmd || opts.help) {
+    help();
+    process.exit(cmd ? 0 : 1);
+  }
+
+  const sites = siteUrls(opts);
+  const browser = await chromium.launch();
+  const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+  const allFailures = [];
+
+  try {
+    if (cmd === "sidebar") {
+      for (const site of sites) {
+        const page = await context.newPage();
+        try {
+          allFailures.push(...(await auditSidebar(page, site)));
+        } catch (e) {
+          allFailures.push(`${site.name}: error — ${e.message}`);
+        } finally {
+          await page.close();
+        }
+      }
+    } else if (cmd === "darkmode") {
+      const outDir = join(process.cwd(), opts.out, "darkmode");
+      await mkdir(outDir, { recursive: true });
+      for (const site of sites) {
+        const page = await context.newPage();
+        try {
+          allFailures.push(...(await auditDarkmode(page, site, outDir)));
+        } catch (e) {
+          allFailures.push(`${site.name}: error — ${e.message}`);
+        } finally {
+          await page.close();
+        }
+      }
+    } else if (cmd === "assets") {
+      for (const site of sites) {
+        try {
+          allFailures.push(...(await auditAssets(context, site)));
+        } catch (e) {
+          allFailures.push(`${site.name}: error — ${e.message}`);
+        }
+      }
+    } else {
+      help();
+      process.exit(2);
+    }
+  } finally {
+    await browser.close();
+  }
+
+  // Persist a JSON report for machine consumption (CI).
+  const reportDir = join(process.cwd(), opts.out);
+  await mkdir(reportDir, { recursive: true });
+  const reportPath = join(reportDir, `${cmd}.json`);
+  await writeFile(reportPath, JSON.stringify({ cmd, target: opts.target, failures: allFailures }, null, 2));
+
+  if (cmd === "darkmode") {
+    // For darkmode, the "failures" array is just informational (paths to
+    // screenshots). Treat them as reportable, not failing.
+    console.log(`✅ Captured ${allFailures.length} dark-mode screenshots → ${opts.out}/darkmode/`);
+    process.exit(0);
+  }
+
+  if (allFailures.length === 0) {
+    console.log(`✅ ${cmd}: no issues found across ${sites.length} sites.`);
+    process.exit(0);
+  }
+  console.log(`❌ ${cmd}: ${allFailures.length} issue(s):`);
+  for (const f of allFailures) console.log(`   - ${f}`);
+  console.log(`\nReport written to ${reportPath}`);
+  process.exit(1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/shared/scripts/theme-persist.js
+++ b/shared/scripts/theme-persist.js
@@ -1,0 +1,104 @@
+/* =============================================================================
+ * theme-persist.js — cross-site dark/light mode persistence + FOUC guard
+ * =============================================================================
+ *
+ * Why this exists
+ * ---------------
+ * Every subsite under mlsysbook.ai is built by a different engine (Quarto for
+ * the book/labs/kits/slides/site/instructors/tinytorch, Next.js for StaffML,
+ * etc). Quarto's built-in toggle stores the user's choice in localStorage
+ * under the key `quarto-color-scheme`. Because every subsite shares the
+ * mlsysbook.ai origin in production, that localStorage entry is *technically*
+ * shared — but Quarto's own bridge script runs late, after the page has
+ * already painted in the wrong theme. The result is a visible flash when a
+ * dark-mode reader navigates from one subsite to another.
+ *
+ * This script:
+ *   1. Runs as the FIRST <script> in <head> (so it executes before render).
+ *   2. Reads the user's stored color-scheme preference and applies the
+ *      corresponding `data-bs-theme` / `data-quarto-color-scheme` attributes
+ *      on <html> *before* the browser paints, eliminating the flash.
+ *   3. Falls back to OS preference (`prefers-color-scheme: dark`) when the
+ *      user has not yet expressed a preference.
+ *   4. Listens for `storage` events so a toggle in tab A is reflected
+ *      immediately in tab B without a refresh.
+ *
+ * It deliberately does *not* render any UI: Quarto's existing toggle button
+ * stays the source of truth for user-initiated changes; this script only
+ * preempts the flash and synchronizes other open tabs.
+ *
+ * Wiring (Quarto sites): add to include-in-header BEFORE any other script:
+ *   <script src="/assets/scripts/theme-persist.js"></script>
+ *
+ * Wiring (non-Quarto sites, e.g. StaffML/Next.js): drop the same file at the
+ * same URL and reference it from the document head. The script is framework-
+ * agnostic; it only touches `<html>` attributes and a single localStorage key.
+ *
+ * Canonical source: shared/scripts/theme-persist.js
+ * Mirrors:          synced via shared/scripts/sync-mirrors.sh (do not hand-edit)
+ * ============================================================================= */
+(function () {
+  'use strict';
+
+  // The single key both Quarto and this shim agree on. Do NOT rename without
+  // also updating Quarto's expected key — Quarto reads/writes the same value
+  // and we explicitly want to interoperate, not shadow it.
+  var STORAGE_KEY = 'quarto-color-scheme';
+
+  function preferredScheme() {
+    try {
+      var stored = window.localStorage.getItem(STORAGE_KEY);
+      if (stored === 'dark' || stored === 'light') {
+        return stored;
+      }
+    } catch (e) {
+      // localStorage may be blocked (private mode, sandboxed iframe).
+      // Silent fallback to OS preference is the right behavior.
+    }
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      return 'dark';
+    }
+    return 'light';
+  }
+
+  function apply(scheme) {
+    var html = document.documentElement;
+    if (!html) return;
+    // Bootstrap 5.3+: data-bs-theme drives semantic colors.
+    html.setAttribute('data-bs-theme', scheme);
+    // Quarto-internal hook used by some subsite SCSS (kept in sync to avoid
+    // half-themed elements during the gap before Quarto's own script runs).
+    html.setAttribute('data-quarto-color-scheme', scheme);
+    // Hint for any CSS using the @media `prefers-color-scheme` shorthand.
+    html.style.colorScheme = scheme;
+  }
+
+  // 1. Apply the initial scheme synchronously (before paint).
+  apply(preferredScheme());
+
+  // 2. Cross-tab sync: react when *another* tab updates the choice.
+  window.addEventListener('storage', function (ev) {
+    if (ev.key !== STORAGE_KEY) return;
+    var next = ev.newValue;
+    if (next !== 'dark' && next !== 'light') return;
+    apply(next);
+  });
+
+  // 3. OS-preference change: only apply if the user has NOT explicitly
+  //    chosen via the toggle (i.e. nothing in localStorage).
+  if (window.matchMedia) {
+    try {
+      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function (ev) {
+        try {
+          if (window.localStorage.getItem(STORAGE_KEY)) return;
+        } catch (e) {
+          /* If we can't read storage, treating OS pref as truth is fine. */
+        }
+        apply(ev.matches ? 'dark' : 'light');
+      });
+    } catch (e) {
+      // Older Safari does not support addEventListener on MediaQueryList.
+      // The initial apply() above is sufficient for those browsers.
+    }
+  }
+})();


### PR DESCRIPTION
## Summary

Visible-on-the-dev-mirror improvements that close several of the
visual/UX gaps the maintainer flagged during the staged-rollout review.
Independent of PR-1 (the safety-net) — can be merged in either order.

### What's in this PR

**Per-volume announcement bars (Crimson / ETH-Blue).** The shared
`announcement.yml` was a single voice for both volumes; Vol II should
read in the ETH-Blue accent (since it's *Machine Learning Systems at
Scale*). Split into:
  - `book/quarto/config/shared/html/announcement-vol1.yml` (Vol I,
    inherits Harvard Crimson via theme accent)
  - `book/quarto/config/shared/html/announcement-vol2.yml` (Vol II,
    inherits ETH Blue)
The legacy file is left in place as a deprecated no-op pointing at
the two new files. Vol I and Vol II `_quarto-html-vol{1,2}.yml`
configs now reference the right one.

**Cross-site dark-mode persistence + FOUC guard.** Today, switching
dark mode on Vol I doesn't carry to TinyTorch / labs / kits / staffml
because each subsite tracks its own preference. New
`shared/scripts/theme-persist.js` (inlined into
`shared/config/site-head.html` so it runs synchronously in `<head>`,
no FOUC) reads `quarto-color-scheme` from `localStorage` and applies
`data-bs-theme` / `data-quarto-color-scheme` /
`html.style.colorScheme` before first paint. StaffML's
`ThemeProvider.tsx` and `theme-bootstrap.js` updated to read/write
the same key as a fallback so the Next.js property participates in
the shared preference. Listens for storage events too, so a tab that
toggles dark mode propagates to other open tabs in the same domain.

**Dev-mirror nested-path bug fix.** `rewrite-dev-urls.sh` had a
hard-coded `PREFIX="../"` which broke nested subsites like
`book/vol1/` and `book/vol2/` — they were getting URLs that walked
up one too few directories. Fixed to compute `PREFIX` from the
actual depth of the subsite's dev-side path. Also fixed an
associative-array key check that wasn't portable to the macOS
default bash 3.2.

**Playwright audit script (subcommands: sidebar / darkmode /
assets).** New `shared/scripts/site-audit.mjs` that opens each
deployed subsite in a headless browser and:
  - `sidebar` — verifies every Quarto subsite has a visible sidebar
    (was missing on a few Vol I / Vol II combinations after the
    split).
  - `darkmode` — toggles dark mode, screenshots before/after,
    flags pages that don't repaint cleanly.
  - `assets` — fetches every `<img src>` and `<link rel="stylesheet">`
    and reports broken ones (catches the "PDF viewer iframe shows a
    404" class of issue the maintainer flagged).
Output goes to `.audit/` (added to `.gitignore` in PR-3).

### Risk surface

- The announcement bar change is purely additive (new files; old file
  defanged but not deleted, so any forgotten reference still resolves).
- The theme-persist script is `<head>`-inlined, so it runs before any
  user-visible content. Worst case if the script throws: nothing
  happens, the user falls back to OS preference (which is the current
  behavior).
- The rewrite-dev-urls fix has been smoke-tested against vol1/vol2
  paths and the depth math verified; included a comment in the script
  explaining the depth derivation.
- The Playwright script is opt-in (run via `node shared/scripts/site-audit.mjs <cmd>`);
  no CI integration in this PR.

### Test plan

- [ ] CI: book-validate-dev passes (announcement files parse as YAML).
- [ ] Local: `node shared/scripts/site-audit.mjs sidebar` produces
      a JSON report covering vol1, vol2, tinytorch, labs, kits,
      slides, instructors, mlsysim, site, staffml.
- [ ] Manual: dev mirror Vol II shows ETH-Blue announcement.
- [ ] Manual: toggle dark mode on Vol I, navigate to TinyTorch,
      verify dark mode is preserved (no flash of light theme).

### Followup

- Wire the audit script into a scheduled GitHub workflow (PR-3 has
  the dedup-finder follow-up; the audit script could share the same
  workflow shell).
- Vol I announcement copy still reads "the unified Volume I/II
  edition is rolling out"; tighten language for actual launch.