### PR TITLE
feat(vault): ID scheme v2 + vault ls/show/chain browse commands

### DIFF
--- a/interviews/vault-cli/src/vault_cli/commands/authoring.py
+++ b/interviews/vault-cli/src/vault_cli/commands/authoring.py
@@ -38,11 +38,64 @@ def _short_hash(title: str) -> str:
     return hashlib.sha256(title.encode("utf-8")).hexdigest()[:6]
 
 
+def _id_hash(title: str, topic: str) -> str:
+    """ID scheme v2 hash: first 4 hex chars of sha256(title + "\\n" + topic).
+
+    Matches the recipe documented in interviews/vault/docs/ID_SCHEMES.md.
+    Including the topic defends against two unrelated questions with
+    identical titles hashing identically.
+    """
+    payload = f"{title}\n{topic}".encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()[:4]
+
+
+def _yyyymm() -> str:
+    """Current year-month as 6 digits, for the v2 ID scheme."""
+    return datetime.now(UTC).strftime("%Y%m")
+
+
 def _slug(s: str) -> str:
     keep = "".join(c if c.isalnum() or c == "-" else "-" for c in s.lower())
     while "--" in keep:
         keep = keep.replace("--", "-")
     return keep.strip("-") or "untitled"
+
+
+def _new_question_id(track: str, title: str, topic: str, existing_ids: set[str]) -> tuple[str, str]:
+    """Mint a v2 question ID: <track>-<yyyymm>-<4hex>.
+
+    On collision within the same (track, yyyymm) bucket, increment the
+    4-hex suffix to the next free hex until a free slot is found.
+    Returns (id, hex_used).
+    """
+    yyyymm = _yyyymm()
+    base_hex = _id_hash(title, topic)
+    # Increment hex on collision (65,536 slots per bucket; collisions rare).
+    n = int(base_hex, 16)
+    for _ in range(0x10000):
+        candidate_hex = f"{n:04x}"
+        qid = f"{track}-{yyyymm}-{candidate_hex}"
+        if qid not in existing_ids:
+            return qid, candidate_hex
+        n = (n + 1) & 0xFFFF
+    raise RuntimeError(f"ID-space exhausted for bucket {track}-{yyyymm}")
+
+
+def _new_chain_id(track: str, topic: str, existing_ids: set[str]) -> str:
+    """Mint a v2 chain ID: chain-<track>-<topic-slug>-<yyyymm>[-<suffix>].
+
+    On collision add a single-letter suffix (a, b, c, …) to disambiguate.
+    """
+    yyyymm = _yyyymm()
+    slug = _slug(topic)
+    base = f"chain-{track}-{slug}-{yyyymm}"
+    if base not in existing_ids:
+        return base
+    for letter in "abcdefghijklmnopqrstuvwxyz":
+        candidate = f"{base}-{letter}"
+        if candidate not in existing_ids:
+            return candidate
+    raise RuntimeError(f"Chain-ID space exhausted for bucket {base}")
 
 
 def _git_user_email() -> str | None:
