### PR TITLE
fix(tinytorch): fix dark mode visibility across cards on milestones page

### DIFF
--- a/tinytorch/site/_static/custom.css
+++ b/tinytorch/site/_static/custom.css
@@ -2260,3 +2260,14 @@ html[data-theme="dark"] .milestones-track-box p,
 html[data-theme="dark"] .milestones-track-box li {
     color: #e2e8f0 !important;
 }
+
+/* Milestones page - "Three Tracking Systems" box */
+html[data-theme="dark"] .milestones-tracking-box {
+    background: #1e293b !important;
+}
+html[data-theme="dark"] .milestones-tracking-box,
+html[data-theme="dark"] .milestones-tracking-box strong,
+html[data-theme="dark"] .milestones-tracking-box p,
+html[data-theme="dark"] .milestones-tracking-box li {
+    color: #e2e8f0 !important;
+}

--- a/tinytorch/site/_static/custom.css
+++ b/tinytorch/site/_static/custom.css
@@ -2221,3 +2221,16 @@ html[data-theme="dark"] .milestones-discover-box p,
 html[data-theme="dark"] .milestones-discover-box li {
     color: #e2e8f0 !important;
 }
+
+/* Milestones page - "Learn About Milestones" card */
+html[data-theme="dark"] .milestones-learn-box {
+    filter: none !important;
+    background: #1f1100 !important;
+    border-left-color: #ffb74d !important;
+}
+html[data-theme="dark"] .milestones-learn-box,
+html[data-theme="dark"] .milestones-learn-box strong,
+html[data-theme="dark"] .milestones-learn-box p,
+html[data-theme="dark"] .milestones-learn-box li {
+    color: #e2e8f0 !important;
+}

--- a/tinytorch/site/_static/custom.css
+++ b/tinytorch/site/_static/custom.css
@@ -2208,3 +2208,16 @@ html[data-theme="dark"] .milestones-quickstart-box p,
 html[data-theme="dark"] .milestones-quickstart-box li {
     color: #e2e8f0 !important;
 }
+
+/* Milestones page - "Discover Milestones" card */
+html[data-theme="dark"] .milestones-discover-box {
+    filter: none !important;
+    background: #0d2137 !important;
+    border-left-color: #64b5f6 !important;
+}
+html[data-theme="dark"] .milestones-discover-box,
+html[data-theme="dark"] .milestones-discover-box strong,
+html[data-theme="dark"] .milestones-discover-box p,
+html[data-theme="dark"] .milestones-discover-box li {
+    color: #e2e8f0 !important;
+}

--- a/tinytorch/site/_static/custom.css
+++ b/tinytorch/site/_static/custom.css
@@ -2234,3 +2234,16 @@ html[data-theme="dark"] .milestones-learn-box p,
 html[data-theme="dark"] .milestones-learn-box li {
     color: #e2e8f0 !important;
 }
+
+/* Milestones page - "Run Milestones" card */
+html[data-theme="dark"] .milestones-run-box {
+    filter: none !important;
+    background: #1a0e2e !important;
+    border-left-color: #ce93d8 !important;
+}
+html[data-theme="dark"] .milestones-run-box,
+html[data-theme="dark"] .milestones-run-box strong,
+html[data-theme="dark"] .milestones-run-box p,
+html[data-theme="dark"] .milestones-run-box li {
+    color: #e2e8f0 !important;
+}

--- a/tinytorch/site/_static/custom.css
+++ b/tinytorch/site/_static/custom.css
@@ -2247,3 +2247,16 @@ html[data-theme="dark"] .milestones-run-box p,
 html[data-theme="dark"] .milestones-run-box li {
     color: #e2e8f0 !important;
 }
+
+/* Milestones page - "Track Progress" card */
+html[data-theme="dark"] .milestones-track-box {
+    filter: none !important;
+    background: #0a1f0a !important;
+    border-left-color: #4ade80 !important;
+}
+html[data-theme="dark"] .milestones-track-box,
+html[data-theme="dark"] .milestones-track-box strong,
+html[data-theme="dark"] .milestones-track-box p,
+html[data-theme="dark"] .milestones-track-box li {
+    color: #e2e8f0 !important;
+}

--- a/tinytorch/site/_static/custom.css
+++ b/tinytorch/site/_static/custom.css
@@ -2196,3 +2196,15 @@ html[data-theme="dark"] .modules-trouble-box p,
 html[data-theme="dark"] .modules-trouble-box li {
     color: #e2e8f0 !important;
 }
+
+/* Milestones page - "Quick Start" box */
+html[data-theme="dark"] .milestones-quickstart-box {
+    background: #1e293b !important;
+    border-color: #334155 !important;
+}
+html[data-theme="dark"] .milestones-quickstart-box,
+html[data-theme="dark"] .milestones-quickstart-box strong,
+html[data-theme="dark"] .milestones-quickstart-box p,
+html[data-theme="dark"] .milestones-quickstart-box li {
+    color: #e2e8f0 !important;
+}

