### PR TITLE
fix(tests): make mlsysim.core importable from CI without pip install

### DIFF
--- a/book/tests/test_units.py
+++ b/book/tests/test_units.py
@@ -14,11 +14,22 @@ registered in pint's registry, not just a Python variable.
 import sys
 import os
 
-# Add repo root to path so mlsysim is importable (works from any working directory)
+# Make `mlsysim` importable without requiring a pip install.
+#
+# Layout reminder:
+#   <repo_root>/mlsysim/                ← project directory (NOT a Python package)
+#   <repo_root>/mlsysim/mlsysim/        ← actual Python package (has __init__.py)
+#   <repo_root>/mlsysim/mlsysim/core/   ← submodule
+#
+# So the directory we must put on sys.path is `<repo_root>/mlsysim/`, NOT
+# `<repo_root>/`. The previous `_repo_root` insert "worked" only in dev
+# environments where `mlsysim` was pip-installed (e.g. `pip install -e mlsysim/`),
+# masking the bug. CI has no editable install, so the import failed there.
 _script_dir = os.path.dirname(os.path.abspath(__file__))
-_book_dir = os.path.dirname(_script_dir)          # book/
-_repo_root = os.path.dirname(_book_dir)            # repo root (contains mlsysim/)
-sys.path.insert(0, _repo_root)
+_book_dir = os.path.dirname(_script_dir)                  # book/
+_repo_root = os.path.dirname(_book_dir)                   # repo root
+_mlsysim_project = os.path.join(_repo_root, "mlsysim")    # contains the package
+sys.path.insert(0, _mlsysim_project)
 sys.path.insert(0, _book_dir)
 
 from mlsysim.core.constants import *


### PR DESCRIPTION
## Summary

Fixes the `book-mlsys-test-units` pre-commit hook, which has been red on
**every** `book-validate-dev` run since 2026-04-18 (last green: 2026-04-17, sha `532eed35`).
The fix is one line of corrected `sys.path` math, with a comment explaining the layout
trap so it doesn't recur.

## Why it failed

`book/tests/test_units.py` did:

```python
sys.path.insert(0, _repo_root)         # cs249r_book/
from mlsysim.core.constants import *
```

But `mlsysim` package layout is two levels deep:

```
<repo_root>/mlsysim/                    ← project dir, NOT a Python package
<repo_root>/mlsysim/mlsysim/__init__.py ← actual package
<repo_root>/mlsysim/mlsysim/core/       ← submodule we want
```

- **In dev:** `mlsysim` is `pip install -e`'d, so Python found it via site-packages.
  The path hack was inert. The import worked. Tests passed locally.
- **In CI:** no editable install. Python 3.3+ saw `<repo_root>/mlsysim/` (no `__init__.py`)
  as an implicit namespace package, and `mlsysim.core` resolved nowhere → `ModuleNotFoundError`.

## Fix

Point `sys.path` at `<repo_root>/mlsysim/` (the directory containing the package),
not `<repo_root>/`:

```python
_mlsysim_project = os.path.join(_repo_root, "mlsysim")
sys.path.insert(0, _mlsysim_project)
```

Comment block above the change documents the layout so the next person to touch it
doesn't reintroduce the bug.

## Verification

- `pre-commit run book-mlsys-test-units --files book/quarto/contents/vol1/benchmarking/benchmarking.qmd` → **Passed** locally.
- All transitive deps (`pint`, `pydantic`, `numpy`, `pyyaml`, `rich`) are already
  in `book/tools/dependencies/requirements.txt`, which `book-validate-dev.yml` installs.
- Sandbox-emulated CI environment (no editable install, plain `sys.path`) resolves
  `mlsysim.core` correctly with this patch.

## What this unblocks

The book publish guard (`infra-publish-guard.yml` → `book-validate-dev.yml`) requires
the most recent dev validate run to be green. With this fix, `book-publish-live` can
be triggered for vol1 v0.6.0 / vol2 v0.1.0 once the next dev run goes green.