### PR TITLE
fix(styles): sync harvard theme mirror after $primary/$accent change

### DIFF
--- a/book/quarto/assets/styles/themes/_theme-harvard.scss
+++ b/book/quarto/assets/styles/themes/_theme-harvard.scss
@@ -13,6 +13,13 @@
 $accent: $brand-crimson;
 $accent-name: "Harvard Crimson";
 
+// Bootstrap $primary must follow $accent so announcement banners
+// (`.alert-primary`) render in the brand colour — otherwise Bootstrap's
+// default blue leaks through on any site that imports this theme without
+// overriding $primary locally.
+$primary: $accent;
+$link-color: $accent;
+
 // Accent for dark mode (lighter/brighter for dark backgrounds)
 $accent-dark: $brand-crimson-dark;
 


### PR DESCRIPTION
## Summary

Last blocker between \`dev\` and a fully green \`📚 Book · ✅ Validate (Dev)\`. The
\`check-shared-mirrors\` pre-commit hook is failing on every dev push because commit
[0e32de8b](https://github.com/harvard-edge/cs249r_book/commit/0e32de8b) edited the shared
source \`shared/styles/themes/_theme-harvard.scss\` but did not update the
\`book/quarto/assets/styles/themes/_theme-harvard.scss\` mirror. Pre-commit is gated, so
the Container Build Matrix never gets a chance to run.

## What was missing from the mirror

The seven lines added to source by 0e32de8b that promote Bootstrap's \`\$primary\` to
follow the Harvard accent:

\`\`\`scss
// Bootstrap \$primary must follow \$accent so announcement banners
// (.alert-primary) render in the brand colour — otherwise Bootstrap's
// default blue leaks through on any site that imports this theme without
// overriding \$primary locally.
\$primary: \$accent;
\$link-color: \$accent;
\`\`\`

## Fix

\`bash shared/scripts/sync-mirrors.sh\` — propagated source → mirror, exactly the
canonical recovery path the hook prints in its failure message.

## Verification

\`\`\`text
$ pre-commit run check-shared-mirrors --all-files
Repo: Verify shared asset mirrors are in sync.....Passed
\`\`\`

## What this unblocks

Pre-commit green → Container Build Matrix runs → if container fix from \`ea0ed68a\`
holds (which my local clean-venv repro confirms it should), \`book-validate-dev\` goes
fully green for the first time since 2026-04-17, re-arming the publish guard.