### PR TITLE
fix(quarto): restore mlsysim importability after PR #1397 outer-init removal

### DIFF
--- a/book/quarto/config/_quarto-pdf-vol1-copyedit.yml
+++ b/book/quarto/config/_quarto-pdf-vol1-copyedit.yml
@@ -114,7 +114,7 @@ bibliography:
 
 execute:
   env:
-    PYTHONPATH: "../.."
+    PYTHONPATH: "../..:../../mlsysim"
     MPLBACKEND: "Agg"
 
 metadata-files:

--- a/book/quarto/config/_quarto-pdf-vol1.yml
+++ b/book/quarto/config/_quarto-pdf-vol1.yml
@@ -130,7 +130,7 @@ metadata-files:
 
 execute:
   env:
-    PYTHONPATH: "../.."
+    PYTHONPATH: "../..:../../mlsysim"
     MPLBACKEND: "Agg"
 
 editor:

--- a/book/quarto/config/_quarto-pdf-vol2-copyedit.yml
+++ b/book/quarto/config/_quarto-pdf-vol2-copyedit.yml
@@ -116,7 +116,7 @@ bibliography:
 
 execute:
   env:
-    PYTHONPATH: "../.."
+    PYTHONPATH: "../..:../../mlsysim"
     MPLBACKEND: "Agg"
 
 metadata-files:

--- a/book/quarto/config/_quarto-pdf-vol2.yml
+++ b/book/quarto/config/_quarto-pdf-vol2.yml
@@ -132,7 +132,7 @@ metadata-files:
 
 execute:
   env:
-    PYTHONPATH: "../.."
+    PYTHONPATH: "../..:../../mlsysim"
     MPLBACKEND: "Agg"
 
 editor:

--- a/book/quarto/config/shared/base/execute-env.yml
+++ b/book/quarto/config/shared/base/execute-env.yml
@@ -1,6 +1,6 @@
 execute:
   env:
-    PYTHONPATH: "../.."
+    PYTHONPATH: "../..:../../mlsysim"
     MPLBACKEND: "Agg"
 
 editor:

--- a/book/tests/test_units.py
+++ b/book/tests/test_units.py
@@ -14,11 +14,22 @@ registered in pint's registry, not just a Python variable.
 import sys
 import os
 
-# Add repo root to path so mlsysim is importable (works from any working directory)
+# Make `mlsysim` importable without requiring a pip install.
+#
+# Layout reminder:
+#   <repo_root>/mlsysim/                ← project directory (NOT a Python package)
+#   <repo_root>/mlsysim/mlsysim/        ← actual Python package (has __init__.py)
+#   <repo_root>/mlsysim/mlsysim/core/   ← submodule
+#
+# So the directory we must put on sys.path is `<repo_root>/mlsysim/`, NOT
+# `<repo_root>/`. The previous `_repo_root` insert "worked" only in dev
+# environments where `mlsysim` was pip-installed (e.g. `pip install -e mlsysim/`),
+# masking the bug. CI has no editable install, so the import failed there.
 _script_dir = os.path.dirname(os.path.abspath(__file__))
-_book_dir = os.path.dirname(_script_dir)          # book/
-_repo_root = os.path.dirname(_book_dir)            # repo root (contains mlsysim/)
-sys.path.insert(0, _repo_root)
+_book_dir = os.path.dirname(_script_dir)                  # book/
+_repo_root = os.path.dirname(_book_dir)                   # repo root
+_mlsysim_project = os.path.join(_repo_root, "mlsysim")    # contains the package
+sys.path.insert(0, _mlsysim_project)
 sys.path.insert(0, _book_dir)
 
 from mlsysim.core.constants import *


### PR DESCRIPTION
## Summary

One-line fix to 5 Quarto config files. Same root cause as #1419 (`test_units.py` path bug),
different surface area: the actual book content. Unblocks the Container Build Matrix on
`book-validate-dev`, which has been failing since PR #1419 exposed it.

## What broke

Quarto's execute env sets:

\`\`\`yaml
execute:
  env:
    PYTHONPATH: "../.."   # = repo root
\`\`\`

The .qmd Python chunks then do \`from mlsysim.core.constants import *\`. That worked because
there used to be an outer \`mlsysim/__init__.py\` that made \`<repo_root>/mlsysim/\` a real
Python package — even though the actual package is one level deeper at
\`<repo_root>/mlsysim/mlsysim/\`. PR #1397 ("MLSys·im 0.1.0 release-prep audit") cleaned up
that nested-with-same-name layout (correct packaging hygiene), and the .qmd imports stopped
resolving with \`ModuleNotFoundError: No module named 'mlsysim.core'\`.

## Why it stayed hidden for 3 days

\`book-validate-dev\` was already red on the \`book-mlsys-test-units\` pre-commit hook
(fixed in #1419). Because the Container Build Matrix depends on Pre-commit Checks passing,
every container job was SKIPPED, not RUN. The moment #1419 made pre-commit green, the
matrix actually executed and surfaced this second failure on the same root cause.

## Blast radius

Roughly 15 vol1 chapters and a similar count in vol2 import \`mlsysim.core\` directly in
Python chunks (\`benchmarking\`, \`nn_architectures\`, \`hw_acceleration\`, \`model_serving\`,
\`training\`, \`ml_ops\`, \`responsible_engr\`, \`introduction\`, …). This affects every
HTML / PDF / EPUB build for both volumes.

## Fix

Prepend \`<repo_root>/mlsysim/\` (where the real package lives) to PYTHONPATH:

\`\`\`yaml
PYTHONPATH: "../..:../../mlsysim"
\`\`\`

Applied to all 5 config files that duplicate the PYTHONPATH line:
- \`book/quarto/config/shared/base/execute-env.yml\` (HTML; the one that matters most)
- \`book/quarto/config/_quarto-pdf-vol1.yml\`
- \`book/quarto/config/_quarto-pdf-vol1-copyedit.yml\`
- \`book/quarto/config/_quarto-pdf-vol2.yml\`
- \`book/quarto/config/_quarto-pdf-vol2-copyedit.yml\`

The original \`../..\` entry is preserved in case any existing import relies on repo-root scope.

## Verification

Emulated the Quarto execution context locally:

\`\`\`
cd book/quarto && PYTHONPATH="../..:../../mlsysim" python3 -c \\
  'from mlsysim import Hardware, Models; from mlsysim.core.constants import *'
\`\`\`

Resolves cleanly; \`Hardware\` comes from \`mlsysim.hardware.registry\`.

## What this unblocks

\`book-validate-dev\` going green for the first time since 2026-04-17 → publish guard
\`infra-publish-guard.yml\` re-armed → \`book-publish-live\` becomes triggerable for vol1
v0.6.0 / vol2 v0.1.0 (B3–B6 of the staged-rollout plan).