### PR TITLE
fix(book): route per-volume builds to per-volume index pages

### DIFF
--- a/book/quarto/config/_quarto-epub-vol1.yml
+++ b/book/quarto/config/_quarto-epub-vol1.yml
@@ -61,7 +61,7 @@ book:
       Built with <a href="https://quarto.org/">Quarto</a>.
 
   chapters:
-    - index.qmd
+    - index-vol1.qmd
 
     # Volume I Frontmatter
     - contents/vol1/frontmatter/dedication.qmd

--- a/book/quarto/config/_quarto-epub-vol2.yml
+++ b/book/quarto/config/_quarto-epub-vol2.yml
@@ -61,7 +61,7 @@ book:
       Built with <a href="https://quarto.org/">Quarto</a>.
 
   chapters:
-    - index.qmd
+    - index-vol2.qmd
 
     # ==================================================
     # Volume II Frontmatter

--- a/book/quarto/config/_quarto-html-vol1.yml
+++ b/book/quarto/config/_quarto-html-vol1.yml
@@ -15,7 +15,7 @@ project:
     - assets/downloads/*
 
   render:
-    - index.qmd
+    - index-vol1.qmd
     - contents/vol1/**/*.qmd
     - contents/frontmatter/**/*.qmd
 

--- a/book/quarto/config/_quarto-html-vol2.yml
+++ b/book/quarto/config/_quarto-html-vol2.yml
@@ -15,7 +15,7 @@ project:
     - assets/downloads/*
 
   render:
-    - index.qmd
+    - index-vol2.qmd
     - contents/vol2/**/*.qmd
     - contents/frontmatter/**/*.qmd
 

--- a/book/quarto/config/_quarto-pdf-vol1-copyedit.yml
+++ b/book/quarto/config/_quarto-pdf-vol1-copyedit.yml
@@ -50,7 +50,7 @@ book:
       Built with <a href="https://quarto.org/">Quarto</a>.
 
   chapters:
-    - index.qmd
+    - index-vol1.qmd
 
     # ==================================================
     # Volume I Frontmatter

--- a/book/quarto/config/_quarto-pdf-vol1.yml
+++ b/book/quarto/config/_quarto-pdf-vol1.yml
@@ -50,7 +50,7 @@ book:
       Built with <a href="https://quarto.org/">Quarto</a>.
 
   chapters:
-    - index.qmd
+    - index-vol1.qmd
 
     # ==================================================
     # Volume I Frontmatter

--- a/book/quarto/config/_quarto-pdf-vol2-copyedit.yml
+++ b/book/quarto/config/_quarto-pdf-vol2-copyedit.yml
@@ -50,7 +50,7 @@ book:
       Built with <a href="https://quarto.org/">Quarto</a>.
 
   chapters:
-    - index.qmd
+    - index-vol2.qmd
 
     # ==================================================
     # Volume II Frontmatter

--- a/book/quarto/config/_quarto-pdf-vol2.yml
+++ b/book/quarto/config/_quarto-pdf-vol2.yml
@@ -50,7 +50,7 @@ book:
       Built with <a href="https://quarto.org/">Quarto</a>.
 
   chapters:
-    - index.qmd
+    - index-vol2.qmd
 
     # ==================================================
     # Volume II Frontmatter

