### PR TITLE
fix(staffml): allow Cloudflare Web Analytics beacon in CSP

### DIFF
--- a/interviews/staffml/src/app/layout.tsx
+++ b/interviews/staffml/src/app/layout.tsx
@@ -73,9 +73,9 @@ export default function RootLayout({
         */}
         <meta
           httpEquiv="Content-Security-Policy"
-          content={`default-src 'self'; script-src 'self' 'unsafe-inline'${
+          content={`default-src 'self'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com${
             process.env.NODE_ENV === "development" ? " 'unsafe-eval'" : ""
-          }; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net; connect-src 'self' https://api.github.com https://mlsysbook.ai https://harvard-edge.github.io https://staffml-vault.mlsysbook-ai-account.workers.dev https://staffml-vault.mlsysbook.ai; img-src 'self' data: https://mlsysbook.ai https://harvard-edge.github.io; base-uri 'self'; form-action 'self';`}
+          }; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net; connect-src 'self' https://api.github.com https://mlsysbook.ai https://harvard-edge.github.io https://staffml-vault.mlsysbook-ai-account.workers.dev https://staffml-vault.mlsysbook.ai https://cloudflareinsights.com; img-src 'self' data: https://mlsysbook.ai https://harvard-edge.github.io; base-uri 'self'; form-action 'self';`}
         />
         {/*
           Theme bootstrap — render-blocking external script (no async/defer)


### PR DESCRIPTION
Cloudflare auto-injects a pageview beacon on every HTML response; CSP blocked it. Adds `https://static.cloudflareinsights.com` to script-src and `https://cloudflareinsights.com` to connect-src. Clears the last console-error noise on every page load. Zero functional impact — harmless either way — just devtools hygiene.