### PR TITLE
Improve sidenote offset handling and intro layout fixes

### DIFF
--- a/book/quarto/contents/vol1/introduction/introduction.qmd
+++ b/book/quarto/contents/vol1/introduction/introduction.qmd
@@ -1070,11 +1070,11 @@ With these four paradigm shifts traced, @tbl-ai-evolution-strengths summarizes t
 
 The progression through four paradigms reveals a consistent pattern: each era's breakthrough came not from cleverer algorithms but from removing a systems bottleneck that prevented existing algorithms from using more data and computation. Symbolic AI had the algorithms for logic but lacked the data; expert systems had domain knowledge but could not scale it; statistical learning had the data but required human feature engineering; deep learning automated feature learning but demanded infrastructure that did not yet exist. The recurring theme is that *systems innovations*, not algorithmic innovations, enabled each transition. The pattern raises a practical dilemma: given limited resources, organizations must decide whether to invest in better algorithms, larger datasets, or higher-throughput hardware. One of AI's leading researchers examined the historical record systematically and reached a conclusion that challenges our deepest intuitions about how intelligence should be built.
 
-## bitter lesson {#sec-introduction-bitter-lesson-79c7}
+## Bitter lesson {#sec-introduction-bitter-lesson-79c7}
 
 Richard Sutton's[^fn-sutton-bitter] 2019 essay "The bitter lesson"\index{bitter lesson, The} formalizes the historical pattern we just traced [@sutton2019bitter]. Looking back at seven decades of research, Sutton observed that general methods that use increasing computation consistently outperform approaches that encode human expertise. He writes: "The biggest lesson that can be read from 70 years of AI research is that general methods that leverage computation are ultimately the most effective, and by a large margin."
 
-[^fn-sutton-bitter]: **Richard Sutton**: A reinforcement learning pioneer whose 2019 essay crystallized the pattern traced in the preceding sections: from symbolic AI through expert systems to deep learning, general methods using computation consistently outperformed hand-engineered expertise. The lesson is "bitter" because it implies that domain-specific logic is a depreciating asset, while the durable advantage belongs to systems engineering that can absorb the billion-fold increase in raw compute since the 1970s. \index{Sutton, Richard!bitter lesson}
+[^fn-sutton-bitter]: [offset=-15mm] **Richard Sutton**: A reinforcement learning pioneer whose 2019 essay crystallized the pattern traced in the preceding sections: from symbolic AI through expert systems to deep learning, general methods using computation consistently outperformed hand-engineered expertise. The lesson is "bitter" because it implies that domain-specific logic is a depreciating asset, while the durable advantage belongs to systems engineering that can absorb the billion-fold increase in raw compute since the 1970s. \index{Sutton, Richard!bitter lesson}
 
 The shift from expert systems to statistical learning to deep learning has dramatically improved performance on representative tasks, with each transition enabled by increased computational scale rather than cleverer encoding of human knowledge.
 
@@ -1119,6 +1119,12 @@ class GPT4Scale:
 
 @tbl-ai-evolution-performance provides quantitative validation of this principle. Examine the rightmost column carefully: as computational resources grew from "minimal" to "millions of GPU-days," performance improved from amateur-level to superhuman.
 
+<!--
+::: {.content-visible when-format="pdf"}
+\newpage
+:::
+-->
+
 | **Era**                          | **Approach**                   | **Representative Task** |        **Performance** | **Computational Resources**                                         |
 |:---------------------------------|:-------------------------------|:------------------------|-----------------------:|:--------------------------------------------------------------------|
 | **Expert Systems (1980s)**       | Hand-crafted rules             | Chess (Elo rating)      |    ~2000 Elo (amateur) | Minimal (rule evaluation)                                           |
@@ -1127,7 +1133,7 @@ class GPT4Scale:
 | **Modern Deep Learning (2020+)** | Large-scale transformers       | ImageNet top-5 accuracy |    90.0 percent+ (ViT) | Hours on distributed systems                                        |
 | **Modern Deep Learning (2023)**  | Foundation models              | MMLU benchmark          |   86.4 percent (GPT-4) | Estimated `{python} GPT4Scale.gpt4_gpu_m_str` million A100 GPU-days |
 
