### PR TITLE
fix(mlsysim): add missing contributors (VJ as #1, Zeljko Hrcek)

### DIFF
--- a/mlsysim/.all-contributorsrc
+++ b/mlsysim/.all-contributorsrc
@@ -14,6 +14,19 @@
     "skipCi": true,
     "contributors": [
         {
+            "login": "profvjreddi",
+            "name": "Vijay Janapa Reddi",
+            "avatar_url": "https://avatars.githubusercontent.com/profvjreddi",
+            "profile": "https://github.com/profvjreddi",
+            "contributions": [
+                "code",
+                "design",
+                "doc",
+                "ideas",
+                "maintenance"
+            ]
+        },
+        {
             "login": "asgalon",
             "name": "Peter Koellner",
             "avatar_url": "https://avatars.githubusercontent.com/u/45242704?v=4",
@@ -21,6 +34,15 @@
             "contributions": [
                 "bug",
                 "doc"
+            ]
+        },
+        {
+            "login": "hzeljko",
+            "name": "Zeljko Hrcek",
+            "avatar_url": "https://avatars.githubusercontent.com/hzeljko",
+            "profile": "https://github.com/hzeljko",
+            "contributions": [
+                "code"
             ]
         },
         {

--- a/mlsysim/README.md
+++ b/mlsysim/README.md
@@ -228,7 +228,9 @@ Thanks to these wonderful people for helping improve MLSys·im!
 <table>
   <tbody>
     <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/profvjreddi"><img src="https://avatars.githubusercontent.com/profvjreddi?v=4?s=80" width="80px;" alt="Vijay Janapa Reddi"/><br /><sub><b>Vijay Janapa Reddi</b></sub></a><br />🧑‍💻 🎨 ✍️ 🤔 🚧</td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/asgalon"><img src="https://avatars.githubusercontent.com/u/45242704?v=4?v=4?s=80" width="80px;" alt="Peter Koellner"/><br /><sub><b>Peter Koellner</b></sub></a><br />🪲 ✍️</td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/hzeljko"><img src="https://avatars.githubusercontent.com/hzeljko?v=4?s=80" width="80px;" alt="Zeljko Hrcek"/><br /><sub><b>Zeljko Hrcek</b></sub></a><br />🧑‍💻</td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Shashank-Tripathi-07"><img src="https://avatars.githubusercontent.com/u/178375647?v=4?v=4?s=80" width="80px;" alt="Rocky"/><br /><sub><b>Rocky</b></sub></a><br />🧑‍💻</td>
     </tr>
   </tbody>


### PR DESCRIPTION
## Why

The MLSys·im contributor list rendered on the site was missing two real contributors. Caught during release prep:

| Contributor | Commits to `mlsysim/` | Status before this PR |
| --- | ---: | --- |
| Vijay Janapa Reddi (`profvjreddi`) | **196** (incl. the project's first commit, `c56cb62c25`, 2026-03-01) | **Missing** |
| Peter Koellner (`asgalon`) | 0 (bug reports / docs) | Present |
| Zeljko Hrcek (`hzeljko`) | 1 (`dd9585543c`, "Add compatibility layer for textbook scenarios") | **Missing** |
| Rocky (`Shashank-Tripathi-07`) | 1 | Present |

This was an mlsysim-only outlier — both `labs/.all-contributorsrc` and the root `.all-contributorsrc` already list VJ as #1, and the root list already includes Zeljko.

## What

- Add VJ to `mlsysim/.all-contributorsrc` as the **first** entry — `code, design, doc, ideas, maintenance` (rendered 🧑‍💻 🎨 ✍️ 🤔 🚧). Categories chosen to reflect originator + ongoing-lead role, going beyond the labs `code+design+doc` baseline.
- Add Zeljko Hrcek (`hzeljko`) — `code` (🧑‍💻).
- Regenerate the matching `<table>` block in `mlsysim/README.md` so the bot's source-of-truth JSON and the rendered HTML stay in lockstep. Final row order: VJ, Peter, Zeljko, Rocky.
- Existing Peter and Rocky entries preserved verbatim.

## Verification

- JSON validates (`python3 -c "import json; json.load(open('mlsysim/.all-contributorsrc'))"`).
- Diff is +24 / −0; no formatting churn elsewhere.
- Table HTML mirrors the JSON one-for-one.

## Notes

- Avatar URL formats are mixed (`/u/<id>?v=4` for the existing two entries vs. `/<login>` for VJ/Zeljko). Both work; matched the format used in the root `.all-contributorsrc` for the new entries. The all-contributors bot will normalize on its next run if anyone uses it.
- The mlsysim README's contribution-emoji **legend** uses custom emojis (🪲 ⚡ 📚 🎨 🧠) but the bot generates standard all-contributors ones (🐛 🧑‍💻 ✍️ 🎨 🤔). That mismatch is pre-existing and out of scope for this PR.