### PR TITLE
fix(publish): block silent version downgrades in tinytorch + book publish-live

### DIFF
--- a/.github/workflows/book-publish-live.yml
+++ b/.github/workflows/book-publish-live.yml
@@ -536,6 +536,115 @@ jobs:
             echo "previous_vol2_version=$PREV_VOL2"
           } >> "$GITHUB_OUTPUT"
 
+      - name: 🛡️ No-downgrade guard (per-volume)
+        env:
+          # Step `run:` blocks don't inherit shell variables across steps;
+          # surface the per-volume outputs as env so the guard can read them.
+          NEW_VOL1: ${{ steps.version.outputs.new_vol1_version }}
+          NEW_VOL2: ${{ steps.version.outputs.new_vol2_version }}
+        run: |
+          # ----------------------------------------------------------------
+          # No-downgrade guard.
+          #
+          # The version-bump step computes NEW_VOL{1,2} from the latest
+          # vol{1,2}-v* tag (with a legacy/zero-seed fallback for first
+          # releases). When the per-volume index.qmd doi has been edited
+          # ahead of the tags — for example vol2 is currently displaying
+          # `doi: "v0.5.1"` inherited from the legacy single-volume era —
+          # the auto-computed value can be LOWER than what the source
+          # already shows, and the downstream sed step would silently
+          # rewrite the doi to the lower version.
+          #
+          # Concrete failure modes this guard prevents:
+          #   - vol2: index-vol2.qmd doi="v0.5.1", no vol2-v* tag exists,
+          #           release_type=patch → workflow computes vol2-v0.0.1
+          #           → sed rewrites doi to "v0.0.1" → the public welcome
+          #           page silently regresses from v0.5.1 to v0.0.1.
+          #   - any volume where someone manually edited doi past the
+          #           latest tag and then ran patch/minor against the
+          #           older tag.
+          #
+          # The guard refuses to proceed if the bare planned version is
+          # not >= the bare doi already in EITHER per-volume index.qmd.
+          # Equality is allowed (no-op write); strictly less is blocked.
+          #
+          # Fix when this trips:
+          #   - If the doi in index-vol{N}.qmd is correct, request the
+          #     matching version: re-run with previous_version pointing
+          #     at the right tag (or seed a tag at the displayed version
+          #     and re-run).
+          #   - If the doi is stale, edit it down to match the latest
+          #     tag and re-run.
+          # ----------------------------------------------------------------
+
+          # sort -V puts the higher semver last
+          semver_lt() {
+            # returns 0 (true) if $1 < $2 strictly
+            local a="$1" b="$2"
+            [ "$a" = "$b" ] && return 1
+            local highest
+            highest=$(printf '%s\n%s\n' "$a" "$b" | sort -V | tail -n1)
+            [ "$highest" = "$b" ]
+          }
+
+          read_doi() {
+            local f="$1"
+            [ -f "$f" ] || { echo ""; return; }
+            grep -E '^[[:space:]]*doi:[[:space:]]*"' "$f" \
+              | head -n1 | sed -E 's/.*"([^"]+)".*/\1/' \
+              | sed -E 's/^v//'
+          }
+
+          check_volume() {
+            # check_volume <vol-tag>  e.g. vol1-v0.6.0
+            local new_tag="$1" prefix bare doi_bare doi_raw f
+            [ -z "$new_tag" ] && return 0   # not in scope this run
+            prefix="${new_tag%%-*}"        # vol1 or vol2
+            bare="${new_tag#${prefix}-v}"  # X.Y.Z
+            f="${{ vars.BOOK_QUARTO }}/index-${prefix}.qmd"
+
+            if [ ! -f "$f" ]; then
+              echo "⚠️ $f missing — skipping guard for $prefix (PR-6 not deployed?)."
+              return 0
+            fi
+
+            doi_bare=$(read_doi "$f")
+            doi_raw="v${doi_bare}"
+            echo "📂 $prefix source-of-truth (${f##*/}): $doi_raw"
+            echo "🎯 $prefix planned new version:        v$bare"
+
+            if [ -z "$doi_bare" ]; then
+              echo "❌ Could not read doi from $f — refusing to proceed."
+              return 1
+            fi
+
+            if semver_lt "$bare" "$doi_bare"; then
+              echo ""
+              echo "❌ DOWNGRADE BLOCKED for $prefix"
+              echo "   ${f##*/} doi is v$doi_bare but this run would write v$bare."
+              echo ""
+              echo "   This usually means index-${prefix}.qmd was edited past"
+              echo "   the latest ${prefix}-v* tag, or no ${prefix}-v* tag"
+              echo "   exists yet and the auto-seeded baseline is lower than"
+              echo "   what readers currently see."
+              echo ""
+              echo "   To proceed, either:"
+              echo "     1. Run with previous_version=${prefix}-v$doi_bare so the"
+              echo "        next bump starts from the displayed version, or"
+              echo "     2. Edit index-${prefix}.qmd doi down to match the"
+              echo "        latest ${prefix}-v* tag and re-run."
+              return 1
+            fi
+
+            echo "✅ $prefix planned v$bare ≥ source v$doi_bare — allowed."
+            return 0
+          }
+
+          rc=0
+          check_volume "$NEW_VOL1" || rc=1
+          check_volume "$NEW_VOL2" || rc=1
+          exit "$rc"
+
   pre-flight-checks:
     name: '🛫 Pre-Flight Validation'
     runs-on: ubuntu-latest