-: **AI Performance Evolution Across Paradigms**: Each paradigm transition correlates with increased computational scale rather than algorithmic sophistication. Performance improved from amateur-level expert systems (2000 Elo) to superhuman foundation models (86.4 percent MMLU), while computational requirements grew from single CPUs to 2.5 million A100 GPU-days. Training time initially increased (hours to days) but later decreased as distributed systems enabled parallelization. {#tbl-ai-evolution-performance}
+: **AI Performance Evolution Across Paradigms**: Each paradigm transition correlates with increased computational scale rather than algorithmic sophistication. Performance improved from amateur-level expert systems (2000 Elo) to superhuman foundation models (86.4 percent MMLU), while computational requirements grew from single CPUs to 2.5 million A100 GPU-days. Training time initially increased (hours to days) but later decreased as distributed systems enabled parallelization. {#tbl-ai-evolution-performance tbl-colwidths="[17,19,20,18,26]"}
 
 MMLU (Multitask Multiple-choice Language Understanding) is a standard benchmark for broad knowledge across many subjects; we formalize benchmarking in @sec-benchmarking.
 
@@ -1235,7 +1241,7 @@ To visualize these interdependencies, consider the triangle in @fig-ai-triad: th
 ::: {#fig-ai-triad fig-env="figure" fig-pos="htb" fig-cap="**The D·A·M Taxonomy**: Interdependent relationship between Data, Algorithm, and Machine. Each node (dataset, model, and infrastructure) constrains the capabilities of the others. ML systems engineering is the discipline of balancing these three axes; optimizing one in isolation often shifts the system bottleneck to another rather than eliminating it." fig-alt="Triangle with circles at vertices labeled Algorithm (top), Data (left), and Machine (right). Double-headed purple arrows connect all three, showing bidirectional dependencies. Icons depict a neural network, database cylinders, and a cloud server."}
 
 ```{.tikz}
-\scalebox{0.8}{
+\scalebox{0.9}{
 \begin{tikzpicture}[line join=round,font=\usefont{T1}{phv}{m}{n}\small]
 \tikzset{
  Line/.style={line width=0.35pt,black!50,text=black},
@@ -1453,7 +1459,7 @@ The difference in failure modes demands new engineering practices. Traditional s
 
 The degradation equation reveals *what goes wrong* with ML systems: silent reliability decay absent from traditional software. Knowing that a system will degrade is not the same as knowing *why* it degrades or *where* to intervene. For that, we need to decompose performance itself into its physical constituents. The bitter lesson established that computational scale drives AI progress; the question now becomes how to reason quantitatively about the data movement, computation, and overhead that constitute that scale.
 
-## iron law of ML systems {#sec-introduction-iron-law-ml-systems-c32a}
+## Iron law of ML systems {#sec-introduction-iron-law-ml-systems-c32a}
 
 \index{iron law of ML systems!definition}
 To reason about ML systems as engineers, we need more than qualitative descriptions. We need a quantitative framework that connects every layer of the stack. Just as classical mechanics is governed by Newton's laws and processor performance is governed by the iron law of Processor Performance, machine learning system performance is governed by the **iron law of ML systems**\index{iron law of ML systems!equation}, formalized in @eq-intro-iron-law:
@@ -1472,7 +1478,7 @@ We call this the "iron law" by analogy to Patterson & Hennessy's iron law of Pro
 
 The additive form assumes sequential execution; in practice, systems can **overlap** these terms, transforming the sum into a max as @eq-intro-iron-law-pipelined shows:
 
-$$T_{pipelined} = \max\left(\frac{D_{\text{vol}}}{BW}, \frac{O}{R_{\text{peak}} \cdot \eta}\right) + L_{\text{lat}}$$ {#eq-intro-iron-law-pipelined}
+$$T_{\text{pipelined}} = \max\left(\frac{D_{\text{vol}}}{BW}, \frac{O}{R_{\text{peak}} \cdot \eta}\right) + L_{\text{lat}}$$ {#eq-intro-iron-law-pipelined}
 
 \index{Amdahl's Law!diagnostic analogy}
 We retain "iron law" because, like **Amdahl's Law**, its value lies in **diagnostic power**: identifying which physical constraint dominates before optimizing. The iron law is useful precisely because it simplifies the complexity of the full stack into three manageable terms. @sec-dam-taxonomy presents the refined treatment, including pipelining and overlap techniques that transform the additive model into the max-based formulation used in practice.
@@ -1610,8 +1616,8 @@ class GPT3Training:
 **2. The Calculation**:
 
 - `{python} GPT3Training.time_formula_math`
-- `{python} GPT3Training.time_value_math`
-- `{python} GPT3Training.time_days_math`
+`{python} GPT3Training.time_value_math`
+`{python} GPT3Training.time_days_math`
 
 **3. The Result**:
 **`{python} GPT3Training.days_initial_str` days**.
@@ -1625,7 +1631,6 @@ The equation is dimensionally consistent: each term resolves to seconds. One can
 The **iron law** governs *time*, but time is not the only constraint. For mobile devices, edge systems, and large-scale training clusters, *energy* often matters more than raw speed.
 
 Just as time is governed by physics, so is energy. We must add a fourth term to our mental model: **The Energy Tax.**\index{Energy Tax!data movement cost} In many modern systems (mobile, edge, and large-scale training), energy, not time, is the hard constraint. Let $D_{\text{vol}}$ be the total data volume moved (bytes), $E_{\text{move}}$ the energy per byte moved, $O$ the total operation count, and $E_{\text{compute}}$ the energy per operation. @eq-energy-cost formalizes this relationship:
-
 $$ \text{Energy}_{\text{total}} \approx \underbrace{ D_{\text{vol}} \times E_{\text{move}} }_{\text{Dominant Term}} + \underbrace{ O \times E_{\text{compute}} }_{\text{Secondary Term}} $$ {#eq-energy-cost}
 
 The dominant term is data movement: $E_{\text{move}} \gg E_{\text{compute}}$. Moving a byte of data from memory often costs 100$\times$ more energy than performing a floating-point operation on it. The physical reason is that data movement requires charging and discharging wires over macroscopic distances, while arithmetic is performed locally within a processing unit's circuits. Therefore, **minimizing data movement ($D_{\text{vol}}$)** is the primary lever for both speed *and* energy efficiency.
@@ -1647,7 +1652,6 @@ The **iron law** ($T \approx \frac{D_{\text{vol}}}{BW} + \frac{O}{R_{\text{peak}
 ### The economic invariant: Return on compute (RoC) {#sec-introduction-roc-invariant}
 
 The decomposition of time is also an economic constraint. In the Hennessy & Patterson tradition of quantitative reasoning, the **return on compute (RoC)** is defined\index{Return on Compute (RoC)!economic invariant} as the marginal accuracy gain per dollar of infrastructure investment.
-
 $$ \text{RoC} = \frac{\Delta \text{Accuracy}}{\Delta \text{Compute Cost}} $$
 
 This invariant forces the engineer to ask: if a one percent gain in accuracy requires a 10$\times$ increase in $O$ (Total Operations), is the **Silicon Contract** still economically viable? Every optimization in the following chapters targets either the numerator (extracting more signal from the same data) or the denominator (reducing the cost of executing the math). If the RoC is negative or negligible, the system is over-engineered, regardless of its technical sophistication. This economic lens transforms "accuracy" from a research target into an engineering budget.
@@ -1881,7 +1885,7 @@ import numpy as np
 sys.path.insert(0, ".")
 from mlsysim import viz
 
-fig, ax, COLORS, plt = viz.setup_plot(figsize=(10, 5))
+fig, ax, COLORS, plt = viz.setup_plot(figsize=(10, 4.5))
 
 # --- Data (model efficiency factors) ---
 algo_efficiency_data = [
@@ -2689,7 +2693,7 @@ The five pillars map directly onto this textbook's four-part structure, which pr
 | **III: Optimize**  | Efficiency: Performance tuning | @sec-data-selection, @sec-model-compression, @sec-hardware-acceleration, @sec-benchmarking   |
 | **IV: Deploy**     | Production: Real-world systems | @sec-model-serving, @sec-ml-operations, @sec-responsible-engineering, @sec-conclusion        |
 
-: **Book Organization**: The four parts follow a pedagogical progression from context (Foundations) through theory (Build) to practice (Optimize, Deploy). Each part builds on the vocabulary and frameworks of its predecessors, so Part III's optimization techniques assume familiarity with Part II's model architectures, and Part IV's deployment practices assume mastery of Parts II and III. {#tbl-book-structure}
+: **Book Organization**: The four parts follow a pedagogical progression from context (Foundations) through theory (Build) to practice (Optimize, Deploy). Each part builds on the vocabulary and frameworks of its predecessors, so Part III's optimization techniques assume familiarity with Part II's model architectures, and Part IV's deployment practices assume mastery of Parts II and III. {#tbl-book-structure tbl-colwidths="[18,30,52]"}
 
 Part I establishes context by surveying the ML systems landscape. @sec-introduction develops the engineering revolution in AI and the frameworks that organize this discipline. @sec-ml-systems explores the deployment spectrum from Cloud to TinyML, examining how physical constraints (power envelopes, memory hierarchies, and latency budgets) govern each tier. @sec-ml-workflow presents the end-to-end process from problem formulation through deployment, providing the conceptual map that guides subsequent learning. @sec-data-engineering addresses data collection, processing, and management, establishing that data infrastructure precedes and enables model development.
 
@@ -2958,12 +2962,16 @@ class DeploymentSystems:
 
 The machine learning systems landscape spans nine orders of magnitude in computational power and memory capacity. We categorize this continuum into four **System Archetypes** that define the constraints for every subsequent chapter:
 
+::: {tbl-colwidths="[16,21,21,21,21]"}
+
 | **Archetype** | **Example System** | **RAM/Memory**                                 | **Peak Compute**                                       | **Power Budget**                                |
 |:--------------|:-------------------|:-----------------------------------------------|:-------------------------------------------------------|:------------------------------------------------|
 | **Cloud**     | H100 Cluster       | `{python} DeploymentSystems.cloud_mem_str` GB  | `{python} DeploymentSystems.cloud_compute_str` TFLOPS  | `{python} DeploymentSystems.cloud_power_str` W  |
 | **Edge**      | Jetson Robotics    | `{python} DeploymentSystems.edge_mem_str` GB   | `{python} DeploymentSystems.edge_compute_str` TFLOPS   | `{python} DeploymentSystems.edge_power_str` W   |
 | **Mobile**    | Smartphone         | `{python} DeploymentSystems.mobile_mem_str` GB | `{python} DeploymentSystems.mobile_compute_str` TFLOPS | `{python} DeploymentSystems.mobile_power_str` W |
 | **TinyML**    | ESP32-S3           | `{python} DeploymentSystems.tiny_mem_str` KB   | `{python} DeploymentSystems.tiny_compute_str` TFLOPS   | `{python} DeploymentSystems.tiny_power_str` mW  |
+
+:::
 
 **The Scaling Gap**: The gap between the Cloud and TinyML archetypes is roughly `{python} DeploymentSystems.mem_span_str` in memory and `{python} DeploymentSystems.compute_span_str` in compute power. This divergence is precisely why we cannot simply "shrink" a cloud model to run at the edge; each tier requires a fundamental redesign of the D·A·M axes.
 

--- a/book/quarto/filters/sidenote.lua
+++ b/book/quarto/filters/sidenote.lua
@@ -1,31 +1,63 @@
-function Note (note)
+function Note(note)
   -- Only convert footnotes to sidenotes for PDF/LaTeX output.
   -- ePub is HTML-based: pandoc.RawInline('latex', ...) nodes are ignored by
   -- the EPUB renderer, so the surrounding \sidenote{} delimiters are stripped
   -- while the note body is emitted inline — causing the sidenote text to
-  -- appear embedded in the running prose (see issue #1333).
+  -- appear embedded in the running prose.
   if quarto.doc.is_format("latex") or quarto.doc.is_format("pdf") then
-    -- For PDF/LaTeX, convert footnote to sidenote for margin placement
-    -- Requires sidenotes package (loaded in header-includes.tex)
-    -- Fallback to \footnote is defined in header-includes.tex if package fails
-    local sidenote_content = {}
-    table.insert(sidenote_content, pandoc.RawInline('latex', '\\sidenote{'))
+    local offset = nil
+
+    -- Detect optional [offset=...] marker at the start of the first Para/Plain block
+    if #note.content > 0 then
+      local first_block = note.content[1]
+      if (first_block.t == "Para" or first_block.t == "Plain") and #first_block.content > 0 then
+        local first_inline = first_block.content[1]
+        if first_inline.t == "Str" then
+          local m = first_inline.text:match("^%[offset=([^%]]+)%]")
+          if m then
+            offset = m
+
+            -- Remove only the [offset=...] part, keep the rest of the text
+            first_inline.text = first_inline.text:gsub("^%[offset=[^%]]+%]", "")
+
+            -- If the inline becomes empty, remove it
+            if first_inline.text == "" then
+              table.remove(first_block.content, 1)
+            end
+
+            -- Remove following space if present
+            if #first_block.content > 0 and first_block.content[1].t == "Space" then
+              table.remove(first_block.content, 1)
+            end
+          end
+        end
+      end
+    end
+
+    local out = {}
+
+    if offset then
+      table.insert(out, pandoc.RawInline('latex', '\\styledsidenote[][' .. offset .. ']{'))
+    else
+      table.insert(out, pandoc.RawInline('latex', '\\sidenote{'))
+    end
 
     -- Add the note content directly as inlines (not converted to latex yet)
     -- This allows citations to be processed by citeproc later
     for _, block in ipairs(note.content) do
       if block.t == "Para" or block.t == "Plain" then
         for _, inline in ipairs(block.content) do
-          table.insert(sidenote_content, inline)
+          table.insert(out, inline)
         end
         -- Add space between paragraphs
-        table.insert(sidenote_content, pandoc.Space())
+        table.insert(out, pandoc.Space())
       end
     end
 
-    table.insert(sidenote_content, pandoc.RawInline('latex', '}'))
-    return sidenote_content
+    table.insert(out, pandoc.RawInline('latex', '}'))
+    return out
   end
+
   -- For ePub and all other formats, let Pandoc render footnotes normally.
   return nil
 end

--- a/book/quarto/tex/header-includes.tex
+++ b/book/quarto/tex/header-includes.tex
@@ -50,8 +50,10 @@ belowskip=2pt,aboveskip=6pt,labelformat=mylabel,
 justification=raggedright,singlelinecheck=false,font={ninept}}
 
 % Table captions: Small font, bold label, ragged right
-\captionsetup[table]{belowskip=6pt,labelfont={bf,ninept},labelsep=none,
+\captionsetup[table]{aboveskip=0pt,belowskip=6pt,labelfont={bf,ninept},labelsep=none,
 labelformat=mylabel,justification=raggedright,singlelinecheck=false,font={ninept}}
+
+ 
 
 % Typography fine-tuning
 \emergencystretch=5pt       % Allow extra stretch to avoid overfull boxes
@@ -316,6 +318,26 @@ aboveskip=0pt
 % =============================================================================
 % Custom sidenote design with crimson vertical bar
 \renewcommand{\thefootnote}{\textcolor{crimson}{\arabic{footnote}}}
+
+% Save original sidenote command only once
+\makeatletter
+\@ifundefined{origsidenote}{%
+  \let\origsidenote\sidenote%
+}{}
+\makeatother
+
+% New command with support for optional offset
+% \styledsidenote[<number>][<offset>]{<text>}
+\NewDocumentCommand{\styledsidenote}{ O{} O{} m }{%
+  \origsidenote[#1][#2]{%
+    \noindent
+    \color{crimson!100}%
+    \raisebox{0pt}{\rule{0.5pt}{1.5em}}%
+    \hspace{0.3em}%
+    \color{black}%
+    \footnotesize #3%
+  }%
+}
 
 % Save original sidenote command
 \makeatletter
@@ -1966,3 +1988,4 @@ align=right,font={\fontsize{40pt}{40}\selectfont}]
 }
 
 \makeatother
+


### PR DESCRIPTION
1. Updated the sidenote.lua filter to support vertical offset for margin notes, allowing finer control of their placement in the PDF output.

2. Added a new LaTeX command \styledsidenote in header-includes.tex, enabling vertical adjustment of margin notes while preserving the existing visual style.
Also updated the table caption configuration (\captionsetup[table]{aboveskip=0pt, ...}) so that table captions align properly at the top of the page when a table appears at the beginning of a new page.

3. Refined introduction.qmd to remove unnecessary large white space at the bottom of pages and improve overall layout.