@@ -136,8 +189,7 @@ def register(app: typer.Typer) -> None:
         rate, per §3.3 concurrency contract.
         """
         # v1.0: classification lives in YAML, filesystem uses track only.
-        topic_slug = _slug(topic)
-        h = _short_hash(title)
+        # v2 ID scheme: <track>-<yyyymm>-<4hex> (see docs/ID_SCHEMES.md).
 
         # §3.3: git pull --rebase on the registry before allocation.
         if not skip_rebase:
@@ -149,18 +201,14 @@ def register(app: typer.Typer) -> None:
                     check=False, capture_output=True,
                 )
 
-        # Allocate seq by scanning existing files under the track directory.
+        # Build the set of existing IDs so _new_question_id can avoid collisions.
         cell_dir = path_for_question(vault_dir, track.value, "").parent
         cell_dir.mkdir(parents=True, exist_ok=True)
-        seq = 1
-        while True:
-            filename = f"{track.value}-{topic_slug}-{h}-{seq:04d}.yaml"
-            candidate = cell_dir / filename
-            if not candidate.exists():
-                break
-            seq += 1
+        existing_ids: set[str] = set()
+        for p in cell_dir.glob("*.yaml"):
+            existing_ids.add(p.stem)
 
-        qid = f"{track.value}-{topic_slug}-{h}-{seq:04d}"
+        qid, _ = _new_question_id(track.value, title, topic, existing_ids)
         now = _now()
 
         author = _git_user_email()

--- a/interviews/vault-cli/src/vault_cli/commands/chain.py
+++ b/interviews/vault-cli/src/vault_cli/commands/chain.py
@@ -1,0 +1,120 @@
+"""``vault chain`` — browse and inspect question chains.
+
+Subcommands:
+    vault chain ls [--track --topic]          list chains with counts + spans
+    vault chain show <chain-id>                walk a chain end-to-end
+
+A chain links questions on a single topic into a progression, usually
+across Bloom's levels. ≈32% of the corpus participates in ≥1 chain;
+≈101 questions are in multiple chains.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from vault_cli.loader import load_all
+
+
+chain_app = typer.Typer(help="Browse and inspect question chains.")
+
+
+def _collect_chains(loaded) -> dict[str, list]:
+    """Return {chain_id: [(position, loaded_question), ...]}."""
+    out: dict[str, list] = {}
+    for lq in loaded:
+        for c in (lq.question.chains or []):
+            out.setdefault(c.id, []).append((c.position, lq))
+    for cid in out:
+        out[cid].sort(key=lambda x: x[0])
+    return out
+
+
+@chain_app.command("ls")
+def chain_ls(
+    track: str | None = typer.Option(None, "--track", help="Filter by track (cloud/edge/mobile/tinyml/global)."),
+    topic: str | None = typer.Option(None, "--topic", help="Filter by topic slug."),
+    vault_dir: Path = typer.Option(Path("interviews/vault"), "--vault-dir"),
+) -> None:
+    """List chains with member count + level span."""
+    console = Console()
+    loaded, _ = load_all(vault_dir)
+    chains = _collect_chains(loaded)
+
+    rows = []
+    for cid, members in chains.items():
+        topics = {m[1].question.topic for m in members}
+        tracks = {m[1].question.track for m in members}
+        levels = sorted({m[1].question.level for m in members})
+        first_topic = next(iter(topics))
+        first_track = next(iter(tracks))
+        if track and first_track != track:
+            continue
+        if topic and topic not in topics:
+            continue
+        rows.append((cid, first_track, first_topic, len(members), "/".join(levels)))
+
+    rows.sort(key=lambda r: (r[1], r[2], r[0]))
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("chain_id", no_wrap=True, style="cyan")
+    table.add_column("track", no_wrap=True)
+    table.add_column("topic", no_wrap=True, style="dim")
+    table.add_column("#", justify="right")
+    table.add_column("level span")
+    for cid, tr, tp, n, sp in rows:
+        table.add_row(cid, tr, tp, str(n), sp)
+    console.print(table)
+    console.print(f"[dim]{len(rows)} chains[/dim]")
+
+
+@chain_app.command("show")
+def chain_show(
+    chain_id: str = typer.Argument(..., help="Chain ID to walk (e.g. cloud-chain-432)."),
+    vault_dir: Path = typer.Option(Path("interviews/vault"), "--vault-dir"),
+) -> None:
+    """Walk a chain end-to-end: one row per member, ordered by position."""
+    console = Console()
+    loaded, _ = load_all(vault_dir)
+    chains = _collect_chains(loaded)
+
+    members = chains.get(chain_id)
+    if members is None:
+        console.print(f"[red]chain not found:[/red] {chain_id!r}")
+        raise typer.Exit(code=1)
+
+    # Detect topic/track drift within the chain.
+    topics = sorted({m[1].question.topic for m in members})
+    tracks = sorted({m[1].question.track for m in members})
+    levels = [m[1].question.level for m in members]
+    levels_sorted = sorted(levels, key=lambda L: ("L1","L2","L3","L4","L5","L6+").index(L))
+    monotonic = levels == levels_sorted
+
+    console.print(f"[bold cyan]{chain_id}[/bold cyan]   "
+                  f"{len(members)} members   track(s)={','.join(tracks)}   topic(s)={','.join(topics)}")
+    if len(topics) > 1:
+        console.print(f"  [yellow]warning[/yellow]: chain spans multiple topics — likely mis-linked")
+    if not monotonic:
+        console.print(f"  [yellow]warning[/yellow]: levels not monotonically non-decreasing across positions")
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("#", justify="right", no_wrap=True)
+    table.add_column("level", no_wrap=True)
+    table.add_column("zone", no_wrap=True)
+    table.add_column("id", no_wrap=True, style="cyan")
+    table.add_column("title")
+    for pos, lq in members:
+        q = lq.question
+        table.add_row(str(pos), q.level, q.zone, q.id, q.title)
+    console.print(table)
+
+
+def register(app: typer.Typer) -> None:
+    app.add_typer(chain_app, name="chain")
+
+
+__all__ = ["register"]