--- a/.github/workflows/tinytorch-publish-live.yml
+++ b/.github/workflows/tinytorch-publish-live.yml
@@ -189,6 +189,77 @@ jobs:
           echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "previous_version=$LATEST_VERSION" >> $GITHUB_OUTPUT
 
+      - name: 🛡️ No-downgrade guard
+        if: github.event.inputs.site_only != 'true'
+        run: |
+          # ----------------------------------------------------------------
+          # No-downgrade guard.
+          #
+          # The version-bump step computes NEW_VERSION from the latest git
+          # tag (`tinytorch-v*`). That works perfectly when the source files
+          # are kept in lockstep with the tags. It silently DOWNGRADES the
+          # source if someone manually pre-bumps `pyproject.toml` and then
+          # forgets to also tag.
+          #
+          # Concrete failure mode this guard prevents:
+          #   - latest tag:        tinytorch-v0.1.9
+          #   - pyproject.toml:    0.10.0   (manually pre-bumped for a non-
+          #                                  incremental jump)
+          #   - workflow dispatch: release_type=patch (the default!)
+          #   - workflow computes: 0.1.10
+          #   - sed step rewrites: pyproject.toml = 0.1.10
+          #   → silent downgrade from 0.10.0 to 0.1.10, no error.
+          #
+          # The guard refuses to proceed if the planned NEW_VERSION is not
+          # strictly greater (semver-wise) than the version already in the
+          # source-of-truth file. The fix when this trips:
+          #   1. If you intended the higher version, re-run with
+          #      explicit_version=<higher>. The override path is exempt
+          #      from the source-comparison only if it equals the source
+          #      (no-op write) or exceeds it (forward bump).
+          #   2. If you intended a lower version (rare, e.g. backing out
+          #      a botched bump), edit pyproject.toml manually first so
+          #      source and intent agree.
+          # ----------------------------------------------------------------
+
+          NEW_VERSION="${{ steps.version.outputs.new_version }}"
+          NEW_BARE="${NEW_VERSION#tinytorch-v}"
+          SRC_BARE=$(grep -E '^version *= *"' tinytorch/pyproject.toml \
+                     | head -n1 | sed -E 's/.*"([^"]+)".*/\1/')
+
+          echo "📂 source-of-truth (pyproject.toml): $SRC_BARE"
+          echo "🎯 planned new version:              $NEW_BARE"
+
+          if [ -z "$SRC_BARE" ]; then
+            echo "❌ Could not read version from tinytorch/pyproject.toml — refusing to proceed."
+            exit 1
+          fi
+
+          if [ "$NEW_BARE" = "$SRC_BARE" ]; then
+            echo "✅ planned version equals source — no-op write, allowed."
+            exit 0
+          fi
+
+          # sort -V puts the higher semver last
+          HIGHEST=$(printf '%s\n%s\n' "$NEW_BARE" "$SRC_BARE" | sort -V | tail -n1)
+          if [ "$HIGHEST" != "$NEW_BARE" ]; then
+            echo ""
+            echo "❌ DOWNGRADE BLOCKED"
+            echo "   pyproject.toml is at $SRC_BARE but this run would write $NEW_BARE."
+            echo "   sort -V says $SRC_BARE > $NEW_BARE."
+            echo ""
+            echo "   This usually means pyproject.toml was manually pre-bumped"
+            echo "   to $SRC_BARE without a matching tinytorch-v$SRC_BARE tag."
+            echo ""
+            echo "   To proceed, re-run this workflow with:"
+            echo "     explicit_version: $SRC_BARE          (publish current source as-is)"
+            echo "   or a higher value if you want to jump further. Or revert the"
+            echo "   manual pre-bump in pyproject.toml so source matches latest tag."
+            exit 1
+          fi
+
+          echo "✅ planned $NEW_BARE > source $SRC_BARE — forward bump, allowed."
+
   preflight:
     name: '✈️ Preflight Checks'
     needs: validate-inputs


