### PR TITLE
fix(staffml/practice): apply effectiveMaxScore to score buttons and save handler

### DIFF
--- a/interviews/staffml/src/app/practice/page.tsx
+++ b/interviews/staffml/src/app/practice/page.tsx
@@ -338,7 +338,7 @@ function PracticePage() {
 
   const handleScore = (score: number) => {
     if (current) {
-      const finalScore = Math.min(score, maxScore);
+      const finalScore = Math.min(score, effectiveMaxScore);
       saveAttempt({
         questionId: current.id,
         competencyArea: current.competency_area,
@@ -989,12 +989,12 @@ function PracticePage() {
                           { score: 2, label: "Partial", color: "border-accentAmber/30 text-accentAmber hover:bg-accentAmber/10" },
                           { score: 3, label: "Nailed It", color: "border-accentGreen/30 text-accentGreen hover:bg-accentGreen/10" },
                         ].map(({ score, label, color }) => {
-                          const disabled = score > maxScore;
+                          const disabled = score > effectiveMaxScore;
                           const isRubricSuggested = rubricScore !== null && score === rubricScore;
                           return (
                             <button
                               key={score}
-                              onClick={() => handleScore(Math.min(score, maxScore))}
+                              onClick={() => handleScore(Math.min(score, effectiveMaxScore))}
                               disabled={disabled}
                               aria-label={`Rate yourself: ${label} (${score} of 3)`}
                               className={clsx(


### PR DESCRIPTION
## What is the bug

In the Practice page, when a user finishes answering a question, they self-score using four buttons: Skip, Wrong, Partial, Nailed It.

Two things are supposed to cap how high a user can score themselves:
1. Napkin math accuracy (if their math was off, the cap lowers)
2. Rubric score (if their rubric checkboxes suggest a lower score, the cap lowers further)

The code already computed the correct combined cap in `effectiveMaxScore`. But the actual save call and the disabled check on the buttons both used `maxScore` (napkin math only), ignoring `effectiveMaxScore` entirely. So the rubric cap was never enforced.

In practice: a user whose rubric said Wrong could still click Nailed It and save a score of 3. The rubric suggestion was shown visually but had zero effect on what got stored.

## The fix

Three one-line changes in `practice/page.tsx`, all replacing `maxScore` with `effectiveMaxScore`:

- `handleScore`: the saved score is now capped by both napkin math and rubric
- Button `disabled` check: buttons above the effective cap are greyed out
- Button `onClick`: same cap applied on click

## How to verify

1. Open Practice on any question that has rubric items
2. Check only the first rubric checkbox (low score suggestion)
3. The higher score buttons should now be disabled
4. Before this fix they were always enabled regardless of rubric