### PR TITLE
feat(ci): E2E smoke + gate publish on validate-vault

### DIFF
--- a/.github/workflows/staffml-publish-live.yml
+++ b/.github/workflows/staffml-publish-live.yml
@@ -38,17 +38,28 @@ permissions:
 # only. The guard runs without holding the lock.
 
 jobs:
-  # Block publish unless the latest dev validate run for this site is green.
+  # Block publish unless BOTH validation workflows were last green on dev.
+  # `staffml-validate-dev` covers the Next.js app + E2E smoke;
+  # `staffml-validate-vault` covers corpus integrity + vault-cli + worker.
+  # A YAML bug that broke chain integrity would surface in validate-vault
+  # but not validate-dev, so publishing without gating on both could ship
+  # a broken vault even when the site builds fine.
   # See .github/workflows/infra-publish-guard.yml for guard semantics.
-  guard:
+  guard-dev:
     name: '🛡️ Validate-Dev Green Gate'
     uses: ./.github/workflows/infra-publish-guard.yml
     with:
       validate_workflow: staffml-validate-dev.yml
 
+  guard-vault:
+    name: '🛡️ Validate-Vault Green Gate'
+    uses: ./.github/workflows/infra-publish-guard.yml
+    with:
+      validate_workflow: staffml-validate-vault.yml
+
   build-and-deploy:
     name: '🔧 Build & Deploy StaffML'
-    needs: [guard]
+    needs: [guard-dev, guard-vault]
     runs-on: ubuntu-latest
     concurrency:
       group: gh-pages-deploy

--- a/.github/workflows/staffml-validate-dev.yml
+++ b/.github/workflows/staffml-validate-dev.yml
@@ -135,6 +135,64 @@ jobs:
           echo "✅ StaffML built: $(find interviews/staffml/out -name '*.html' | wc -l) pages"
 
   # ===========================================================================
+  # Stage 2.5: Headless-Chromium end-to-end smoke
+  # ===========================================================================
+  # Would have caught the hydration shape-mismatch bug from PR #1440
+  # before merge. Loads a handful of critical routes in a real browser
+  # and fails on uncaught page errors / console.error / missing content.
+  # See interviews/staffml/scripts/e2e-smoke.py for the allowlist +
+  # assertion catalog.
+  e2e-smoke:
+    name: '🎭 E2E Smoke (headless Chromium)'
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 10
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v6
+
+      - name: 🔧 Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: interviews/staffml/package-lock.json
+
+      - name: 📦 Install dependencies
+        working-directory: interviews/staffml
+        run: npm ci
+
+      - name: 🐍 Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: 🛠️ Install vault-cli
+        run: pip install -e interviews/vault-cli/
+
+      - name: 🔄 Regenerate corpus from YAMLs
+        # Ensures the E2E build sees current YAML state (same as preview/
+        # publish workflows do).
+        run: vault build --vault-dir interviews/vault --release-id e2e-smoke --legacy-json
+
+      - name: 🔨 Build StaffML for E2E (no base-path)
+        working-directory: interviews/staffml
+        # Builds at the root path so we can serve out/ locally without
+        # mirroring the /cs249r_book_dev/staffml/ prefix. Base-path
+        # fidelity is already validated by the main `build` job above.
+        env:
+          NEXT_PUBLIC_VAULT_API: https://staffml-vault.mlsysbook-ai-account.workers.dev
+        run: npm run build
+
+      - name: 🎭 Install Playwright + Chromium
+        run: |
+          pip install playwright
+          playwright install --with-deps chromium
+
+      - name: 🧪 Run E2E smoke
+        run: python3 interviews/staffml/scripts/e2e-smoke.py
+
+  # ===========================================================================
   # Stage 3: Vault integrity + corpus smoke tests
   # ===========================================================================
   smoke:
@@ -216,7 +274,7 @@ jobs:
   summary:
     name: '📊 Summary'
     runs-on: ubuntu-latest
