### PR TITLE
feat(ci): close the deploy loop — YAML change triggers full pipeline

### DIFF
--- a/.github/workflows/staffml-preview-dev.yml
+++ b/.github/workflows/staffml-preview-dev.yml
@@ -33,6 +33,12 @@ on:
     branches: [dev]
     paths:
       - 'interviews/staffml/**'
+      # Also redeploy when YAMLs or chains change — the workflow
+      # regenerates corpus.json + corpus-summary.json from YAMLs before
+      # building, so the dev site always reflects current vault state.
+      - 'interviews/vault/questions/**'
+      - 'interviews/vault/chains.json'
+      - 'interviews/vault/schema/**'
 
 permissions:
   contents: read
@@ -61,6 +67,21 @@ jobs:
       - name: 📦 Install dependencies
         working-directory: interviews/staffml
         run: npm ci
+
+      - name: 🐍 Setup Python (for vault-cli)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: 🛠️ Install vault-cli
+        run: pip install -e interviews/vault-cli/
+
+      - name: 🔄 Regenerate corpus from YAMLs (vault build --legacy-json)
+        # Emits interviews/staffml/src/data/corpus.json (full) +
+        # corpus-summary.json (site bundle) from the committed YAMLs.
+        # Guarantees the built site reflects current vault state even if
+        # the committed JSON artifacts drift from YAMLs.
+        run: vault build --vault-dir interviews/vault --release-id preview-dev --legacy-json
 
       - name: 🔍 Type check
         working-directory: interviews/staffml

--- a/.github/workflows/staffml-publish-live.yml
+++ b/.github/workflows/staffml-publish-live.yml
@@ -67,6 +67,21 @@ jobs:
         working-directory: interviews/staffml
         run: npm ci
 
+      - name: 🐍 Setup Python (for vault-cli)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: 🛠️ Install vault-cli
+        run: pip install -e interviews/vault-cli/
+
+      - name: 🔄 Regenerate corpus from YAMLs (vault build --legacy-json)
+        # Ships interviews/staffml/src/data/corpus.json (full) +
+        # corpus-summary.json (bundled by the site) straight from the
+        # committed YAMLs. The site always deploys with current YAML state,
+        # even if the committed JSON artifacts drifted on the last commit.
+        run: vault build --vault-dir interviews/vault --release-id publish-live --legacy-json
+
       - name: 🔍 Type check
         working-directory: interviews/staffml
         run: npx tsc --noEmit
@@ -215,3 +230,27 @@ jobs:
           publish_branch: gh-pages
           keep_files: false
           commit_message: '🔀 Update /interviews/ redirect to /staffml/'
+
+      # ── Cloudflare (D1 data + Worker code) ─────────────────────────
+      # After the static site ships to GH Pages, sync the Cloudflare side:
+      # 1. Push the fresh vault.db data to D1 (vault contents match the
+      #    site's bundled summary; users get identical answers whether they
+      #    hit the bundle or the worker).
+      # 2. Deploy the worker code if interviews/staffml-vault-worker/** changed
+      #    (wrangler is idempotent — no-op if the upload is identical).
+      #
+      # Requires CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID secrets.
+      - name: 🚢 Ship vault data to D1
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: python3 interviews/vault-cli/scripts/ship_d1.py --skip-build
+
+      - name: 📦 Install worker deps + deploy
+        working-directory: interviews/staffml-vault-worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          npm ci
+          npx wrangler deploy

--- a/.github/workflows/staffml-update-paper.yml
+++ b/.github/workflows/staffml-update-paper.yml
@@ -31,6 +31,11 @@ on:
     paths:
       - 'interviews/paper/**'
       - 'interviews/vault/corpus.json'
+      # Also regenerate when YAMLs change — analyze_corpus.py needs a
+      # fresh corpus.json. The vault-cli step below regenerates it from
+      # the YAMLs before calling analyze_corpus.py.
+      - 'interviews/vault/questions/**'
+      - 'interviews/vault/chains.json'
 
 permissions:
   contents: write
@@ -53,6 +58,14 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r interviews/paper/requirements.txt
           pip check
+
+      - name: 🛠️ Install vault-cli (for corpus regen from YAMLs)
+        run: pip install -e interviews/vault-cli/
+
+      - name: 🔄 Regenerate corpus.json from YAMLs
+        # Ensures analyze_corpus sees current YAML state even if the
+        # committed corpus.json drifted.
+        run: vault build --vault-dir interviews/vault --release-id paper-refresh --legacy-json
 
       - name: 📊 Analyze corpus & generate figures
         working-directory: interviews/paper