--- a/book/quarto/index-vol1.qmd
+++ b/book/quarto/index-vol1.qmd
@@ -1,0 +1,135 @@
+---
+output-file: index.html
+format:
+  html:
+    title: "Introduction to Machine Learning Systems"
+    date: today
+    date-format: long
+    doi: "v0.5.1"
+    doi-title: "Version"
+    author:
+      name: Vijay Janapa Reddi
+      email: vj@eecs.harvard.edu
+      url: https://vijay.seas.harvard.edu
+      affiliation: Harvard University
+---
+
+::: {.content-visible unless-format="html:js"}
+
+# Author's Note {.unnumbered}
+
+::: {style="font-style: italic;"}
+
+The world is rushing to build AI systems. It is not yet engineering them. That gap is what we mean by AI engineering. Who designs the training infrastructure? Who builds serving systems that scale? Who optimizes models to run on a phone or a sensor? Who architects the accelerators those models execute on? That work is AI engineering: the discipline of building efficient, reliable, safe, and robust intelligent systems that operate in the real world, not models in isolation. It is not yet recognized as a discipline.
+
+By most industry estimates, the vast majority of AI projects never reach production or fail to deliver the value they promised. The failures are not exotic: a model degrades silently because no one built monitoring for distribution shift; a system that worked in the lab fails at the edge because latency requirements were never communicated to the team selecting architectures; a deployment pipeline breaks because the team retrained a model without versioning the data and cannot reproduce last week's results. These are not research problems. They are engineering problems, and they recur because the field lacks the shared principles, vocabulary, and training that a discipline provides.
+
+Part of the gap is fragmentation. The knowledge to build ML systems exists, but it is scattered across silos. One course teaches compilers. Another covers hardware architecture. A third focuses on data pipelines. A fourth introduces the mathematics of optimization. Each is valuable on its own, but none of them teaches the *system*, and the result is engineers who understand individual components but not how they fit together. Nobody learns how a computer works by studying the processor in one course, the memory hierarchy in another, and the interconnect in a third, without ever building a complete machine. A computer is an integrated machine; understanding it means understanding where bottlenecks form between components, where trade-offs hide, and where one design decision constrains every other. An ML system is no different. Data pipelines, model architectures, software frameworks, and accelerator hardware constrain each other and fail together. The engineer who understands only one piece will build systems that break at the seams.
+
+This book provides that missing integration. Not a survey of tools, not a collection of recipes, but the enduring principles that govern ML systems regardless of which framework or accelerator is fashionable this year. We do not teach operating systems by starting with distributed operating systems or embedded operating systems; we teach the fundamentals (scheduling, memory management, concurrency) and then specialization follows. That philosophy guides this book. Whether you are building a model that runs on a microcontroller or training one across a thousand GPUs, the principles are the same: memory bandwidth limits data movement, arithmetic intensity governs compute utilization, and the interplay between data, models, and hardware determines what is practical to build. The scale changes; the principles do not.
+
+The existence of such principles is precisely what makes a discipline possible. Software engineering and computer engineering each emerged when practitioners recognized that building reliable systems required its own body of knowledge, distinct from the science that produced the underlying ideas. AI engineering is at that same inflection point. The best textbooks I encountered as a student, in both traditions, did not teach me subjects; they taught me how to think. They took vast, messy landscapes and revealed the structure underneath. That is what I have tried to do here.
+
+--- Vijay Janapa Reddi
+
+:::
+
+:::
+
+::: {.content-visible when-format="html:js"}
+
+# Welcome {.unnumbered}
+
+```{=html}
+<div class="abstract-section">
+  <div class="abstract-content">
+    <p>Machine learning has evolved from a research discipline into an engineering practice. Building systems that learn from data requires more than understanding algorithms—it demands expertise spanning data pipelines, model development, optimization for deployment constraints, and operational practices. This book introduces AI engineering: the discipline of building ML systems that work in the real world. The treatment covers four areas: foundations (system characteristics, development workflows), building (deep learning mathematics, architectures, framework internals), optimization (compression, hardware acceleration, benchmarking), and deployment (serving infrastructure, operations, responsible engineering). The emphasis throughout is on engineering trade-offs and quantitative analysis.</p>
+  </div>
+
+  <a href="assets/downloads/Machine-Learning-Systems-Vol1.pdf" target="_blank" class="book-card-link" title="Download PDF">
+    <div class="book-card">
+      <img src="assets/images/covers/cover-hardcover-book-vol1.png" alt="Machine Learning Systems Book Cover" class="book-image" />
+      <p class="book-title">Introduction to Machine Learning Systems</p>
+      <p class="book-subtitle">Publisher: The MIT Press (2026)</p>
+      <p style="font-size: 0.8em; color: #6c757d; margin-top: 6px; margin-bottom: 0;">📖 Click here to download PDF</p>
+    </div>
+  </a>
+</div>
+```
+
+## What You Will Learn {.unnumbered}
+
+The book progresses through four stages:
+
+- **Part I: Foundations**—Build your conceptual foundation with mental models that underpin all effective systems work.
+- **Part II: Build**—Engineer complete workflows from data pipelines through training infrastructure.
+- **Part III: Optimize**—Transform theoretical understanding into systems that run efficiently in resource-constrained environments.
+- **Part IV: Deploy**—Navigate serving, operations, and responsible engineering practices.
+
+## Prerequisites {.unnumbered}
+
+This book assumes:
+
+- **Programming proficiency** in Python with familiarity in NumPy
+- **Mathematics foundations** in linear algebra, calculus, and probability at the undergraduate level
+- Prior ML experience is helpful but not required; @sec-neural-computation provides essential background
+
+## Support Our Mission {.unnumbered}
+
+```{=html}
+<div class="support-mission">
+  <p><strong>2026 Goal:</strong> Help 100,000 students learn ML Systems. Sponsors like the <a href="https://edgeaifoundation.org/" target="_blank" rel="noopener noreferrer">EDGE AI Foundation</a> match every star with funding that supports learning.</p>
+
+  <div class="support-actions">
+    <span class="star-count" id="star-count">Loading...</span>
+    <a href="https://github.com/harvard-edge/cs249r_book" target="_blank" rel="noopener" class="github-star-btn">⭐ Star on GitHub</a>
+  </div>
+
+  <p class="support-note">
+    <a href="https://opencollective.com/mlsysbook" target="_blank" rel="noopener">Support us on Open Collective →</a>
+  </p>
+</div>
+```
+
+```{=html}
+<script>
+async function fetchGitHubStars() {
+  const starElement = document.getElementById('star-count');
+
+  try {
+    const response = await fetch('https://api.github.com/repos/harvard-edge/cs249r_book');
+    const data = await response.json();
+    const starCount = data.stargazers_count;
+    const formattedCount = starCount.toLocaleString();
+    starElement.textContent = formattedCount;
+    starElement.style.opacity = '1';
+  } catch (error) {
+    console.error('Failed to fetch GitHub stars:', error);
+    starElement.textContent = 'Loading...';
+    starElement.style.opacity = '1';
+  }
+}
+
+document.addEventListener('DOMContentLoaded', fetchGitHubStars);
+</script>
+```
+
+## Listen to the AI Podcast {.unnumbered}
+
+```{=html}
+<div class="podcast-section">
+  <p>
+    This short podcast, created with Google's Notebook LM and inspired by insights from our <a href="https://web.eng.fiu.edu/gaquan/Papers/ESWEEK24Papers/CPS-Proceedings/pdfs/CODES-ISSS/563900a043/563900a043.pdf" target="_blank" rel="noopener">IEEE education viewpoint paper</a>, offers an accessible overview of the book's key ideas and themes.
+  </p>
+  <audio controls="controls">
+    <source src="assets/media/notebooklm_podcast_mlsysbookai.mp3" type="audio/mpeg" />
+    Your browser does not support the audio element.
+  </audio>
+</div>
+```
+
+## Want to Help Out? {.unnumbered}
+
+This is a collaborative project, and your input matters. If you'd like to contribute, check out our [contribution guidelines](https://github.com/harvard-edge/cs249r_book/blob/main/book/docs/CONTRIBUTING.md). Feedback, corrections, and new ideas are welcome. Simply file a GitHub [issue](https://github.com/harvard-edge/cs249r_book/issues).
+
+:::

