### PR TITLE
fix(worker): move Gemini API key from URL query param to request header

### DIFF
--- a/interviews/staffml/worker/src/index.ts
+++ b/interviews/staffml/worker/src/index.ts
@@ -433,7 +433,7 @@ async function callGemini(
 ): Promise<string> {
   const apiKey = env[adapter.apiKeyEnv!] as string;
   const model = getModel(adapter, env);
-  const url = `${getBaseUrl(adapter, env)}/models/${model}:generateContent?key=${apiKey}`;
+  const url = `${getBaseUrl(adapter, env)}/models/${model}:generateContent`;
 
   // Gemini also expects alternating user/model turns. Filter out 'system'
   // (it goes in systemInstruction) and coalesce same-role runs.
@@ -450,7 +450,7 @@ async function callGemini(
 
   const res = await timedFetch(url, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", "x-goog-api-key": apiKey },
     body: JSON.stringify({
       systemInstruction: { parts: [{ text: system }] },
       contents: coalesced.map((m) => ({


### PR DESCRIPTION
## What the bug is

The Gemini adapter in the Ask Interviewer worker passes the API key as a URL query parameter:

```
https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=AIzaSy...
```

This is against standard security practice for API credentials. Three specific reasons it matters here:

**1. Cloudflare Tail Workers / wrangler tail capture subrequest URLs**

Cloudflare's observability tooling (enabled via `observability.enabled = true` in `wrangler.toml`) includes subrequest tracing: outbound `fetch()` calls made by the worker, with their full URLs. Anyone running `wrangler tail` to debug a live issue, or anyone with access to a Tail Worker log stream, sees the Gemini URL with the key in plain text on every request.

**2. Google logs query parameters server-side**

Per Google's own API key best-practices documentation, API keys passed as URL query parameters are recorded in server-side access logs. Those logs can surface in GCP audit exports, support tickets, or any future log sharing.

**3. Any future log aggregation inherits this**

If the project wires a log aggregation tool (Datadog, Axiom, Grafana Loki, etc.) to Cloudflare in the future, the key travels into that system automatically with no extra configuration needed, because it is already in the URL.

## Why headers are the right fix

RFC 6750 Section 5.3 explicitly states that bearer tokens and credentials should not be placed in URIs because URIs get logged. Every other adapter in this file already follows this: OpenAI-compat uses `Authorization: Bearer`, Anthropic uses `x-api-key`. The Gemini REST API supports `x-goog-api-key` as a header, which keeps the credential out of any URL-based logging path entirely.

## The fix

```diff
- const url = `${baseUrl}/models/${model}:generateContent?key=${apiKey}`;
+ const url = `${baseUrl}/models/${model}:generateContent`;

- headers: { "Content-Type": "application/json" }
+ headers: { "Content-Type": "application/json", "x-goog-api-key": apiKey }
```

Two lines changed. Behavior is identical. Verified locally by confirming `x-goog-api-key` returns `API_KEY_INVALID` (not `UNAUTHENTICATED`) with a fake key, meaning Google fully recognizes the header as a valid auth method.

TypeScript compiles cleanly. No other call sites affected.

## Note

Caught this while auditing the worker code from a software security best-practices perspective. Moving credentials out of URLs into request headers is a standard hardening recommendation regardless of the specific threat model. It keeps the credential out of any logging layer, present or future, by default.