### PR TITLE
fix(ci): prepend mlsysim/ to container PYTHONPATH so Quarto can find the package

### DIFF
--- a/.github/workflows/book-build-container.yml
+++ b/.github/workflows/book-build-container.yml
@@ -441,7 +441,7 @@ jobs:
         if: matrix.platform == 'linux' && matrix.enabled
         working-directory: ${{ vars.BOOK_QUARTO }}
         env:
-          PYTHONPATH: ${{ github.workspace }}
+          PYTHONPATH: ${{ github.workspace }}/mlsysim:${{ github.workspace }}
         run: |
           set -eu
           echo "🧪 Running Linux toolchain preflight checks..."
@@ -570,7 +570,7 @@ jobs:
           Set-Content -Path $scriptPath -Value $fullScript -Encoding UTF8
 
           docker run --rm `
-            -e PYTHONPATH=C:\workspace `
+            -e PYTHONPATH=C:\workspace\mlsysim;C:\workspace `
             -e PYTHONIOENCODING=utf-8 `
             -e PYTHONUTF8=1 `
             -v "$($PWD.Path):C:\workspace" `
@@ -588,7 +588,7 @@ jobs:
         if: matrix.platform == 'linux' && matrix.enabled
         working-directory: ${{ vars.BOOK_QUARTO }}
         env:
-          PYTHONPATH: ${{ github.workspace }}
+          PYTHONPATH: ${{ github.workspace }}/mlsysim:${{ github.workspace }}
           CHROMIUM_FLAGS: "--no-sandbox"
         run: |
           # Ensure Quarto can find Chromium (installed by Dockerfile but .bashrc not sourced in CI)
@@ -646,7 +646,7 @@ jobs:
           Set-Content -Path $scriptPath -Value $scriptContent -Encoding UTF8
 
           docker run --rm `
-            -e PYTHONPATH=C:\workspace `
+            -e PYTHONPATH=C:\workspace\mlsysim;C:\workspace `
             -e PYTHONIOENCODING=utf-8 `
             -e PYTHONUTF8=1 `
             -v "$($PWD.Path):C:\workspace" `
@@ -722,7 +722,7 @@ jobs:
           Set-Content -Path $scriptPath -Value $scriptContent -Encoding UTF8
 
           docker run --rm `
-            -e PYTHONPATH=C:\workspace `
+            -e PYTHONPATH=C:\workspace\mlsysim;C:\workspace `
             -e PYTHONIOENCODING=utf-8 `
             -e PYTHONUTF8=1 `
             -v "$($PWD.Path):C:\workspace" `
@@ -805,7 +805,7 @@ jobs:
           Set-Content -Path $scriptPath -Value $scriptContent -Encoding UTF8
 
           docker run --rm `
-            -e PYTHONPATH=C:\workspace `
+            -e PYTHONPATH=C:\workspace\mlsysim;C:\workspace `
             -e PYTHONIOENCODING=utf-8 `
             -e PYTHONUTF8=1 `
             -v "$($PWD.Path):C:\workspace" `


### PR DESCRIPTION
## Summary

Final fix in the chain of three (#1419 → #1420 → this). The book build workflow sets
\`PYTHONPATH\` at the runner-step level for Linux and via \`docker run -e PYTHONPATH\` for
Windows, both pointing at the repo root. That override wins over the Quarto config change
in #1420 and runs into the exact same packaging issue exposed by #1397: the actual
\`mlsysim\` package lives at \`<repo_root>/mlsysim/mlsysim/\`, not at \`<repo_root>/mlsysim/\`.

Without this fix, \`book-validate-dev\` stays red on every Container Build Matrix job
(6 Linux + 6 Windows = 12 jobs) with \`ModuleNotFoundError: No module named 'mlsysim.core'\`.

## Fix

Prepend \`<repo_root>/mlsysim/\` to \`PYTHONPATH\` in all 6 places it's set in
\`book-build-container.yml\`:

| Line | Context | Platform |
|---|---|---|
| 444 | Preflight toolchain | Linux |
| 573 | Preflight toolchain | Windows (docker run -e) |
| 591 | Build (HTML/PDF/EPUB) | Linux |
| 649 | Build (HTML/PDF/EPUB) | Windows (docker run -e) |
| 725 | Compress PDF | Windows (docker run -e) |
| 808 | Compress EPUB | Windows (docker run -e) |

Path separators per OS: \`:\` on Linux, \`;\` on Windows. The original repo-root entry is
preserved.

## Why three PRs instead of one

Same root cause, three surfaces. I cut them small so each one's blast radius is obvious
in review and the bisect history stays useful:

- **#1419** — \`book/tests/test_units.py\` (one test file)
- **#1420** — Quarto exec env (5 config files; protects local builds)
- **This PR** — workflow env (1 workflow file; protects CI builds, which override the config env)

Together they restore \`book-validate-dev\` to green for the first time since 2026-04-17.

## Verification

- YAML parses cleanly.
- Linux pattern verified locally with the equivalent environment in PR #1420's verification step.
- Windows pattern can only be validated in CI; the patch is a mechanical translation of the
  Linux fix using \`;\` separator and backslash paths to match the existing template.

## What this unblocks

\`book-validate-dev\` green → \`infra-publish-guard.yml\` re-armed → \`book-publish-live\`
becomes triggerable for vol1 v0.6.0 / vol2 v0.1.0.