--- a/book/quarto/index-vol2.qmd
+++ b/book/quarto/index-vol2.qmd
@@ -1,0 +1,136 @@
+---
+output-file: index.html
+format:
+  html:
+    title: "Machine Learning Systems at Scale"
+    date: today
+    date-format: long
+    doi: "v0.5.1"
+    doi-title: "Version"
+    author:
+      name: Vijay Janapa Reddi
+      email: vj@eecs.harvard.edu
+      url: https://vijay.seas.harvard.edu
+      affiliation: Harvard University
+---
+
+::: {.content-visible unless-format="html:js"}
+
+# Author's Note {.unnumbered}
+
+::: {style="font-style: italic;"}
+
+When a new model is announced, the world pays attention to the model. The headlines celebrate the benchmark, the parameter count, the capability. What they do not celebrate is the engineering that made it possible. Behind every frontier model is a fleet: tens of thousands of accelerators coordinated across a network fabric where a single misconfigured switch can stall the entire training run. Cooling systems that dissipate megawatts of heat from racks so dense that air alone cannot carry it away. Checkpoint protocols that race against a clock where, in a cluster of ten thousand devices, a hardware failure arrives roughly every two hours. Scheduling systems that must keep utilization high across a machine the size of a small campus while serving workloads with sharply different resource profiles.
+
+This engineering has no precedent. Humanity has built large distributed systems before: the telephone network, the internet, the global financial infrastructure. Yet none of them required the sustained, synchronized, high-bandwidth coordination that training a single model across thousands of accelerators demands. An AllReduce operation that synchronizes gradients across a cluster must complete in milliseconds, not seconds; a straggler that falls behind by even a fraction disrupts every other node waiting at the barrier. The tolerances are tighter, the data volumes larger, and the failure modes more subtle than anything the field of distributed systems has confronted at this scale.
+
+This engineering is largely invisible. It is hidden behind APIs, behind cloud abstractions, behind announcements that describe what a model can do but not what it took to build it. The people who design the network topologies, who write the collective communication libraries, who architect the fault tolerance that keeps a ninety-day training run from collapsing on day forty-seven: their work is indispensable but rarely discussed. The model gets the paper. The fleet gets a footnote, if that.
+
+This book is an argument that the fleet deserves more than a footnote. The engineering that makes large-scale ML possible is not a supporting function beneath a more visible discipline. It *is* the discipline. A model that cannot be trained is an idea, not a system. A model that cannot be served is a research artifact, not a product. A model that cannot be governed is a liability, not an asset. At every stage of the lifecycle, from training through serving, operating, and governing, the fleet determines what is possible and what is practical. The principles that govern fleet-scale systems are as deep, as quantitative, and as worthy of study as the algorithms they support.
+
+This book makes that engineering visible. It gives it vocabulary, principles, and the quantitative rigor it deserves. If the companion volume asked "what does it take to build an ML system?", this volume asks "what does it take to build a *thousand* of them, make them work together, and govern them responsibly?" That question is, I believe, the defining engineering challenge of this generation. It deserves a discipline. This book is a step toward building one.
+
+--- Vijay Janapa Reddi
+
+:::
+
+:::
+
+::: {.content-visible when-format="html:js"}
+
+# Welcome {.unnumbered}
+
+```{=html}
+<div class="abstract-section">
+  <div class="abstract-content">
+    <p>Modern machine learning operates at scales that fundamentally change engineering requirements—models too large for single GPUs, services spanning continents, deployments carrying societal responsibilities. This book addresses AI engineering at scale. The treatment follows the lifecycle of a massive-scale system: defining the distributed architecture, building the physical infrastructure fleet, ensuring operational reliability, deploying to global users, and hardening the system for safety and responsibility.</p>
+  </div>
+
+  <a href="assets/downloads/Machine-Learning-Systems-Vol2.pdf" target="_blank" class="book-card-link" title="Download PDF">
+    <div class="book-card">
+      <img src="assets/images/covers/cover-hardcover-book-vol2.png" alt="Machine Learning Systems Book Cover" class="book-image" />
+      <p class="book-title">Machine Learning Systems at Scale</p>
+      <p class="book-subtitle">Publisher: The MIT Press (2027)</p>
+      <p style="font-size: 0.8em; color: #6c757d; margin-top: 6px; margin-bottom: 0;">📖 Click here to download PDF</p>
+    </div>
+  </a>
+</div>
+```
+
+## What You Will Learn {.unnumbered}
+
+This book extends the foundations into production-scale systems through four parts that follow the **Fleet Stack** from bottom to top:
+
+- **Part I: The Fleet**—Build the physical computer. Architect the datacenter infrastructure, high-bandwidth network fabrics, and scalable data storage that form the foundation of every distributed ML deployment.
+- **Part II: Distributed ML**—Master the algorithms of scale. Learn how to coordinate computation across thousands of devices using parallelism strategies, collective communication primitives, fault tolerance mechanisms, and fleet orchestration.
+- **Part III: Deployment at Scale**—Serve the world. Navigate the shift from training to inference, optimize performance across the serving stack, push intelligence to the edge, and manage the operational lifecycle of production fleets.
+- **Part IV: The Responsible Fleet**—Harden and govern the system. Address security, robustness, environmental sustainability, and responsible engineering in large-scale operations.
+
+## Prerequisites {.unnumbered}
+
+This book assumes:
+
+- **Foundational or equivalent** background in single-machine ML systems
+- **Programming proficiency** in Python with familiarity in NumPy
+- **Mathematics foundations** in linear algebra, calculus, and probability
+- Familiarity with distributed systems concepts (networking, parallelism) is helpful for advanced topics
+
+## Support Our Mission {.unnumbered}
+
+```{=html}
+<div class="support-mission">
+  <p><strong>2026 Goal:</strong> Help 100,000 students learn ML Systems. Sponsors like the <a href="https://edgeaifoundation.org/" target="_blank" rel="noopener noreferrer">EDGE AI Foundation</a> match every star with funding that supports learning.</p>
+
+  <div class="support-actions">
+    <span class="star-count" id="star-count">Loading...</span>
+    <a href="https://github.com/harvard-edge/cs249r_book" target="_blank" rel="noopener" class="github-star-btn">⭐ Star on GitHub</a>
+  </div>
+
+  <p class="support-note">
+    <a href="https://opencollective.com/mlsysbook" target="_blank" rel="noopener">Support us on Open Collective →</a>
+  </p>
+</div>
+```
+
+```{=html}
+<script>
+async function fetchGitHubStars() {
+  const starElement = document.getElementById('star-count');
+
+  try {
+    const response = await fetch('https://api.github.com/repos/harvard-edge/cs249r_book');
+    const data = await response.json();
+    const starCount = data.stargazers_count;
+    const formattedCount = starCount.toLocaleString();
+    starElement.textContent = formattedCount;
+    starElement.style.opacity = '1';
+  } catch (error) {
+    console.error('Failed to fetch GitHub stars:', error);
+    starElement.textContent = 'Loading...';
+    starElement.style.opacity = '1';
+  }
+}
+
+document.addEventListener('DOMContentLoaded', fetchGitHubStars);
+</script>
+```
+
+## Listen to the AI Podcast {.unnumbered}
+
+```{=html}
+<div class="podcast-section">
+  <p>
+    This short podcast, created with Google's Notebook LM and inspired by insights from our <a href="https://web.eng.fiu.edu/gaquan/Papers/ESWEEK24Papers/CPS-Proceedings/pdfs/CODES-ISSS/563900a043/563900a043.pdf" target="_blank" rel="noopener">IEEE education viewpoint paper</a>, offers an accessible overview of the book's key ideas and themes.
+  </p>
+  <audio controls="controls">
+    <source src="assets/media/notebooklm_podcast_mlsysbookai.mp3" type="audio/mpeg" />
+    Your browser does not support the audio element.
+  </audio>
+</div>
+```
+
+## Want to Help Out? {.unnumbered}
+
+This is a collaborative project, and your input matters. If you'd like to contribute, check out our [contribution guidelines](https://github.com/harvard-edge/cs249r_book/blob/main/book/docs/CONTRIBUTING.md). Feedback, corrections, and new ideas are welcome. Simply file a GitHub [issue](https://github.com/harvard-edge/cs249r_book/issues).
+
+:::


