### PR TITLE
feat(d1): cutover production D1 + live worker serving v1.0 schema

### DIFF
--- a/interviews/staffml-vault-worker/src/rate_limit.ts
+++ b/interviews/staffml-vault-worker/src/rate_limit.ts
@@ -77,7 +77,11 @@ export async function checkRateLimit(
   // abusive scraper blowing D1 budget" goal. Tight enforcement requires
   // Durable Objects; deferred to Phase-4 follow-up if KV-level leakage is
   // observed in telemetry.
-  const ttl = 60 - (nowSec % 60) + 10;
+  // Cloudflare KV rejects expirationTtl < 60. The intended value here is
+  // "remainder-of-minute + 10s grace"; floor at 60 so we never ship an
+  // illegal TTL. A slightly-longer-than-needed TTL on the tail end of a
+  // minute is harmless (key naturally expires on the NEXT minute's rotation).
+  const ttl = Math.max(60, 60 - (nowSec % 60) + 10);
   await env.RATE_LIMIT_KV.put(key, String(count + 1), { expirationTtl: ttl });
   return { ok: true };
 }

--- a/interviews/staffml-vault-worker/src/types.ts
+++ b/interviews/staffml-vault-worker/src/types.ts
@@ -27,16 +27,24 @@ export interface QuestionRow {
   track: string;
   level: string;
   zone: string;
+  /** v1.0: 13 canonical competency areas (memory, compute, latency, …). */
+  competency_area: string | null;
+  /** v1.0: Bloom's revised taxonomy verb (remember/understand/apply/analyze/evaluate/create). */
+  bloom_level: string | null;
+  /** v1.0: ML lifecycle phase (training/inference/both). */
+  phase: string | null;
   status: string;
   scenario: string;
   common_mistake: string | null;
   realistic_solution: string;
   napkin_math: string | null;
-  deep_dive_title: string | null;
-  deep_dive_url: string | null;
   provenance: string;
   created_at: string | null;
   last_modified: string | null;
+  /** v1.0: human verification status, independent of LLM validation. */
+  human_review_status: string | null;
+  human_review_by: string | null;
+  human_review_date: string | null;
   content_hash: string;
   authors_json: string | null;
 }

--- a/interviews/staffml-vault-worker/wrangler.toml
+++ b/interviews/staffml-vault-worker/wrangler.toml
@@ -20,7 +20,7 @@ CACHE_TTL_QUESTION = "3600"
 CACHE_TTL_SEARCH = "300"
 CACHE_TTL_TAXONOMY = "86400"
 CORS_ALLOWLIST = "https://staffml.mlsysbook.ai,https://mlsysbook.ai,https://staffml-vault.mlsysbook.ai,http://localhost:3000"
-SCHEMA_FINGERPRINT = "d964851fc1a7ced6b4068542441d374a6c3f291a211832a1dce90278faac7f84"
+SCHEMA_FINGERPRINT = "b97218dae6354b1ba0ed4a93242f0ca848554ed02ec86246dc8977ae918c5ad6"
 GRACE_WINDOW_SECONDS = "600"
 
 [env.staging]
@@ -32,7 +32,7 @@ CACHE_TTL_QUESTION = "3600"
 CACHE_TTL_SEARCH = "300"
 CACHE_TTL_TAXONOMY = "86400"
 CORS_ALLOWLIST = "https://staging.staffml.mlsysbook.ai,http://localhost:3000"
-SCHEMA_FINGERPRINT = "d964851fc1a7ced6b4068542441d374a6c3f291a211832a1dce90278faac7f84"
+SCHEMA_FINGERPRINT = "b97218dae6354b1ba0ed4a93242f0ca848554ed02ec86246dc8977ae918c5ad6"
 GRACE_WINDOW_SECONDS = "600"
 
 [[env.staging.d1_databases]]

