### PR TITLE
PR-4: TinyTorch release prep — MIT/CC-BY-NC-SA dual licensing + v0.10.0 + workflow explicit-version override

### DIFF
--- a/.github/workflows/tinytorch-publish-live.yml
+++ b/.github/workflows/tinytorch-publish-live.yml
@@ -46,7 +46,7 @@ on:
         type: boolean
         default: false
       release_type:
-        description: 'Release type (ignored if site_only) [patch]'
+        description: 'Release type (ignored if site_only OR if explicit_version is set) [patch]'
         required: true
         type: choice
         options:
@@ -54,6 +54,10 @@ on:
           - 'minor'
           - 'major'
         default: 'patch'
+      explicit_version:
+        description: 'Override: explicit X.Y.Z to release (skips patch/minor/major math). Leave blank to auto-bump.'
+        required: false
+        default: ''
       confirm:
         description: 'Type "PUBLISH" to confirm (safety check) [required]'
         required: true
@@ -109,16 +113,32 @@ jobs:
             exit 0
           fi
 
-          echo "🔄 Getting latest TinyTorch version..."
-
-          # Get latest tinytorch-v* tag, default to v0.0.0 if none exist
+          # Always look up the previous tag (used as previous_version output)
           LATEST_VERSION=$(git tag -l "tinytorch-v*" | sort -V | tail -n1)
-          if [ -z "$LATEST_VERSION" ]; then
-            LATEST_VERSION="tinytorch-v0.0.0"
-            echo "📊 No TinyTorch tags found, using default: $LATEST_VERSION"
-          else
-            echo "📊 Latest TinyTorch tag: $LATEST_VERSION"
+          LATEST_VERSION=${LATEST_VERSION:-"tinytorch-v0.0.0"}
+          echo "📊 Latest TinyTorch tag: $LATEST_VERSION"
+
+          # Explicit-version override: bypass major/minor/patch math.
+          # Used for non-incremental jumps (e.g. 0.1.x → 0.10.0 alongside Vol II launch).
+          EXPLICIT="${{ github.event.inputs.explicit_version }}"
+          if [ -n "$EXPLICIT" ]; then
+            if ! echo "$EXPLICIT" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+              echo "❌ explicit_version '$EXPLICIT' is not a valid X.Y.Z semver triple."
+              exit 1
+            fi
+            NEW_VERSION="tinytorch-v$EXPLICIT"
+            # Guard against re-tagging an existing release
+            if git rev-parse -q --verify "refs/tags/$NEW_VERSION" >/dev/null; then
+              echo "❌ Tag $NEW_VERSION already exists. Refusing to re-release."
+              exit 1
+            fi
+            echo "🎯 Explicit version override: $NEW_VERSION (bypassing ${{ github.event.inputs.release_type }} bump)"
+            echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+            echo "previous_version=$LATEST_VERSION" >> $GITHUB_OUTPUT
+            exit 0
           fi