### PR DESCRIPTION
## Summary

Critical release-blocker: the deployed dev mirror's `/book/vol1/` page renders **vol2 content** (h1 "Machine Learning Systems at Scale", vol2 cover image), and the cover image 404s on both volumes. Without this fix, the first vol1 publish to `mlsysbook.ai` would ship vol2's welcome page under the vol1 URL.

## Root cause

1. **Symlink misroutes vol1's index** — `book/quarto/index.qmd` is a symlink to `contents/vol2/index.qmd` (commit `74cff1e833`). Both `_quarto-html-vol1.yml` and `_quarto-html-vol2.yml` declare `render: - index.qmd`, so vol1 ends up rendering vol2's welcome content. The h1 we see on the live dev page proves this:

   - https://harvard-edge.github.io/cs249r_book_dev/book/vol1/ → \`<h1 class="title">Machine Learning Systems at Scale</h1>\` (that's vol2's title)

2. **`../../` cover/audio paths 404** — both `contents/vol1/index.qmd` and `contents/vol2/index.qmd` set the cover `<img src>` and podcast `<source src>` to `../../assets/...`. Quarto leaves paths inside `\`\`\`{=html}` raw blocks verbatim, so on the deployed page at `/book/volX/index.html`, `../../assets/...` resolves above the per-volume deploy root (where no asset exists) instead of the per-volume `assets/` directory (where Quarto actually copies it via `resources:`).