--- a/interviews/vault-cli/scripts/ship_d1.py
+++ b/interviews/vault-cli/scripts/ship_d1.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Ship the current vault.db to the live Cloudflare D1 database.
+
+Generates a full-reload SQL script (DROP + CREATE + INSERT) from a fresh
+vault.db build, then applies it via `wrangler d1 execute --remote`.
+
+Usage:
+    # Fresh build + push to production D1:
+    python3 interviews/vault-cli/scripts/ship_d1.py
+
+    # Dry-run: write SQL to /tmp/d1_cutover.sql, don't apply:
+    python3 interviews/vault-cli/scripts/ship_d1.py --dry-run
+
+    # Stage instead of production:
+    python3 interviews/vault-cli/scripts/ship_d1.py --env staging
+
+Requires:
+    - `vault` CLI installed (`pip install -e interviews/vault-cli/`)
+    - `wrangler` CLI authenticated (`wrangler whoami`)
+"""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+VAULT_DIR = REPO / "interviews" / "vault"
+VAULT_DB = VAULT_DIR / "vault.db"
+WORKER_DIR = REPO / "interviews" / "staffml-vault-worker"
+D1_SCHEMA = REPO / "interviews" / "vault-cli" / "scripts" / "d1-schema.sql"
+
+
+def _sql_lit(v):
+    if v is None:
+        return "NULL"
+    if isinstance(v, (int, float)):
+        return str(v)
+    return "'" + str(v).replace("'", "''") + "'"
+
+
+def generate_sql(vault_db: Path, d1_schema: Path, out: Path) -> None:
+    parts = []
+    parts.append("-- D1 full-reload migration — DROP + CREATE + INSERT")
+    parts.append(f"-- Generated from {vault_db.name} (byte-for-byte reproducible)")
+    parts.append("PRAGMA foreign_keys = OFF;")
+    for tbl in ["questions_fts", "chain_questions", "chains", "tags", "release_metadata", "questions"]:
+        parts.append(f"DROP TABLE IF EXISTS {tbl};")
+    for trig in ["questions_ai", "questions_ad", "questions_au"]:
+        parts.append(f"DROP TRIGGER IF EXISTS {trig};")
+    parts.append("")
+    parts.append(d1_schema.read_text())
+    parts.append("PRAGMA foreign_keys = ON;")
+
+    conn = sqlite3.connect(vault_db)
+    cur = conn.cursor()
+
+    # Parent tables first so FKs don't bounce the child inserts.
+    parts.append("\n-- chains (parent of chain_questions)")
+    for row in cur.execute("SELECT id, name, topic FROM chains"):
+        parts.append(f"INSERT INTO chains VALUES ({','.join(_sql_lit(v) for v in row)});")
+
+    parts.append("\n-- questions")
+    for row in cur.execute("""
+        SELECT id, title, topic, track, level, zone, competency_area, bloom_level, phase,
+               status, scenario, common_mistake, realistic_solution, napkin_math,
+               provenance, created_at, last_modified,
+               human_review_status, human_review_by, human_review_date,
+               file_path, content_hash, authors_json
+        FROM questions
+    """):
+        parts.append(f"INSERT INTO questions VALUES ({','.join(_sql_lit(v) for v in row)});")
+
+    parts.append("\n-- chain_questions")
+    for row in cur.execute("SELECT chain_id, question_id, position FROM chain_questions"):
+        parts.append(f"INSERT INTO chain_questions VALUES ({','.join(_sql_lit(v) for v in row)});")
+
+    parts.append("\n-- tags")
+    for row in cur.execute("SELECT question_id, tag FROM tags"):
+        parts.append(f"INSERT INTO tags VALUES ({','.join(_sql_lit(v) for v in row)});")
+
+    parts.append("\n-- release_metadata")
+    for row in cur.execute("SELECT key, value FROM release_metadata"):
+        parts.append(f"INSERT INTO release_metadata VALUES ({','.join(_sql_lit(v) for v in row)});")
+
+    conn.close()
+    out.write_text("\n".join(parts) + "\n")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Ship vault.db to Cloudflare D1.")
+    ap.add_argument("--env", choices=["production", "staging"], default="production",
+                    help="Target D1 environment (default: production).")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Write SQL to /tmp/d1_cutover.sql but do not apply.")
+    ap.add_argument("--skip-build", action="store_true",
+                    help="Assume vault.db is already up to date.")
+    args = ap.parse_args()
+
+    if not args.skip_build:
+        print("==> vault build", flush=True)
+        subprocess.check_call(
+            ["vault", "build", "--vault-dir", str(VAULT_DIR), "--release-id", f"ship-{args.env}"],
+            cwd=REPO,
+        )
+
+    sql_path = Path("/tmp/d1_cutover.sql")
+    print(f"==> generating {sql_path} from {VAULT_DB.name}", flush=True)
+    generate_sql(VAULT_DB, D1_SCHEMA, sql_path)
+    size_mb = sql_path.stat().st_size / 1024 / 1024
+    with sql_path.open() as fh:
+        line_count = sum(1 for _ in fh)
+    print(f"    wrote {line_count} lines ({size_mb:.1f} MiB)", flush=True)
+
+    if args.dry_run:
+        print("==> dry-run; skipping wrangler d1 execute", flush=True)
+        return 0
+
+    env_flag = "" if args.env == "production" else f"--env {args.env}"
+    cmd = f"npx wrangler d1 execute staffml-vault --remote {env_flag} --file={sql_path}".strip()
+    print(f"==> {cmd}", flush=True)
+    subprocess.check_call(shlex.split(cmd), cwd=WORKER_DIR)
+    print("==> done", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/interviews/vault-cli/src/vault_cli/compiler.py
+++ b/interviews/vault-cli/src/vault_cli/compiler.py
@@ -232,6 +232,33 @@ def _populate_taxonomy(conn: sqlite3.Connection, data_dir: Path) -> None:
     conn.commit()
 
 
+def _populate_chains(conn: sqlite3.Connection, vault_dir: Path) -> None:
+    """Load chains.json into the `chains` table.
+
+    The compiler previously left this table empty, which made
+    chain_questions FK constraints fail on any engine that enforces
+    them (e.g., Cloudflare D1).
+    """
+    chains_path = vault_dir / "chains.json"
+    if not chains_path.exists():
+        return
+    data = json.loads(chains_path.read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        return
+    cur = conn.cursor()
+    for c in data:
+        if not isinstance(c, dict):
+            continue
+        cid = c.get("chain_id") or c.get("id")
+        if not cid:
+            continue
+        cur.execute(
+            "INSERT OR REPLACE INTO chains(id, name, topic) VALUES (?, ?, ?)",
+            (cid, c.get("name"), c.get("topic")),
+        )
+    conn.commit()
+
+
 def _populate_zones(conn: sqlite3.Connection, data_dir: Path) -> None:
     """Load zones.json into the zones table."""
     zones_path = data_dir / "zones.json"
@@ -280,6 +307,11 @@ def build(
         staffml_data = (vault_dir / ".." / "staffml" / "src" / "data").resolve()
         _populate_taxonomy(conn, staffml_data)
         _populate_zones(conn, staffml_data)
+
+        # ── Populate chains table from chains.json ──
+        # Without this the chains table is empty and FK enforcement (D1)
+        # rejects chain_questions inserts pointing at unknown chain IDs.
+        _populate_chains(conn, vault_dir)
 
         taxonomy_path = vault_dir / "taxonomy.yaml"
         chains_path = vault_dir / "chains.yaml"


### PR DESCRIPTION
## Summary

Cutover of the production Cloudflare D1 database + staffml-vault Worker to the schema v1.0 corpus. Worker is live and serving v1.0 + Phase 2 reclassifications end-to-end.

Live verification (run at commit time):

```
$ curl https://staffml-vault.mlsysbook-ai-account.workers.dev/manifest
{"release_id":"d1-cutover","release_hash":"997747a8f43bbd89…","schema_version":"1","published_count":9199,"schema_fingerprint_ok":true}

$ curl .../questions/cloud-0185
{"id":"cloud-0185","level":"L6+","zone":"mastery","competency_area":"latency","bloom_level":"create","phase":"both",…}

$ curl '.../questions?track=cloud&level=L6%2B&limit=1'
{"items":[{"id":"cloud-0179","level":"L6+","zone":"mastery",…}],"next_cursor":"…"}
```

## Four fixes

1. **`compiler.py`** — populate `chains` table from `chains.json`. Was silently empty; only surfaced when D1 (FKs enforced by default, unlike SQLite) rejected `chain_questions` inserts with `FOREIGN KEY constraint failed`.
2. **`types.ts` (worker)** — add `competency_area`, `bloom_level`, `phase`, `human_review_*` fields. Worker SQL was already `SELECT *` so columns flowed through; only the TS row interface needed updating.
3. **`rate_limit.ts`** — floor expirationTtl at 60s. Old calc could emit 11s, which D1 KV rejects. Was throwing error 1101 on every request post-deploy.
4. **`wrangler.toml`** — bump `SCHEMA_FINGERPRINT` to match v1.0 vault.db (`b97218dae…`).

## New script

`interviews/vault-cli/scripts/ship_d1.py` — end-to-end `vault build` → SQL dump → `wrangler d1 execute --file`. Handles FK ordering. Repeatable for future schema bumps. Used for this cutover; can be wired into `vault ship` as a leg later.

## Site cutover status — hybrid today

The bundled `corpus.json` is still the primary data path for the Next.js site. The worker path works but is opt-in via env vars. Full sync→async conversion of all `getQuestions()` callers is a separate refactor (deferred because every caller needs an audit pass).

To flip when ready:
```
export NEXT_PUBLIC_VAULT_API=https://staffml-vault.mlsysbook-ai-account.workers.dev
unset NEXT_PUBLIC_VAULT_FALLBACK
```

## Still outstanding

- DNS / custom domain `staffml-vault.mlsysbook.ai` isn't mapped; currently on `workers.dev` default
- Site callers → async migration for full bundle drop
- Paper figures regen (pre-v1.0 counts still baked)