### PR DESCRIPTION
## Summary

Adds a no-downgrade guard to both \`tinytorch-publish-live.yml\` and \`book-publish-live.yml\`.
Catches a real footgun in the next release: triggering with the default \`release_type=patch\`
silently regresses TinyTorch from \`0.10.0\` → \`0.1.10\` and Vol II from \`v0.5.1\` → \`v0.0.1\`.

## The footgun in concrete terms

| Workflow | Source-of-truth | Current value | Latest tag | Default \`patch\` would write | Result |
|---|---|---|---|---|---|
| \`tinytorch-publish-live\` | \`pyproject.toml\` | \`0.10.0\` | \`tinytorch-v0.1.9\` | \`0.1.10\` | **DOWNGRADE** |
| \`book-publish-live\` (vol2) | \`index-vol2.qmd\` doi | \`v0.5.1\` (legacy inheritance) | none → seeds \`v0.0.0\` | \`v0.0.1\` | **DOWNGRADE** |
| \`book-publish-live\` (vol1) | \`index-vol1.qmd\` doi | \`v0.5.1\` | seeds from \`book-v0.5.1\` | \`v0.5.2\` | OK (forward) |

Both downgrades complete with no error and silently overwrite the source.

## How the guard works

After version computation, before any \`sed\` write:

1. Read the bare version from the source-of-truth file.
2. Use \`sort -V\` to compare against the planned new version.
3. If planned \< source (strict), fail with a remediation message that names the exact dispatch
   input to use (\`explicit_version=X.Y.Z\` for tinytorch, \`previous_version=vol{N}-vX.Y.Z\`
   for the book).
4. Equality (no-op write) is allowed — needed for the v0.10.0 release where \`pyproject.toml\`
   is already at the target.
5. Site-only mode skips the guard (no version write happens at all).
6. Missing \`index-vol{N}.qmd\` warns rather than fails (defensive against future routing changes).

## Verification

Tested \`semver_lt\` locally against 9 cases:

\`\`\`
PASS  0.1.10 vs 0.10.0 → LT     ← the TinyTorch footgun
PASS  0.10.0 vs 0.1.10 → GE
PASS  0.10.0 vs 0.10.0 → GE     ← equality allowed
PASS  0.0.1 vs 0.5.1 → LT       ← vol2 patch regression
PASS  0.1.0 vs 0.5.1 → LT       ← vol2 minor still regresses
PASS  0.6.0 vs 0.5.1 → GE       ← vol1 normal forward bump
PASS  0.5.2 vs 0.5.1 → GE
PASS  1.0.0 vs 0.99.99 → GE
PASS  0.5.1 vs 0.5.10 → LT      ← naive lex sort would get this wrong
\`\`\`

YAML parses cleanly for both workflows. \`CI: Check workflows are safe for fork PRs\` hook passes.

## What this unblocks

The actual staged rollout (TinyTorch v0.10.0, Book vol1 v0.6.0, Book vol2 v0.1.0) can now be
triggered without worrying about the default-button creating a silent regression. Each volume's
first release just needs the right \`previous_version\` / \`explicit_version\` override, and the
guard tells you exactly which one to set if you forget.