### PR TITLE
feat(staffml): flip default data source to vault worker

### DIFF
--- a/.github/workflows/staffml-preview-dev.yml
+++ b/.github/workflows/staffml-preview-dev.yml
@@ -82,7 +82,9 @@ jobs:
           # same global budget as production. The CORS allowlist on the
           # worker already includes localhost plus the production origins.
           NEXT_PUBLIC_INTERVIEWER_ENDPOINT: https://mlsysbook.ai/api/staffml-interviewer
+          # Preview shares the production worker (same D1 data).
           NEXT_PUBLIC_VAULT_API: https://staffml-vault.mlsysbook-ai-account.workers.dev
+          NEXT_PUBLIC_VAULT_RELEASE: "1.0.2"
         run: npm run build
 
       - name: 📁 Inject paper and figures into build

--- a/.github/workflows/staffml-publish-live.yml
+++ b/.github/workflows/staffml-publish-live.yml
@@ -86,7 +86,12 @@ jobs:
           # live site at mlsysbook.ai/staffml/ so no CORS preflight is
           # required on /ask calls from the AskInterviewer panel.
           NEXT_PUBLIC_INTERVIEWER_ENDPOINT: https://mlsysbook.ai/api/staffml-interviewer
+          # Vault cutover (PRs #1433, #1434): site reads live data from the
+          # Cloudflare Worker in production; bundled corpus.json is the
+          # offline fallback. NEXT_PUBLIC_VAULT_FALLBACK is intentionally
+          # unset so vault-fallback.ts defaults to 'vault-api'.
           NEXT_PUBLIC_VAULT_API: https://staffml-vault.mlsysbook-ai-account.workers.dev
+          NEXT_PUBLIC_VAULT_RELEASE: "1.0.2"
         run: npm run build
 
       - name: 📁 Inject paper and figures into build

--- a/interviews/staffml/.env.example
+++ b/interviews/staffml/.env.example
@@ -3,19 +3,23 @@
 # Copy to .env.local and edit for your local dev setup.
 # ──────────────────────────────────────────────────────────────────────
 
-# ── Phase-4 vault API config ────────────────────────────────────────────
-# Production: https://api.staffml.mlsysbook.ai (the staffml-vault Worker)
-# Local dev : http://localhost:8002 (vault api shim from vault-cli)
-NEXT_PUBLIC_VAULT_API=http://localhost:8002
+# ── Vault API (Cloudflare Worker + D1) ─────────────────────────────────
+# Production worker URL (live since 2026-04-22; cutover PR #1433 + #1434).
+# Endpoints: /manifest, /questions/:id, /questions?filters, /search (FTS5).
+# Custom domain `staffml-vault.mlsysbook.ai` is planned but not yet mapped.
+NEXT_PUBLIC_VAULT_API=https://staffml-vault.mlsysbook-ai-account.workers.dev
 
-# The release the site's bundle was built against. Worker accepts mismatches
-# during the 10-min grace window (ARCHITECTURE.md §6.1.1); after that, the
-# mismatch shows up in X-Vault-Release SLI but still serves.
-NEXT_PUBLIC_VAULT_RELEASE=0.9.0
+# Local dev: point at the vault-cli dev shim (vault serve-api):
+# NEXT_PUBLIC_VAULT_API=http://localhost:8002
+
+# Release the site bundle was built against. The worker accepts mismatches
+# during the 10-min grace window (ARCHITECTURE.md §6.1.1); after that,
+# mismatch surfaces in X-Vault-Release SLI but still serves.
+NEXT_PUBLIC_VAULT_RELEASE=1.0.2
 
 # Data-source switch:
-#   unset or 'vault' → site reads from Worker API (post-cutover)
-#   'static'          → site reads from bundled corpus.json (pre-cutover,
-#                       rollback, or local dev without a Worker)
-# This is the C-1 "one-line revert" — a config flip, not a file restore.
-NEXT_PUBLIC_VAULT_FALLBACK=static
+#   unset or 'vault' → worker-primary, bundled corpus.json as fallback (DEFAULT)
+#   'static'         → bundled-only (rollback / offline / worker-unreachable dev)
+# The bundled corpus.json is preserved on disk as a safety net — it is not
+# deleted, but the site reads from the worker when it's reachable.
+# NEXT_PUBLIC_VAULT_FALLBACK=static


### PR DESCRIPTION
## Summary

Makes the production Cloudflare Worker the default data source for the StaffML site. The bundled `corpus.json` stays on disk as the safety-net fallback — not deleted, not moved. Rollback is a one-line env uncomment.

## Mechanics

`vault-fallback.ts` already returns `'vault-api'` unless `NEXT_PUBLIC_VAULT_FALLBACK=static` is set. Production CI never set that flag, so the worker path was already the runtime default — this commit makes that fact explicit and pins the release version.

Three tiny diffs:

- `.env.example`: `NEXT_PUBLIC_VAULT_API` now documents the live worker URL; `NEXT_PUBLIC_VAULT_FALLBACK` commented out; `NEXT_PUBLIC_VAULT_RELEASE` bumped 0.9.0 → 1.0.2
- `staffml-publish-live.yml`: adds `NEXT_PUBLIC_VAULT_RELEASE=1.0.2` + comment documenting the intentional unset of fallback
- `staffml-preview-dev.yml`: same release pin

## What's worker-backed today

- Full-text search (FTS5 via `/search`)
- Question lookup via `corpus-source.ts` async path
- Service worker caching
- Manifest probe at app boot

## What's still bundle-backed

13 sync callers of `@/lib/corpus` (about, progress, plans, practice, gauntlet, home, daily, layout, not-found, CommandPalette, ChainStrip). Converting those to async is a separate refactor. Since the site uses `next.config.mjs` `output: 'export'` (static export), bundling the first-paint data is actually the right architectural choice — the worker supplements with live data for runtime operations.

## Bundled `corpus.json`

Preserved exactly as-is. It remains the static-export data source AND the offline fallback.

## Rollback

One line in either CI workflow or `.env`:
```
NEXT_PUBLIC_VAULT_FALLBACK=static
```

## Test plan

- [ ] Live worker `curl .../manifest` returns `release_hash=9cb0d7fc…` (verified in prior commit)
- [ ] `npm run build` succeeds in `interviews/staffml` with the new env
- [ ] CommandPalette search hits `/search` FTS5 endpoint (check browser devtools after deploy)
- [ ] Service worker registers on first visit