### PR TITLE
fix(book-publish): bump version in BOTH per-volume index files

### DIFF
--- a/.github/workflows/book-publish-live.yml
+++ b/.github/workflows/book-publish-live.yml
@@ -677,15 +677,18 @@ jobs:
 
       - name: 📝 Update per-volume version in index.qmd
         run: |
-          # The volume version display lives in:
-          #   contents/vol1/index.qmd   doi: "vX.Y.Z"
-          #   contents/vol2/index.qmd   doi: "vA.B.C"
-          # rendered into the "Version" field of each volume's title block.
-          # version-link.js picks up the v\d+\.\d+\.\d+ string and hyperlinks
-          # it to the releases page.
+          # The volume version display lives in TWO places per volume:
+          #   index-vol{N}.qmd                 (project-root, renders /book/vol{N}/index.html)
+          #   contents/vol{N}/index.qmd        (deep, renders /book/vol{N}/contents/vol{N}/index.html)
+          # Both have a `doi: "vX.Y.Z"` line that surfaces in the title block,
+          # and version-link.js picks up the v\d+\.\d+\.\d+ string to hyperlink
+          # it to the releases page. The deep file remains the canonical
+          # sidebar "Volume home"; the root file is what the public URL hits.
           #
-          # We update the bare "vX.Y.Z" form (no prefix) because that's what
-          # readers see; the per-volume tag itself uses the vol{N}-v prefix.
+          # We MUST update both — otherwise the publicly-rendered welcome page
+          # at /book/vol{N}/ would display a stale version after the publish.
+          # The bare "vX.Y.Z" form (no `vol{N}-` prefix) is what readers see;
+          # the per-volume git tag itself uses the vol{N}-v prefix.
 
           NEW_VOL1="${{ needs.validate-inputs.outputs.new_vol1_version }}"
           NEW_VOL2="${{ needs.validate-inputs.outputs.new_vol2_version }}"
@@ -695,22 +698,35 @@ jobs:
 
           UPDATED_FILES=()
 
+          # bump_volume_doi <bare-version> <file...>
+          # Tolerates a missing file (warn only) so a future config change
+          # that removes one of the surfaces doesn't fail the publish.
+          bump_volume_doi() {
+            local bare="$1"; shift
+            for f in "$@"; do
+              if [ ! -f "$f" ]; then
+                echo "⚠️ skipping (not found): $f"
+                continue
+              fi
+              echo "📝 setting doi → $bare in $f"
+              sed -i "s|doi: \".*\"|doi: \"$bare\"|g" "$f"
+              grep "doi:" "$f" || echo "⚠️ no doi: line found in $f"
+              UPDATED_FILES+=("$f")
+            done
+          }
+
           if [ -n "$NEW_VOL1" ]; then
             BARE="${NEW_VOL1#vol1-}"   # strip "vol1-" → "vX.Y.Z"
-            FILE="${{ vars.BOOK_QUARTO }}/contents/vol1/index.qmd"
-            echo "📝 vol1: setting doi → $BARE in $FILE"
-            sed -i "s|doi: \".*\"|doi: \"$BARE\"|g" "$FILE"
-            grep "doi:" "$FILE" || echo "⚠️ no doi: line found in $FILE"
-            UPDATED_FILES+=("$FILE")
+            bump_volume_doi "$BARE" \
+              "${{ vars.BOOK_QUARTO }}/index-vol1.qmd" \
+              "${{ vars.BOOK_QUARTO }}/contents/vol1/index.qmd"
           fi
 
           if [ -n "$NEW_VOL2" ]; then
             BARE="${NEW_VOL2#vol2-}"
-            FILE="${{ vars.BOOK_QUARTO }}/contents/vol2/index.qmd"
-            echo "📝 vol2: setting doi → $BARE in $FILE"
-            sed -i "s|doi: \".*\"|doi: \"$BARE\"|g" "$FILE"
-            grep "doi:" "$FILE" || echo "⚠️ no doi: line found in $FILE"
-            UPDATED_FILES+=("$FILE")
+            bump_volume_doi "$BARE" \
+              "${{ vars.BOOK_QUARTO }}/index-vol2.qmd" \
+              "${{ vars.BOOK_QUARTO }}/contents/vol2/index.qmd"
           fi
 
           if [ "${#UPDATED_FILES[@]}" -eq 0 ]; then


### PR DESCRIPTION
## Summary

PR-6 (#1410) routed each volume's `/book/vol{N}/` URL to a new project-root `index-vol{N}.qmd`. The `Update per-volume version in index.qmd` step in `book-publish-live.yml` was written before that change and still only sed-updates `contents/vol{N}/index.qmd`. After the next book publish:

- `contents/vol1/index.qmd` → `doi: \"v0.6.0\"` ✅ (deep page)
- `index-vol1.qmd` → `doi: \"v0.5.1\"` ❌ (the actual public welcome page at `/book/vol1/`)

So readers would see the **old** version on the page they actually land on. This PR fixes that.

## Change

- Refactor the step into a `bump_volume_doi <bare-version> <file...>` helper.
- Call it for both surfaces per volume:
  - `index-vol{N}.qmd` (project root, public welcome)
  - `contents/vol{N}/index.qmd` (sidebar Volume home)
- Helper warns and skips on a missing file so a future config change that removes one surface doesn't fail the publish.
- Comment block updated to spell out the two surfaces and why both must move in lockstep.
- No behavior change for either file: same `sed` pattern, same commit message, same `UPDATED_FILES` gating, same downstream merge-to-main step.

## How this came up

While answering \"didn't the publish-live workflow handle the version bump automatically?\" during TinyTorch v0.10.0 release prep. The TinyTorch workflow does fully automate the bump and PR-4's manual pre-bump was redundant (safe with `explicit_version=0.10.0`, but redundant). That led to checking the parallel book workflow and noticing this gap PR-6 had silently introduced.

## Test plan

- [ ] Workflow YAML is valid (`yamllint` / GitHub Actions parser)
- [ ] Next book-publish-live run with a non-empty `new_vol1_version` updates both files and the resulting commit message lists both
- [ ] If `index-vol1.qmd` ever gets removed/renamed, publish proceeds (warns instead of failing)

## Risk

Trivial. One step, additive logic, defensive on missing files.