--- a/interviews/vault-cli/src/vault_cli/commands/ls.py
+++ b/interviews/vault-cli/src/vault_cli/commands/ls.py
@@ -1,0 +1,89 @@
+"""``vault ls`` — browse questions with axis filters.
+
+One-line-per-question output, aligned columns, filterable on every
+first-class classification axis. Powers the "I want to see level at a
+glance" workflow without opening individual YAMLs.
+
+Usage:
+    vault ls                             # every question in the vault
+    vault ls --track cloud               # cloud-only
+    vault ls --level L6+                 # only L6+ questions
+    vault ls --zone mastery              # only mastery-zone
+    vault ls --topic kv-cache-management
+    vault ls --status published
+    vault ls --in-chains                 # only questions that are in >=1 chain
+    vault ls --track cloud --level L4 --zone diagnosis   # combinable
+
+Output columns: id | track | level | zone | topic | #chains | title
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from vault_cli.loader import load_all
+
+
+def register(app: typer.Typer) -> None:
+    @app.command("ls")
+    def ls_cmd(
+        track: str | None = typer.Option(None, "--track", help="Filter by track."),
+        level: str | None = typer.Option(None, "--level", help="Filter by level (L1 … L6+)."),
+        zone: str | None = typer.Option(None, "--zone", help="Filter by zone (one of the 11 ikigai zones)."),
+        topic: str | None = typer.Option(None, "--topic", help="Filter by topic slug."),
+        status: str | None = typer.Option(None, "--status", help="Filter by status (published, draft, flagged, archived, deleted)."),
+        in_chains: bool = typer.Option(False, "--in-chains", help="Only questions that belong to ≥1 chain."),
+        vault_dir: Path = typer.Option(
+            Path("interviews/vault"), "--vault-dir",
+            help="Vault root.",
+        ),
+        limit: int = typer.Option(0, "--limit", "-n", help="Truncate output after N rows (0 = all)."),
+        plain: bool = typer.Option(False, "--plain", help="Plain tab-separated output (for piping to awk/grep)."),
+    ) -> None:
+        """List questions with axis filters. Aligned output or TSV."""
+        console = Console()
+        loaded, errors = load_all(vault_dir)
+        if errors:
+            console.print(f"[yellow]warning[/yellow]: {len(errors)} load errors (skipped)")
+
+        rows = []
+        for lq in loaded:
+            q = lq.question
+            if track and q.track != track: continue
+            if level and q.level != level: continue
+            if zone and q.zone != zone: continue
+            if topic and q.topic != topic: continue
+            if status and q.status != status: continue
+            n_chains = len(q.chains or [])
+            if in_chains and n_chains == 0: continue
+            rows.append((q.id, q.track, q.level, q.zone, q.topic, n_chains, q.title))
+
+        rows.sort(key=lambda r: (r[1], r[2], r[0]))   # track, level, id
+        if limit:
+            rows = rows[:limit]
+
+        if plain:
+            for r in rows:
+                print("\t".join(str(x) for x in r))
+            console.print(f"[dim]({len(rows)} rows)[/dim]", style="dim")
+            return
+
+        table = Table(show_header=True, header_style="bold")
+        table.add_column("id", no_wrap=True, style="cyan")
+        table.add_column("track", no_wrap=True)
+        table.add_column("level", no_wrap=True)
+        table.add_column("zone", no_wrap=True)
+        table.add_column("topic", no_wrap=True, style="dim")
+        table.add_column("ch", justify="right", style="dim")
+        table.add_column("title", no_wrap=False)
+        for qid, tr, lv, zn, tp, nc, ti in rows:
+            table.add_row(qid, tr, lv, zn, tp, str(nc), ti)
+        console.print(table)
+        console.print(f"[dim]{len(rows)} rows[/dim]")
+
+
+__all__ = ["register"]

--- a/interviews/vault-cli/src/vault_cli/commands/show.py
+++ b/interviews/vault-cli/src/vault_cli/commands/show.py
@@ -1,0 +1,121 @@
+"""``vault show`` — inspect one question with its chain context.
+
+Usage:
+    vault show cloud-0185
+
+Output:
+    - full classification (track/level/zone/topic/competency_area/bloom_level/phase)
+    - title + scenario preview
+    - validation + human-review lineage
+    - every chain the question belongs to, with prev/next walk
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from vault_cli.loader import load_all
+
+
+def register(app: typer.Typer) -> None:
+    @app.command("show")
+    def show_cmd(
+        question_id: str = typer.Argument(..., help="Question ID to inspect (e.g. cloud-0185)."),
+        vault_dir: Path = typer.Option(
+            Path("interviews/vault"), "--vault-dir",
+            help="Vault root.",
+        ),
+        preview_chars: int = typer.Option(400, "--preview", help="Scenario preview length (chars)."),
+    ) -> None:
+        """Inspect one question + walk its chains for prev/next links."""
+        console = Console()
+        loaded, errors = load_all(vault_dir)
+
+        by_id = {lq.id: lq for lq in loaded}
+        lq = by_id.get(question_id)
+        if lq is None:
+            console.print(f"[red]not found:[/red] {question_id!r}")
+            raise typer.Exit(code=1)
+
+        q = lq.question
+        console.print(Panel.fit(
+            f"[bold cyan]{q.id}[/bold cyan]    [dim]{q.status}[/dim]\n"
+            f"[bold]{q.title}[/bold]",
+            title="question",
+            border_style="cyan",
+        ))
+
+        cls = Table(show_header=False, box=None, pad_edge=False)
+        cls.add_column(style="dim", no_wrap=True)
+        cls.add_column()
+        cls.add_row("track",            q.track)
+        cls.add_row("level",            q.level)
+        cls.add_row("zone",             q.zone)
+        cls.add_row("topic",            q.topic)
+        cls.add_row("competency_area",  q.competency_area)
+        cls.add_row("bloom_level",      q.bloom_level or "[dim](unset)[/dim]")
+        if q.phase:
+            cls.add_row("phase",        q.phase)
+        cls.add_row("provenance",       q.provenance)
+        console.print(cls)
+
+        # Validation lineage.
+        vs = []
+        if q.validated is not None:
+            mark = "✓" if q.validated else "✗"
+            vs.append(f"{mark} LLM-validated ({q.validation_model or '?'}, {q.validation_date or '?'})")
+        if q.math_verified is not None:
+            mark = "✓" if q.math_verified else "✗"
+            vs.append(f"{mark} math-verified ({q.math_model or '?'}, {q.math_date or '?'})")
+        if q.human_reviewed:
+            hr = q.human_reviewed
+            vs.append(f"• human-reviewed: {hr.status}" + (f" by {hr.by}" if hr.by else ""))
+        else:
+            vs.append("[dim]• human-reviewed: not-reviewed[/dim]")
+        console.print("\n[bold]Validation:[/bold]")
+        for line in vs:
+            console.print(f"  {line}")
+
+        # Scenario preview.
+        console.print("\n[bold]Scenario:[/bold]")
+        s = q.scenario.strip()
+        if len(s) > preview_chars:
+            s = s[:preview_chars].rstrip() + " …"
+        console.print(f"  {s}")
+
+        # Chain memberships + prev/next walk.
+        console.print("\n[bold]Chains:[/bold]")
+        if not q.chains:
+            console.print("  [dim](not in any chain)[/dim]")
+        else:
+            # Build chain → ordered member list.
+            chain_members: dict[str, list] = {}
+            for other in loaded:
+                for c in (other.question.chains or []):
+                    chain_members.setdefault(c.id, []).append((c.position, other))
+            for c in sorted(q.chains, key=lambda x: x.id):
+                members = sorted(chain_members.get(c.id, []), key=lambda x: x[0])
+                positions = [m[0] for m in members]
+                idx = next((i for i, p in enumerate(positions) if p == c.position), -1)
+                console.print(f"  [cyan]{c.id}[/cyan]   position={c.position}   "
+                              f"({len(members)} members, spans {sorted({m[1].question.level for m in members})})")
+                prev_q = members[idx - 1][1] if idx > 0 else None
+                next_q = members[idx + 1][1] if 0 <= idx < len(members) - 1 else None
+                if prev_q:
+                    console.print(f"    prev: [dim]{prev_q.id}[/dim]  ({prev_q.question.level}, {prev_q.question.zone})  {prev_q.question.title}")
+                else:
+                    console.print(f"    prev: [dim](start of chain)[/dim]")
+                if next_q:
+                    console.print(f"    next: [dim]{next_q.id}[/dim]  ({next_q.question.level}, {next_q.question.zone})  {next_q.question.title}")
+                else:
+                    console.print(f"    next: [dim](end of chain)[/dim]")
+
+        console.print(f"\n[dim]file: {lq.path.relative_to(vault_dir)}[/dim]")
+
+
+__all__ = ["register"]