## Fix

- Add real (non-symlink) `book/quarto/index-vol1.qmd` and `book/quarto/index-vol2.qmd` at the project root, copied from each volume's existing `contents/volX/index.qmd` with two corrections:
  - Cover `<img src>` and podcast `<source src>` lose the `../../` prefix.
  - `output-file: index.html` in the front matter so the rendered artifact lands as `_build/html-volX/index.html` directly (no redirect stub).
- Point all 8 per-volume render blocks (html / pdf / pdf-copyedit / epub × vol1 / vol2) at `index-volX.qmd` instead of the shared `index.qmd` symlink.
- **Untouched on purpose:** `book/quarto/index.qmd` (no longer rendered, kept for local dev tooling) and `book/quarto/contents/volX/index.qmd` (still the sidebar "Volume home" landing under each volume).

## Verification (local)

\`\`\`
cd book/quarto
quarto render index-vol1.qmd --to html
\`\`\`

Produces a single `_build/html-vol1/index.html` (no redirect stub). Probed via `python3 -m http.server`:

| URL | Before | After |
|---|---|---|
| `/` `<title>` | `Introduction to Machine Learning Systems` | same ✓ |
| `/` `<h1 class="title">` | **`Machine Learning Systems at Scale`** (wrong, vol2) | `Introduction to Machine Learning Systems` ✓ |
| `/assets/images/covers/cover-hardcover-book-vol1.png` | n/a (page used `../../`) | **200** ✓ |
| `/assets/media/notebooklm_podcast_mlsysbookai.mp3` | n/a (page used `../../`) | **200** ✓ |

## Test plan

- [ ] `book-validate-dev.yml` builds vol1 and vol2 cleanly
- [ ] After merge to `dev`, the dev-mirror smoke probe should show:
  - `/book/vol1/` → `<h1 class="title">Introduction to Machine Learning Systems</h1>`
  - `/book/vol1/assets/images/covers/cover-hardcover-book-vol1.png` → 200
  - `/book/vol2/` → `<h1 class="title">Machine Learning Systems at Scale</h1>` (still correct)
  - `/book/vol2/assets/images/covers/cover-hardcover-book-vol2.png` → 200
- [ ] PDF/EPUB builds in CI complete without "missing input file" errors

## Risk

- **Low.** Diff is 8 single-line yml swaps + 2 new root files. Symlink and per-volume `contents/` files are untouched. PDF/EPUB configs are updated symmetrically with HTML so no format will silently drift.

## Discovered by

Live URL probing while preparing the staged release. The bug had been latent since the index symlink was repointed at vol2 during vol2 development; vol1 hadn't been re-published since.