--- a/interviews/vault-cli/src/vault_cli/legacy_export.py
+++ b/interviews/vault-cli/src/vault_cli/legacy_export.py
@@ -108,11 +108,50 @@ def emit_legacy_corpus(
         encoding="utf-8",
     )
 
+    # Also emit a summary-only companion next to the full corpus for
+    # callers that only need classification axes (~80% smaller). The
+    # site bundles this file instead of the full corpus.json; scenario
+    # and details are fetched on demand from the worker via
+    # useFullQuestion() / getQuestionFullDetail().
+    summary_output = output.with_name(output.stem + "-summary" + output.suffix)
+    summary_items = [_to_summary(item) for item in legacy_items]
+    summary_output.write_text(
+        json.dumps(summary_items, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
     return {
         "output": str(output),
+        "summary_output": str(summary_output),
         "count": len(legacy_items),
         "mode": "published-only" if publish_only else "all-states",
     }
+
+
+def _to_summary(item: dict[str, Any]) -> dict[str, Any]:
+    """Return the summary form of a legacy corpus item.
+
+    Keeps every classification axis and chain membership. Replaces the
+    heavy scenario + details.{common_mistake,realistic_solution,napkin_math}
+    with empty-string stubs so the TypeScript Question interface stays
+    backward-compatible. MCQ options + correct_index are PRESERVED
+    (scoring logic reads them synchronously).
+    """
+    drop_fields = {"scenario", "details"}
+    summary: dict[str, Any] = {k: v for k, v in item.items() if k not in drop_fields}
+    summary["scenario"] = ""
+    original_details = item.get("details", {}) or {}
+    details_stub: dict[str, Any] = {
+        "common_mistake": "",
+        "realistic_solution": "",
+        "napkin_math": "",
+    }
+    if original_details.get("options") is not None:
+        details_stub["options"] = original_details["options"]
+    if original_details.get("correct_index") is not None:
+        details_stub["correct_index"] = original_details["correct_index"]
+    summary["details"] = details_stub
+    return summary
 
 
 __all__ = ["emit_legacy_corpus"]


### PR DESCRIPTION
## Why

Today's state: validation automated, deployment manual. A contributor editing a YAML has to run 4 scripts locally (`vault build --legacy-json`, `ship_d1.py`, `wrangler deploy`, paper regen) and commit the outputs. Forget any of them → site serves stale data.

## What lands

Existing workflows extended so a YAML-only PR triggers the entire pipeline.

### Legacy export

`emit_legacy_corpus()` now writes **both** `corpus.json` (full, 22 MiB) and `corpus-summary.json` (lite, 4.5 MiB — what the site bundles) from one `vault build --legacy-json` call. No more separate script.

### staffml-preview-dev.yml
- Trigger extended: also fires on `interviews/vault/questions/**`, `chains.json`, `schema/**`
- Adds Python + vault-cli install
- Adds `vault build --legacy-json` before `npm run build` — site always reflects current YAMLs

### staffml-publish-live.yml
- Same build-time regen as preview-dev
- Adds `ship vault data to D1` (after site deploy)
- Adds `wrangler deploy` (worker code ships with site; idempotent)

### staffml-update-paper.yml
- Trigger extended: also fires on YAML changes
- Installs vault-cli + runs `vault build --legacy-json` before `analyze_corpus.py`
- Paper figures + `macros.tex` auto-regenerate on corpus evolution

## Required secrets (one-time setup)

```
CLOUDFLARE_API_TOKEN    Workers + D1 edit scope
CLOUDFLARE_ACCOUNT_ID   MLSysBook.AI Account ID
```

Set in GitHub → Settings → Secrets → Actions. GITHUB_TOKEN already wired.

## End-to-end flow after this PR

**YAML edit (e.g. `vault lint` catches a misclass → contributor reclassifies):**
1. Push to `dev` branch
2. `vault-ci.yml` → invariant checks pass
3. `staffml-update-paper.yml` → paper figures + macros regenerate
4. `staffml-preview-dev.yml` → corpus regen → site build → deploy to dev-site
5. Maintainer triggers `staffml-publish-live.yml` → full refresh + D1 ship + worker deploy

Nothing for the contributor to run locally. Nothing to forget.

## Test plan

- [ ] CI passes on this PR
- [ ] `vault build --legacy-json` emits both `corpus.json` and `corpus-summary.json` (verified locally)
- [ ] Workflow YAML syntax valid (checked via PyYAML)
- [ ] Next YAML-only PR after this lands → verify dev site auto-rebuilds