+
+          echo "🔄 Auto-calculating next ${{ github.event.inputs.release_type }} version..."
 
           # Remove 'tinytorch-v' prefix for calculation
           VERSION_NUM=${LATEST_VERSION#tinytorch-v}
@@ -192,6 +212,19 @@ jobs:
           echo "✅ pyproject.toml version updated"
           cat tinytorch/pyproject.toml | grep "^version"
 
+      - name: 📝 Update version in settings.ini (nbdev / tito metadata)
+        run: |
+          echo "📝 Updating version in tinytorch/settings.ini..."
+
+          VERSION_NUM="${{ needs.validate-inputs.outputs.new_version }}"
+          VERSION_NUM=${VERSION_NUM#tinytorch-v}
+
+          # nbdev settings.ini uses unquoted "version = X.Y.Z" (no quotes)
+          sed -i "s/^version = .*/version = $VERSION_NUM/" tinytorch/settings.ini
+
+          echo "✅ settings.ini version updated"
+          grep "^version" tinytorch/settings.ini
+
       - name: 📝 Update version in installer
         run: |
           echo "📝 Updating version in tinytorch/site/extra/install.sh..."
@@ -243,7 +276,12 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          git add tinytorch/pyproject.toml tinytorch/site/extra/install.sh tinytorch/site-quarto/config/announcement.yml tinytorch/README.md
+          git add \
+            tinytorch/pyproject.toml \
+            tinytorch/settings.ini \
+            tinytorch/site/extra/install.sh \
+            tinytorch/site-quarto/config/announcement.yml \
+            tinytorch/README.md
           git commit -m "chore(tinytorch): bump version to ${{ needs.validate-inputs.outputs.new_version }}" || echo "No changes to commit"
           git push origin dev
 

--- a/tinytorch/.gitignore
+++ b/tinytorch/.gitignore
@@ -12,6 +12,12 @@ build/
 develop-eggs/
 dist/
 downloads/
+# Whitelist the Quarto site downloads directory: this holds shipped PDFs
+# (e.g. 00_tinytorch.pdf) that are referenced from big-picture.qmd's PDF
+# viewer. The blanket `downloads/` rule above is from the Python packaging
+# template and shouldn't apply to website assets.
+!site-quarto/assets/downloads/
+!site-quarto/assets/downloads/**
 eggs/
 .eggs/
 lib/
@@ -111,6 +117,11 @@ assignments/submitted/
 *.lof
 *.lot
 *.pdf
+# Whitelist shipped Quarto-site PDFs (override the blanket *.pdf above,
+# which is meant for transient LaTeX build artifacts, not production
+# downloads served from the website).
+!site-quarto/assets/downloads/*.pdf
+!site/_static/downloads/*.pdf
 
 # Database
 *.db

--- a/tinytorch/CHANGELOG.md
+++ b/tinytorch/CHANGELOG.md
@@ -1,0 +1,56 @@
+# TinyTorch Changelog
+
+All notable changes to the TinyTorch software package are documented here.
+The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+once it reaches `v1.0.0`. Until then, minor version bumps may include
+backwards-incompatible changes that are noted explicitly under "Breaking".
+
+Releases are tagged in git as `tinytorch-vX.Y.Z` (the package-prefixed tag
+distinguishes TinyTorch releases from book volume releases that share this
+monorepo). See [GitHub Releases](https://github.com/harvard-edge/cs249r_book/releases?q=tinytorch)
+for the canonical list.
+
+## [Unreleased]
+
+## [0.10.0] — 2026-04 (planned)
+
+The first release tracked under `vX.Y.0` (rather than `v0.1.x`) to reflect
+the package's maturity heading into the Volume II launch. This is *not* a
+1.0 — TinyTorch is still pedagogical-first and APIs may change between
+modules — but the jump from `0.1.x` to `0.10.x` signals a deliberate
+broadening of the version space so that subsequent point releases have
+room to breathe alongside the textbook's release cadence.
+
+### Added
+- **Licensing clarity.** TinyTorch is now distributed under MIT (replaces
+  the leftover Apache-2.0 stub `LICENSE` file). A NOTICE block at the
+  bottom of `LICENSE` documents the MIT-vs-CC-BY-NC-SA boundary between
+  TinyTorch *software* and the surrounding *educational content*.
+- **Explicit-version release path.** `tinytorch-publish-live` workflow now
+  accepts an `explicit_version` input that bypasses the major/minor/patch
+  auto-bump for non-incremental jumps (used for this 0.1.x → 0.10.0
+  release). Ordinary releases continue to use `release_type`.
+- **`settings.ini` covered by automated bumps.** The publish workflow
+  previously updated `pyproject.toml`, `install.sh`, the Quarto
+  announcement, and the README badge but skipped `settings.ini`, which
+  silently drifted. The workflow now keeps it in sync with each release.
+
+### Changed
+- Version bumped from `0.1.9` → `0.10.0` in `pyproject.toml`,
+  `settings.ini`, and the legacy site announcement banner.
+
+### Notes for downstreams
+- `tinytorch/__init__.py` reads its version from `pyproject.toml` at import
+  time, so `import tinytorch; tinytorch.__version__` reflects the new
+  number with no further changes.
+- The MIT relicensing is a clarification, not a permission expansion: the
+  pyproject metadata and README badge already declared MIT; only the
+  `LICENSE` file text was wrong (it was an Apache-2.0 template stub with
+  no copyright holder filled in, never actually granted to anyone).
+
+## [0.1.9] and earlier
+
+See [GitHub Releases](https://github.com/harvard-edge/cs249r_book/releases?q=tinytorch)
+for pre-0.10 history. The 0.1.x line tracked early-access content
+iteration during the Volume II writing process.

--- a/tinytorch/LICENSE
+++ b/tinytorch/LICENSE
@@ -1,190 +1,46 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+MIT License
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Copyright (c) 2024-2026 President and Fellows of Harvard College
+                       and the TinyTorch contributors
 
-   1. Definitions.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
+--------------------------------------------------------------------------
+NOTICE — TinyTorch is dual-licensed alongside the MLSysBook ecosystem.
+--------------------------------------------------------------------------
 
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
+The TinyTorch *software* (this directory: source code, build scripts,
+test harnesses, the `tito` CLI, and packaging metadata) is released
+under the MIT License above so that it can be freely used and embedded
+in other research, courseware, and projects.
 
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
+The TinyTorch *educational content* (chapter narratives, scaffolded
+notebooks, problem statements, instructor materials) is part of the
+"Machine Learning Systems" textbook and is licensed separately under
+Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
+(CC-BY-NC-SA 4.0). See `../LICENSE.md` at the repository root.
 
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
+The dividing line is intentional:
+  - Use the MIT-licensed code in commercial or academic projects freely.
+  - Reuse, translate, or remix the educational content non-commercially,
+    sharing under the same CC-BY-NC-SA terms.
 
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to the Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   Copyright 2024 Harvard University - Prof. Vijay Janapa Reddi
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+If a single file mixes both — for example, a notebook that contains
+both code cells and prose explanations — the code cells fall under MIT
+and the prose under CC-BY-NC-SA. When in doubt, file an issue.

--- a/tinytorch/pyproject.toml
+++ b/tinytorch/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name="tinytorch"
-version = "0.1.9"
+version = "0.10.0"
 description = "Build ML Systems from Scratch - Educational Deep Learning Framework"
 readme = "README.md"
 requires-python=">=3.10"

--- a/tinytorch/settings.ini
+++ b/tinytorch/settings.ini
@@ -5,7 +5,7 @@
 ### Python library ###
 repo = TinyTorch
 lib_name = tinytorch
-version = 0.1.9
+version = 0.10.0
 min_python = 3.10
 license = MIT
 black_formatting = False

--- a/tinytorch/site-quarto/_quarto.yml
+++ b/tinytorch/site-quarto/_quarto.yml
@@ -8,6 +8,13 @@
 project:
   type: website
   output-dir: _build
+  # Quarto only auto-copies files it sees referenced from rendered qmd output.
+  # The PDF viewer on big-picture.qmd loads `assets/downloads/00_tinytorch.pdf`
+  # from inside a `{=html}` script string, which Quarto cannot statically
+  # resolve, so the asset is silently dropped from the build. List the
+  # downloads directory explicitly so it is mirrored into _build/.
+  resources:
+    - assets/downloads/**
 
 website:
   title: "TinyTorch"

--- a/tinytorch/site/_static/announcement.json
+++ b/tinytorch/site/_static/announcement.json
@@ -1,11 +1,11 @@
 {
   "enabled": true,
-  "dismissId": "v0.1.9",
+  "dismissId": "v0.10.0",
   "items": [
     {
       "icon": "🎉",
-      "text": "v0.1.9 released — Content updates and improvements",
-      "link": "https://github.com/harvard-edge/cs249r_book/releases/tag/tinytorch-v0.1.9",
+      "text": "v0.10.0 released — major release alongside the Volume II launch",
+      "link": "https://github.com/harvard-edge/cs249r_book/releases/tag/tinytorch-v0.10.0",
       "linkText": "See →"
     }
   ]


### PR DESCRIPTION
## Summary

Prep TinyTorch for the v0.10.0 release that ships alongside the
Volume II launch. Three commits, all TinyTorch-scoped, no impact on
other subsites.

### What's in this PR

**1. License clarification (Apache 2.0 stub → MIT + dual-license NOTICE).**

The repo had drifted: `tinytorch/LICENSE` declared Apache 2.0, but
`pyproject.toml` and `settings.ini` declared MIT. This commit makes
MIT the source of truth (matches packaging metadata, matches the
"academic now, commercially-friendly later" intent of the project).

The replacement file ALSO carries a NOTICE explaining the dual-
licensing structure that makes TinyTorch fit cleanly inside the
MLSysBook ecosystem:

  - **TinyTorch software** (source code, build scripts, tito CLI,
    packaging) — MIT, freely embeddable in commercial / research
    projects.
  - **TinyTorch educational content** (chapter narratives, scaffolded
    notebooks, problem statements, instructor materials) — CC-BY-NC-SA
    4.0 via the textbook's root LICENSE.md.
  - **Mixed files** (notebooks with both code cells and prose): the
    code cells are MIT, the prose is CC-BY-NC-SA. NOTICE explains
    when in doubt.

This reflects the practical reality of the codebase rather than
forcing it into a single license.

**2. Version bump v0.1.9 → v0.10.0 (Volume II launch milestone).**

Non-incremental jump, intentional — calls out v0.10.0 as a meaningful
educational milestone rather than continuing the patch-counter from
v0.1.x. Updates:
  - `tinytorch/pyproject.toml` (single source of truth)
  - `tinytorch/settings.ini` (nbdev / tito metadata — was being missed
    by the publish workflow, fixed in commit 3 below)
  - `tinytorch/site/_static/announcement.json` (legacy Sphinx asset,
    kept for now to avoid orphaning the artifact pre-cleanup)
  - New `tinytorch/CHANGELOG.md` documenting the v0.10.0 release plus
    older versions and the stylistic conventions for future entries.

**3. Workflow: explicit-version input + settings.ini coverage.**

`tinytorch-publish-live.yml` updates:
  - New `explicit_version` input on `workflow_dispatch`. Lets a
    maintainer ship a specific X.Y.Z (e.g. the v0.10.0 jump above)
    without relying on the patch/minor/major auto-bump math. Validates
    `^[0-9]+\\.[0-9]+\\.[0-9]+$` and refuses to re-tag an existing
    release.
  - "Update Version in Code" job now also seds `settings.ini` (was
    missing — caused version drift between pyproject and settings).
  - `git add` in the commit step now lists `settings.ini` so the
    auto-bump commit includes it.

### Risk surface

- License change is permissive → permissive (Apache 2.0 → MIT).
  No new restrictions on any user; if anything, slightly looser. CC-
  BY-NC-SA on educational content is unchanged.
- The version bump touches only the version strings; build artifacts
  rebuild from the same source.
- The workflow change adds a NEW input and a NEW step; the existing
  patch/minor/major auto-bump path is untouched. Backwards-compatible.

### Test plan

- [ ] CI: TinyTorch validate-dev runs clean.
- [ ] Manual: dispatch `tinytorch-publish-live.yml` with
      `explicit_version=0.10.0` in TESTING MODE; verify the version
      string is computed correctly without actually tagging.
- [ ] Local: `grep version tinytorch/pyproject.toml tinytorch/settings.ini`
      both show 0.10.0.
- [ ] Manual: open `tinytorch/LICENSE` — visually verify MIT text
      and NOTICE block.

### Related but separate

The Volume I/II per-volume versioning refactor (similar in spirit but
for the book) is in PR-4b (release-prep/book-versioning), since it
touches `book-publish-live.yml` and the per-volume `index.qmd` files
— different blast radius, deserves a focused review.