-    needs: [typecheck-and-test, build, smoke, check-links]
+    needs: [typecheck-and-test, build, e2e-smoke, smoke, check-links]
     if: always()
 
     steps:
@@ -228,6 +286,7 @@ jobs:
           echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
           echo "| 🔍 Typecheck + Tests | ${{ needs.typecheck-and-test.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| 🔨 Build | ${{ needs.build.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| 🎭 E2E Smoke | ${{ needs.e2e-smoke.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| 🧪 Vault Smoke Tests | ${{ needs.smoke.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| 🔗 Link Check | ${{ needs.check-links.result }} (non-blocking) |" >> $GITHUB_STEP_SUMMARY
 
@@ -235,6 +294,7 @@ jobs:
         run: |
           if [ "${{ needs.typecheck-and-test.result }}" = "failure" ] || \
              [ "${{ needs.build.result }}" = "failure" ] || \
+             [ "${{ needs.e2e-smoke.result }}" = "failure" ] || \
              [ "${{ needs.smoke.result }}" = "failure" ]; then
             echo "❌ Validation failed"
             exit 1

--- a/interviews/staffml/scripts/e2e-smoke.py
+++ b/interviews/staffml/scripts/e2e-smoke.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Headless-Chromium smoke test for the built Next.js export.
+
+Runs in CI after `npm run build`. Starts a static file server from
+`interviews/staffml/out/`, loads a handful of critical routes in
+Playwright, and fails the job if any of these invariants break:
+
+  1. HTTP 200 on every page
+  2. No uncaught page errors (React error boundaries / TypeErrors /
+     null derefs — the class that bit us in PR #1440)
+  3. No console.error except a small allowlist of known benign noise
+     (Next.js RSC .txt prefetches on static export; Cloudflare beacon
+     404s that don't fire under localhost anyway)
+  4. Practice page renders the scenario for a known question within
+     a reasonable timeout (covers the hydration code path)
+
+This is intentionally a CHEAP gate: one browser, <60 seconds, no
+visual regression tests. The goal is to catch "white screen of death"
+class bugs before they merge, not to comprehensively cover UX.
+"""
+
+from __future__ import annotations
+
+import http.server
+import socketserver
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+OUT_DIR = Path("interviews/staffml/out")
+# Must match an origin on the vault-worker CORS allowlist (wrangler.toml
+# CORS_ALLOWLIST includes http://localhost:3000). If you change this,
+# update the worker allowlist too or the hydration fetches will fail with
+# CORS errors in the smoke — which is exactly what the smoke is designed
+# to catch, so it's a load-bearing constraint.
+PORT = 3000
+
+# Every route listed here gets loaded. Keep this list small — each adds
+# ~2 seconds. If a new feature deserves E2E coverage, add the route here
+# and optionally a visible-text assertion in `ASSERT_CONTAINS`.
+ROUTES = [
+    "/",
+    "/practice.html",
+    "/plans.html",
+    "/gauntlet.html",
+    "/about.html",
+    "/progress.html",
+]
+
+# After load, assert these substrings appear somewhere in document.body.
+# Catches "page loads but content missing" — exactly the failure mode
+# of the hydration shape-mismatch bug.
+ASSERT_CONTAINS: dict[str, list[str]] = {
+    "/practice.html": ["Practice"],      # title at minimum
+    "/about.html":    ["StaffML"],
+}
+
+# Console errors whose text matches any of these substrings are ignored.
+# Add new entries only with a code comment explaining WHY (avoid growing
+# the allowlist into a "silence everything" sink).
+CONSOLE_IGNORE = [
+    # Next.js static-export tries to prefetch RSC .txt payloads on
+    # cross-site <Link> hover; 404s against static hosts. Known quirk.
+    "_rsc=",
+    ".txt 404",
+    # Cloudflare Web Analytics beacon — fires on prod Cloudflare zones
+    # but not on localhost, so this shouldn't appear in CI but keeping
+    # the filter defensively.
+    "cloudflareinsights",
+    # Chromium logs "Failed to load resource" as a console.error for
+    # every 4xx. We already trip on the network layer; don't double-fail.
+    "Failed to load resource",
+]
+
+
+class SilentHandler(http.server.SimpleHTTPRequestHandler):
+    def log_message(self, *args, **kwargs) -> None:  # noqa: D401
+        pass
+
+
+class _ReusableServer(socketserver.TCPServer):
+    # Allow quick re-bind to the same port across runs; CI reuses the same
+    # ephemeral VM for the step so this matters less, but it's harmless
+    # and saves "Address already in use" errors when iterating locally.
+    allow_reuse_address = True
+
+
+def start_server() -> _ReusableServer:
+    """Start a static file server in a daemon thread."""
+    import os
+    os.chdir(OUT_DIR)
+    httpd = _ReusableServer(("", PORT), SilentHandler)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    # Wait a beat for the socket to listen.
+    time.sleep(0.5)
+    return httpd
+
+
+def main() -> int:
+    if not OUT_DIR.exists():
+        print(f"❌ {OUT_DIR} missing — run `npm run build` first.", file=sys.stderr)
+        return 2
+
+    # Lazy-import Playwright so a missing install fails with a clearer error.
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        print("❌ playwright not installed. Run: pip install playwright && playwright install chromium", file=sys.stderr)
+        return 3
+
+    start_server()
+    base = f"http://localhost:{PORT}"
+    print(f"📡 Serving {OUT_DIR} at {base}")
+
+    failures: list[str] = []
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        ctx = browser.new_context()
+        page = ctx.new_page()
+
+        console_errs: list[str] = []
+        page_errs: list[str] = []
+        page.on("console", lambda m: m.type == "error" and console_errs.append(m.text))
+        page.on("pageerror", lambda exc: page_errs.append(str(exc)))
+
+        for route in ROUTES:
+            url = base + route
+            print(f"\n→ {url}")
+            console_errs.clear()
+            page_errs.clear()
+            try:
+                resp = page.goto(url, wait_until="networkidle", timeout=20_000)
+            except Exception as exc:
+                failures.append(f"{route}: goto failed — {exc}")
+                continue
+
+            if resp is None or resp.status >= 400:
+                failures.append(f"{route}: HTTP {resp.status if resp else 'None'}")
+                continue
+
+            page.wait_for_timeout(2000)   # let hydration + worker fetches settle
+
+            for marker in ASSERT_CONTAINS.get(route, []):
+                body = page.inner_text("body")
+                if marker not in body:
+                    failures.append(f"{route}: expected text {marker!r} not found in DOM")
+
+            if page_errs:
+                failures.extend(f"{route}: pageerror — {e[:200]}" for e in page_errs)
+
+            real_console = [
+                e for e in console_errs
+                if not any(ignored in e for ignored in CONSOLE_IGNORE)
+            ]
+            if real_console:
+                failures.extend(f"{route}: console.error — {e[:200]}" for e in real_console)
+
+            status = "✅" if not (page_errs or real_console) else "❌"
+            print(f"  {status}  HTTP {resp.status}  "
+                  f"pageerror={len(page_errs)}  console.error={len(real_console)}")
+
+        browser.close()
+
+    print()
+    if failures:
+        print(f"❌ E2E smoke FAILED — {len(failures)} issue(s):")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+
+    print("✅ E2E smoke passed across all routes.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Two pre-release polish items.

**1. Playwright E2E smoke in `staffml-validate-dev`** — new job loads 6 routes in headless Chromium and asserts zero uncaught errors + zero console.errors (with allowlist for Next.js static-export quirks). Would have caught the hydration shape-mismatch bug (PR #1440) before merge.

**2. `validate-vault` gates publish-live** — second guard job mirrors the existing validate-dev gate. A YAML-only PR that broke chain integrity used to slip through; now doesn't.

Local dry-run of `e2e-smoke.py`: all 6 routes pass, zero errors.