### PR TITLE
fix(staffml): stale closure in gauntlet keyboard handler and importProgress partial-write

### DIFF
--- a/interviews/staffml/src/app/gauntlet/page.tsx
+++ b/interviews/staffml/src/app/gauntlet/page.tsx
@@ -161,25 +161,6 @@ export default function GauntletPage() {
     }
   }, [timeRemaining, phase]);
 
-  // Keyboard shortcuts: Cmd+Enter to reveal, 1-4 for scoring
-  useEffect(() => {
-    if (phase !== "active") return;
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.target instanceof HTMLTextAreaElement) {
-        if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && !showAnswer) {
-          e.preventDefault();
-          revealAnswer();
-        }
-        return;
-      }
-      if (showAnswer && ['1', '2', '3', '4'].includes(e.key)) {
-        scoreAndNext(parseInt(e.key) - 1);
-      }
-    };
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [phase, showAnswer]);
-
   const isDesignMode = selectedDuration === 3; // "Design (1 deep)"
 
   const startGauntlet = useCallback(() => {
@@ -228,7 +209,7 @@ export default function GauntletPage() {
     setShowAnswer(true);
   };
 
-  const scoreAndNext = (score: number) => {
+  const scoreAndNext = useCallback((score: number) => {
     const q = questions[currentIdx];
     const attempt: AttemptRecord = {
       questionId: q.id,
@@ -276,7 +257,27 @@ export default function GauntletPage() {
       track({ type: 'gauntlet_completed', track: selectedTrack, level: selectedLevel, pct: pctScore, questionCount: questions.length });
       setPhase("results");
     }
-  };
+  }, [questions, currentIdx, scores, timeRemaining, selectedDuration, selectedTrack, selectedLevel]);
+
+  // Keyboard shortcuts: Cmd+Enter to reveal, 1-4 for scoring.
+  // Placed after scoreAndNext so the stable callback reference is in scope.
+  useEffect(() => {
+    if (phase !== "active") return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLTextAreaElement) {
+        if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && !showAnswer) {
+          e.preventDefault();
+          revealAnswer();
+        }
+        return;
+      }
+      if (showAnswer && ['1', '2', '3', '4'].includes(e.key)) {
+        scoreAndNext(parseInt(e.key) - 1);
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [phase, showAnswer, scoreAndNext]);
 
   const formatTime = (seconds: number) => {
     const m = Math.floor(seconds / 60);

--- a/interviews/staffml/src/lib/progress.ts
+++ b/interviews/staffml/src/lib/progress.ts
@@ -338,33 +338,47 @@ export function importProgress(json: string): boolean {
     const data = JSON.parse(json);
     if (!data.version || typeof data.version !== 'number') return false;
 
-    // Validate shapes before writing
-    if (data.attempts) {
+    // Validate all shapes before touching storage.
+    if (data.attempts !== undefined) {
       if (!Array.isArray(data.attempts)) return false;
-      // Verify first item has expected shape (if array is non-empty)
       if (data.attempts.length > 0) {
         const first = data.attempts[0];
         if (typeof first.questionId !== 'string' || typeof first.selfScore !== 'number') return false;
       }
-      setStorage(STORAGE_KEY, data.attempts);
     }
-    if (data.gauntlets) {
-      if (!Array.isArray(data.gauntlets)) return false;
-      setStorage(GAUNTLET_KEY, data.gauntlets);
+    if (data.gauntlets !== undefined && !Array.isArray(data.gauntlets)) return false;
+    if (data.sr !== undefined && (typeof data.sr !== 'object' || Array.isArray(data.sr))) return false;
+    if (data.streak !== undefined && (typeof data.streak !== 'object' || Array.isArray(data.streak))) return false;
+
+    // Snapshot existing values so we can roll back on any write failure.
+    const KEYS = [STORAGE_KEY, GAUNTLET_KEY, SR_KEY, STREAK_KEY, 'staffml_daily', 'staffml_plan_progress', 'staffml_analytics'] as const;
+    const snapshot: Record<string, string | null> = {};
+    for (const k of KEYS) {
+      try { snapshot[k] = window.localStorage.getItem(k); } catch { snapshot[k] = null; }
     }
-    if (data.sr && typeof data.sr === 'object' && !Array.isArray(data.sr)) {
-      setStorage(SR_KEY, data.sr);
+
+    const rollback = () => {
+      for (const k of KEYS) {
+        try {
+          if (snapshot[k] === null) window.localStorage.removeItem(k);
+          else window.localStorage.setItem(k, snapshot[k]!);
+        } catch { /* best-effort */ }
+      }
+    };
+
+    try {
+      if (data.attempts !== undefined) setStorage(STORAGE_KEY, data.attempts);
+      if (data.gauntlets !== undefined) setStorage(GAUNTLET_KEY, data.gauntlets);
+      if (data.sr !== undefined) setStorage(SR_KEY, data.sr);
+      if (data.streak !== undefined) setStorage(STREAK_KEY, data.streak);
+      if (data.daily !== undefined) setStorage('staffml_daily', data.daily);
+      if (data.planProgress !== undefined) setStorage('staffml_plan_progress', data.planProgress);
+      if (data.analytics !== undefined && Array.isArray(data.analytics)) setStorage('staffml_analytics', data.analytics);
+    } catch {
+      rollback();
+      return false;
     }
-    if (data.streak && typeof data.streak === 'object' && !Array.isArray(data.streak)) {
-      setStorage(STREAK_KEY, data.streak);
-    }
-    if (data.daily) setStorage('staffml_daily', data.daily);
-    if (data.planProgress && typeof data.planProgress === 'object') {
-      setStorage('staffml_plan_progress', data.planProgress);
-    }
-    if (data.analytics && Array.isArray(data.analytics)) {
-      setStorage('staffml_analytics', data.analytics);
-    }
+
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## What this fixes

Two independent bugs in StaffML that silently corrupt user state under specific but realistic conditions.

### Bug 1: Stale closure in gauntlet keyboard shortcuts

**File:** `interviews/staffml/src/app/gauntlet/page.tsx`

`scoreAndNext` was a plain function (not wrapped in `useCallback`). The keyboard shortcut `useEffect` had a dependency array of `[phase, showAnswer]`, which meant the event handler captured stale values of `currentIdx` and `scores` from the render in which the effect last ran.

Repro: open a gauntlet, answer Q1 with the mouse (state updates), then press key `2` to score Q2. The handler fires with `currentIdx = 0` still captured, so Q1 gets scored a second time and Q2 is skipped entirely.

Fix: wrap `scoreAndNext` in `useCallback` with its actual deps (`questions`, `currentIdx`, `scores`, `timeRemaining`, `selectedDuration`, `selectedTrack`, `selectedLevel`), add it to the keyboard effect's dependency array, and move the effect below the `scoreAndNext` declaration to satisfy TypeScript's temporal dead zone check.

### Bug 2: importProgress partial-write with no rollback

**File:** `interviews/staffml/src/lib/progress.ts`

`importProgress` validated and wrote keys to `localStorage` one at a time. If `attempts` passed validation and was written, then `gauntlets` failed its `Array.isArray` check, the function returned `false` but `STORAGE_KEY` already held the new attempts data while `GAUNTLET_KEY` still held the old gauntlet history. The user ends up with a silently inconsistent state: a mix of new and old data that skews cross-session analytics.

The same class of failure applies to `QuotaExceededError` (private browsing mode with limited quota) mid-write.

Fix: validate all shapes first before touching storage, snapshot all relevant `localStorage` keys upfront, and restore the snapshot if any write throws.

## Verification

Both changes pass `tsc --noEmit` with zero errors. No new dependencies introduced.