--- a/tinytorch/site/tito/milestones.md
+++ b/tinytorch/site/tito/milestones.md
@@ -325,7 +325,7 @@ Unlock by completing module: 09
 
 TinyTorch tracks progress in three ways (all are related but distinct):
 
-<div style="background: #f8f9fa; padding: 1.5rem; border-radius: 0.5rem; margin: 1rem 0;">
+<div class="milestones-tracking-box" style="background: #f8f9fa; padding: 1.5rem; border-radius: 0.5rem; margin: 1rem 0;">
 
 **1. Module Completion** (`tito module status`)
 - Which modules (01-20) you've implemented

--- a/tinytorch/site/tito/milestones.md
+++ b/tinytorch/site/tito/milestones.md
@@ -117,7 +117,7 @@ tito milestone run 03 --skip-checks
 
 ### Track Progress
 
-<div style="background: #f0fdf4; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #22c55e; margin: 1rem 0;">
+<div class="milestones-track-box" style="background: #f0fdf4; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #22c55e; margin: 1rem 0;">
 
 **View Milestone Progress**
 ```bash

--- a/tinytorch/site/tito/milestones.md
+++ b/tinytorch/site/tito/milestones.md
@@ -76,7 +76,7 @@ tito milestone list --simple
 
 ### Learn About Milestones
 
-<div style="background: #fff3e0; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #ff9800; margin: 1rem 0;">
+<div class="milestones-learn-box" style="background: #fff3e0; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #ff9800; margin: 1rem 0;">
 
 **Get Detailed Information**
 ```bash

--- a/tinytorch/site/tito/milestones.md
+++ b/tinytorch/site/tito/milestones.md
@@ -55,7 +55,7 @@ tito milestone run 03
 
 ### Discover Milestones
 
-<div style="background: #e3f2fd; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #2196f3; margin: 1rem 0;">
+<div class="milestones-discover-box" style="background: #e3f2fd; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #2196f3; margin: 1rem 0;">
 
 **List All Milestones**
 ```bash

--- a/tinytorch/site/tito/milestones.md
+++ b/tinytorch/site/tito/milestones.md
@@ -24,7 +24,7 @@ Each milestone script imports **YOUR code** from the TinyTorch package you built
 
 ## Quick Start
 
-<div style="background: #f8f9fa; padding: 1.5rem; border: 1px solid #dee2e6; border-radius: 0.5rem; margin: 1.5rem 0;">
+<div class="milestones-quickstart-box" style="background: #f8f9fa; padding: 1.5rem; border: 1px solid #dee2e6; border-radius: 0.5rem; margin: 1.5rem 0;">
 
 **Typical workflow:**
 

--- a/tinytorch/site/tito/milestones.md
+++ b/tinytorch/site/tito/milestones.md
@@ -93,7 +93,7 @@ Shows:
 
 ### Run Milestones
 
-<div style="background: #f3e5f5; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #9c27b0; margin: 1rem 0;">
+<div class="milestones-run-box" style="background: #f3e5f5; padding: 1.5rem; border-radius: 0.5rem; border-left: 4px solid #9c27b0; margin: 1rem 0;">
 
 **Run a Milestone**
 ```bash


### PR DESCRIPTION
## Problem

Six cards/boxes on the milestones page had invisible text in dark mode due
to hardcoded light background colors in inline `style` attributes with no
dark mode CSS overrides.

## Sections fixed

| Section | Light bg | Dark bg | Class |
|---|---|---|---|
| Quick Start | `#f8f9fa` | `#1e293b` | `milestones-quickstart-box` |
| Discover Milestones | `#e3f2fd` | `#0d2137` | `milestones-discover-box` |
| Learn About Milestones | `#fff3e0` | `#1f1100` | `milestones-learn-box` |
| Run Milestones | `#f3e5f5` | `#1a0e2e` | `milestones-run-box` |
| Track Progress | `#f0fdf4` | `#0a1f0a` | `milestones-track-box` |
| Three Tracking Systems | `#f8f9fa` | `#1e293b` | `milestones-tracking-box` |

## Solution

**`tito/milestones.md`** — Added semantic CSS classes to each affected
element while keeping existing inline styles intact for light mode.

**`_static/custom.css`** — Added targeted `html[data-theme="dark"]` overrides
for each class. Each card gets a brand-tinted dark background that preserves
its color identity (blue → navy, purple → dark purple, green → dark green,
amber → deep amber) with `filter: none !important` where needed to bypass
the existing brightness dimmer. Border-left colors switched to lighter
shades for dark-mode contrast.

## Files changed
- `tinytorch/site/tito/milestones.md` — 6 lines changed (class attributes added)
- `tinytorch/site/_static/custom.css` — 80 lines added (dark mode overrides)