--- a/interviews/vault-cli/src/vault_cli/main.py
+++ b/interviews/vault-cli/src/vault_cli/main.py
@@ -39,6 +39,15 @@ from vault_cli.commands import (
     lint as lint_cmd_mod,
 )
 from vault_cli.commands import (
+    ls as ls_cmd_mod,
+)
+from vault_cli.commands import (
+    show as show_cmd_mod,
+)
+from vault_cli.commands import (
+    chain as chain_cmd_mod,
+)
+from vault_cli.commands import (
     promote as promote_cmd_mod,
 )
 from vault_cli.commands import (
@@ -75,6 +84,9 @@ promote_cmd_mod.register(app)
 dup_cmd_mod.register(app)
 generate_cmd_mod.register(app)
 lint_cmd_mod.register(app)
+ls_cmd_mod.register(app)
+show_cmd_mod.register(app)
+chain_cmd_mod.register(app)
 
 
 def _version_callback(value: bool) -> None:

--- a/interviews/vault/docs/ID_SCHEMES.md
+++ b/interviews/vault/docs/ID_SCHEMES.md
@@ -1,0 +1,168 @@
+# Vault ID schemes
+
+**Status:** active (proposed 2026-04-21, effective for new content)
+**Supersedes:** ad-hoc ID conventions in pre-v1.0 corpus (`cell-*`, `fill-*`, `fill2-*`, `sus-*`, `r2-*`, `crit-*`, `new-*`, `top-*` prefix markers)
+
+---
+
+## The durability principle
+
+Identifiers are *load-bearing*: they appear in chain references, URLs, the
+paper's appendix, contributor bookmarks, and the audit trail. Once assigned,
+an ID should **never change**. This single constraint rules out encoding any
+mutable attribute in the ID.
+
+The corpus has four mutable axes (`level`, `zone`, `topic`, `status`) and
+one near-immutable axis (`track`). Only the immutable axis is appropriate
+for ID encoding.
+
+Everything else — "what level is this?", "what zone is this?", "which chain
+is this in?" — is answered by **tooling**, not by the ID.
+
+---
+
+## Question ID scheme
+
+```
+<track>-<yyyymm>-<4hex>
+```
+
+| Segment | Values | Source | Mutable? |
+|---|---|---|---|
+| `track` | `cloud \| edge \| mobile \| tinyml \| global` | author's choice | no |
+| `yyyymm` | 6-digit year-month | creation time | no |
+| `4hex` | 4 hex chars | `sha256(title + "\n" + topic)[:4]` | no (content-addressed) |
+
+**Examples:**
+- `cloud-202604-a3f2`
+- `tinyml-202605-9b01`
+- `edge-202604-c5de`
+
+**Properties:**
+- **18-char maximum length.** Easy to copy/paste.
+- **Chronologically sortable** — sort the filename list and you're ordered by creation month.
+- **Collision-resistant**: 65 536 slots per `(track, yyyymm)` bucket. On collision `vault new` auto-increments `4hex` to the next free hex value.
+- **No mutable state.** If a question's level/zone/topic later changes, the ID stays.
+- **Visually greppable.** `cloud-202604-*` = "cloud questions authored April 2026" without opening anything.
+
+---
+
+## Chain ID scheme
+
+Chains are **topic-bound by definition** — a chain's identity is its topic,
+not its arbitrary sequence number. Encode that directly:
+
+```
+chain-<track>-<topic-slug>-<yyyymm>[-<suffix>]
+```
+
+The optional `-<suffix>` (single letter `a`, `b`, `c`, …) only appears when
+two chains in the same `(track, topic, month)` bucket need to disambiguate.
+
+**Examples:**
+- `chain-cloud-kv-cache-management-202604`
+- `chain-tinyml-ota-firmware-updates-202604`
+- `chain-edge-quantization-fundamentals-202605`
+- `chain-cloud-latency-decomposition-202604-b` (second chain that month in that bucket)
+
+**Properties:**
+- **Self-describing.** Read the chain ID and you know what it's about.
+- **Stable under corpus growth.** Adding questions to a chain doesn't rename the chain.
+- **Per-chain topic invariant.** `vault lint` warns if any question's `topic` differs from the chain's topic — guards against a chain silently drifting off-topic.
+
+---
+
+## Migration policy
+
+**Legacy IDs are preserved.** Every existing question ID
+(`cloud-0185`, `tinyml-cell-13212`, `mobile-fill-00191`, …) stays as-is.
+Same for existing chain IDs (`cloud-chain-432`, …). Renaming would break
+3 100+ chain references, external bookmarks, the Phase 2 audit JSONLs, and
+`git blame` chains.
+
+**New content uses the new scheme.** `vault new` emits IDs in the new
+format as of this policy. Old and new coexist freely in `id-registry.yaml`
+and `chains.yaml`.
+
+**Status today (2026-04-21):**
+- Question IDs: 9 657 legacy (cell/fill/sus/r2/crit/new/top/plain prefixes)
+- Chain IDs: 970 legacy (`<track>-chain-<NNN>`)
+- New scheme IDs: 0 (this doc is the spec; first use lands with the next `vault new`)
+
+---
+
+## Companion tooling
+
+The "I want to know X at a glance" pain point is solved by the CLI, not by
+the ID:
+
+| Need | Command |
+|---|---|
+| Browse all questions with filters | `vault ls [--track --level --zone --topic --status --in-chains]` |
+| Inspect a single question + its chain context | `vault show <question-id>` |
+| Walk a chain end-to-end | `vault chain show <chain-id>` |
+| All chains for a track/topic | `vault chain ls [--track --topic]` |
+| Confirm no orphan chain refs | `vault check --strict` |
+
+All three read `vault.db` (compiled from YAMLs via `vault build`) or the
+live YAMLs directly, so the outputs always reflect current classifications.
+
+---
+
+## Position semantics inside a chain
+
+Chain positions are **non-negative integers**. Where a chain spans Bloom's
+levels (the most common pattern), convention is:
+
+- `position: 0` = L1
+- `position: 1` = L2
+- …
+- `position: 5` = L6+
+
+`vault lint` warns when a chain's level sequence isn't monotonically
+non-decreasing over its positions. This is a soft warning, not a
+hard rule — some chains legitimately iterate within a level (two L3
+fluency variants of the same concept, for instance).
+
+A question may belong to multiple chains (≈101 of them do in the
+current corpus); its position is independent in each chain.
+
+---
+
+## Hash function (reproducibility)
+
+For the `4hex` question-ID suffix, the deterministic recipe is:
+
+```python
+import hashlib
+def question_id_hash(title: str, topic: str) -> str:
+    payload = f"{title}\n{topic}".encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()[:4]
+```
+
+The topic is included so two unrelated questions with identical titles
+(rare but possible) hash differently. Canonical ordering is `title + "\n" + topic`;
+no normalization beyond UTF-8 encoding.
+
+---
+
+## Why not include level/zone/topic in the ID?
+
+We considered — and rejected — an alternative scheme that encoded
+`level` or `zone` in the ID (e.g. `cloud-L4-kv-cache-management-0042` or
+"L1 questions are 1000, L2 are 2000…"). Concrete reasons:
+
+1. **Levels change.** The Phase 2 content audit (2026-04-21) moved 25
+   questions across level boundaries. Every move would force an ID
+   rename under a level-encoded scheme.
+2. **Chain references.** ≈3 100 question references live inside chain
+   YAMLs. Every rename cascades.
+3. **URL rot.** The Next.js site uses IDs as anchors (`/practice?id=…`).
+   ID renames break bookmarks and external links.
+4. **Git history.** Renames are traceable via `--follow`, but audit
+   trails and commit messages referring to the old ID become stale.
+5. **We don't need it.** The 4-axis classification is a `vault.db`
+   query or a `grep ^level:` away. Tooling is cheaper than renaming.
+
+The rule we settled on: **encode only the immutable (track + time +
+content-hash). Push everything else to the query layer.**


### PR DESCRIPTION
## Summary

Two additive changes that address today's conversation about "how do I know what's in the vault without opening every file":

1. **Durable ID scheme v2** for newly-created questions and chains, documented in [interviews/vault/docs/ID_SCHEMES.md](../blob/feat/vault-id-schemes-and-browse/interviews/vault/docs/ID_SCHEMES.md). Encodes only immutable axes (track + creation month + content hash). Level/zone/topic/status stay out of the name — they live in the query layer.

2. **Three browse CLI commands** — `vault ls`, `vault show`, `vault chain ls/show` — that surface per-question and per-chain views with filters, validation lineage, and prev/next chain walks. Works against the entire corpus today, legacy IDs included.

**Nothing is renamed.** All 9,657 legacy question IDs and 970 legacy chain IDs stay exactly as they are. The new scheme kicks in only for `vault new`.

## ID schemes

| Object | Scheme | Example |
|---|---|---|
| Question | `<track>-<yyyymm>-<4hex>` | `cloud-202604-a3f2` |
| Chain | `chain-<track>-<topic-slug>-<yyyymm>[-suffix]` | `chain-cloud-kv-cache-management-202604` |

The 4-hex is `sha256(title + "\\n" + topic)[:4]`. Collision-on-create bumps the hex within the same `(track, yyyymm)` bucket.

Chain IDs include topic so the chain's identity is self-describing. `vault lint` can enforce "every question in a chain shares the chain's topic" as a soft invariant.

## New commands

- `vault ls [--track --level --zone --topic --status --in-chains --limit --plain]`
- `vault show <question-id>` — full classification + validation lineage + scenario preview + chain walk
- `vault chain ls [--track --topic]` — lists chains with member counts + level spans
- `vault chain show <chain-id>` — walks a chain end-to-end; warns on multi-topic or non-monotonic level sequences

**First real finding surfaced by the new tooling:** `cloud-chain-432` spans two topics (`latency-decomposition` + `roofline-analysis`) — flagged by `vault chain show` as likely mis-linked. Not fixed here; queued for follow-up.

## Test plan

- [ ] CI checks pass
- [ ] `vault ls --track cloud --level L6+ --zone mastery --limit 5` prints 5 aligned rows
- [ ] `vault show cloud-0185` prints scenario + chain walk + validation lineage
- [ ] `vault chain show cloud-chain-432` warns about multi-topic span
- [ ] `vault new` emits IDs in the v2 format