### PR TITLE
chore(ci): rename vault-ci.yml → staffml-validate-vault.yml

### DIFF
--- a/.github/workflows/staffml-validate-vault.yml
+++ b/.github/workflows/staffml-validate-vault.yml
@@ -1,12 +1,14 @@
-name: '🎯 StaffML · 🔎 Vault CI'
+name: '🎯 StaffML · ✅ Validate (Vault)'
 
 # =============================================================================
-# Vault CI — package validation + invariant checks + release-hash regression.
-# =============================================================================
+# Vault validation — data integrity + CLI package + worker contract.
 #
-# Reflects the full post-Bucket-B state:
+# Parallel to staffml-validate-dev.yml (which validates the site build);
+# this one validates the vault data layer + vault-cli + worker code.
+#
+# Checks performed:
 #   - ruff + mypy + pytest on vault-cli.
-#   - vault check --strict on the full corpus.
+#   - vault check --strict on the full corpus (9 structural invariants).
 #   - vault build + release_hash equivalence vs corpus-equivalence-hash.txt.
 #   - vault codegen --check (hash-based shared-types drift guard).
 #   - Registry append-only check vs base ref.
@@ -14,6 +16,8 @@ name: '🎯 StaffML · 🔎 Vault CI'
 #   - Worker vitest (staffml-vault-worker/tests) on worker-path PRs.
 #
 # Referenced from: interviews/vault/ARCHITECTURE.md §19.3, TESTING.md §4.1.
+# Renamed 2026-04-22 from vault-ci.yml for consistency with the
+# staffml-<verb>-<scope> workflow naming convention used across the repo.
 # =============================================================================
 
 on:
@@ -23,7 +27,7 @@ on:
       - 'interviews/vault-cli/**'
       - 'interviews/staffml-vault-worker/**'
       - 'interviews/staffml-vault-types/**'
-      - '.github/workflows/vault-ci.yml'
+      - '.github/workflows/staffml-validate-vault.yml'
   push:
     branches: [dev]
     paths:

--- a/interviews/vault-cli/scripts/check_registry_append_only.py
+++ b/interviews/vault-cli/scripts/check_registry_append_only.py
@@ -6,7 +6,7 @@ Rejects PRs that remove or reorder lines from ``interviews/vault/id-registry.yam
 between the PR base and HEAD; ensures every base-line is still present and
 in the same relative order.
 
-Invoked from ``.github/workflows/vault-ci.yml``.
+Invoked from ``.github/workflows/staffml-validate-vault.yml``.
 """
 
 from __future__ import annotations

--- a/interviews/vault/ARCHITECTURE.md
+++ b/interviews/vault/ARCHITECTURE.md
@@ -1175,7 +1175,7 @@ Each phase is a safe stopping point. If priorities shift, pause at a phase bound
 - Write `interviews/CONTRIBUTING.md` documenting clone → first-question-visible path. (Fixes H-17.)
 - Write `vault/schema/EVOLUTION.md` — SemVer rules, loader contract, migration mechanics. (Fixes H-1.)
 - Write `vault-cli/docs/JSON_OUTPUT.md` and `EXIT_CODES.md`.
-- CI scaffolding: `.github/workflows/vault-ci.yml` runs `vault check` placeholder (expanded in Phase 1).
+- CI scaffolding: `.github/workflows/staffml-validate-vault.yml` runs `vault check` placeholder (expanded in Phase 1).
 - **Exemplar-coverage audit** (v2.1 — Chip N-H3): `vault stats --exemplar-coverage` reports which `(track, level, zone)` cells have <3 human-reviewed questions eligible for the `vault/exemplars/` pool. Output to `vault/exemplar-gaps.yaml`. This is a READ-ONLY audit at Phase 0; filling gaps is backlog work that unblocks `vault generate` (Phase 7), not a Phase 0 blocker.
 - **Milestone**: `pip install -e vault-cli/ && vault --version` works. Skeleton CI green. Exemplar gap inventory produced.
 
@@ -1401,7 +1401,7 @@ Testing is NOT an afterthought. It's the gate between stages. This section is th
 
 ### 19.3 CI integration (v2)
 
-GitHub Actions workflow `.github/workflows/vault-ci.yml`:
+GitHub Actions workflow `.github/workflows/staffml-validate-vault.yml`:
 1. On every PR touching `interviews/vault/` or `interviews/vault-cli/`:
    - Run `pytest vault-cli/` (all unit + integration + contract tests).
    - Run `vault check --strict` on the full corpus (fast + structural tiers, <60s budget).

--- a/interviews/vault/TESTING.md
+++ b/interviews/vault/TESTING.md
@@ -226,10 +226,10 @@ Worker crons per ARCHITECTURE.md §10.5 table. Alert on any divergence.
 
 ## 4. CI workflow spec
 
-### 4.1 `.github/workflows/vault-ci.yml` (every PR touching `interviews/vault/` or `interviews/vault-cli/`)
+### 4.1 `.github/workflows/staffml-validate-vault.yml` (every PR touching `interviews/vault/` or `interviews/vault-cli/`)
 
 ```yaml
-name: vault-ci
+name: '🎯 StaffML · ✅ Validate (Vault)'
 on:
   pull_request:
     paths:


### PR DESCRIPTION
Brings the last outlier workflow file into the repo-wide `<cluster>-<verb>-<scope>.yml` convention. Direct sibling of `staffml-validate-dev.yml` — same verb, different scope.

- Filename: `vault-ci.yml` → `staffml-validate-vault.yml`
- Display name: `'🎯 StaffML · 🔎 Vault CI'` → `'🎯 StaffML · ✅ Validate (Vault)'`
- Updated refs in ARCHITECTURE.md, TESTING.md, check_registry_append_only.py
- Branch protection unaffected (GitHub matches on workflow name field, not filename)

Surveyed rest of workflow catalog; no other naming improvements needed. Full list in commit message.