### PR TITLE
fix(vault-cli): resolve ruff errors blocking validate-vault

### DIFF
--- a/interviews/vault-cli/src/vault_cli/commands/authoring.py
+++ b/interviews/vault-cli/src/vault_cli/commands/authoring.py
@@ -45,7 +45,7 @@ def _id_hash(title: str, topic: str) -> str:
     Including the topic defends against two unrelated questions with
     identical titles hashing identically.
     """
-    payload = f"{title}\n{topic}".encode("utf-8")
+    payload = f"{title}\n{topic}".encode()
     return hashlib.sha256(payload).hexdigest()[:4]
 
 
@@ -235,6 +235,7 @@ def register(app: typer.Typer) -> None:
             },
         })
 
+        candidate = cell_dir / f"{qid}.yaml"
         candidate.write_text(dump_str(payload), encoding="utf-8")
         _append_registry({"id": qid, "created_at": now, "created_by": author or "unknown"})
         console.print(f"created [cyan]{candidate}[/cyan] (id={qid})")

--- a/interviews/vault-cli/src/vault_cli/commands/chain.py
+++ b/interviews/vault-cli/src/vault_cli/commands/chain.py
@@ -19,7 +19,6 @@ from rich.table import Table
 
 from vault_cli.loader import load_all
 
-
 chain_app = typer.Typer(help="Browse and inspect question chains.")
 
 
@@ -91,15 +90,15 @@ def chain_show(
     topics = sorted({m[1].question.topic for m in members})
     tracks = sorted({m[1].question.track for m in members})
     levels = [m[1].question.level for m in members]
-    levels_sorted = sorted(levels, key=lambda L: ("L1","L2","L3","L4","L5","L6+").index(L))
+    levels_sorted = sorted(levels, key=lambda lvl: ("L1","L2","L3","L4","L5","L6+").index(lvl))
     monotonic = levels == levels_sorted
 
     console.print(f"[bold cyan]{chain_id}[/bold cyan]   "
                   f"{len(members)} members   track(s)={','.join(tracks)}   topic(s)={','.join(topics)}")
     if len(topics) > 1:
-        console.print(f"  [yellow]warning[/yellow]: chain spans multiple topics — likely mis-linked")
+        console.print("  [yellow]warning[/yellow]: chain spans multiple topics — likely mis-linked")
     if not monotonic:
-        console.print(f"  [yellow]warning[/yellow]: levels not monotonically non-decreasing across positions")
+        console.print("  [yellow]warning[/yellow]: levels not monotonically non-decreasing across positions")
 
     table = Table(show_header=True, header_style="bold")
     table.add_column("#", justify="right", no_wrap=True)

--- a/interviews/vault-cli/src/vault_cli/commands/ls.py
+++ b/interviews/vault-cli/src/vault_cli/commands/ls.py
@@ -53,13 +53,19 @@ def register(app: typer.Typer) -> None:
         rows = []
         for lq in loaded:
             q = lq.question
-            if track and q.track != track: continue
-            if level and q.level != level: continue
-            if zone and q.zone != zone: continue
-            if topic and q.topic != topic: continue
-            if status and q.status != status: continue
+            if track and q.track != track:
+                continue
+            if level and q.level != level:
+                continue
+            if zone and q.zone != zone:
+                continue
+            if topic and q.topic != topic:
+                continue
+            if status and q.status != status:
+                continue
             n_chains = len(q.chains or [])
-            if in_chains and n_chains == 0: continue
+            if in_chains and n_chains == 0:
+                continue
             rows.append((q.id, q.track, q.level, q.zone, q.topic, n_chains, q.title))
 
         rows.sort(key=lambda r: (r[1], r[2], r[0]))   # track, level, id

--- a/interviews/vault-cli/src/vault_cli/commands/show.py
+++ b/interviews/vault-cli/src/vault_cli/commands/show.py
@@ -109,11 +109,11 @@ def register(app: typer.Typer) -> None:
                 if prev_q:
                     console.print(f"    prev: [dim]{prev_q.id}[/dim]  ({prev_q.question.level}, {prev_q.question.zone})  {prev_q.question.title}")
                 else:
-                    console.print(f"    prev: [dim](start of chain)[/dim]")
+                    console.print("    prev: [dim](start of chain)[/dim]")
                 if next_q:
                     console.print(f"    next: [dim]{next_q.id}[/dim]  ({next_q.question.level}, {next_q.question.zone})  {next_q.question.title}")
                 else:
-                    console.print(f"    next: [dim](end of chain)[/dim]")
+                    console.print("    next: [dim](end of chain)[/dim]")
 
         console.print(f"\n[dim]file: {lq.path.relative_to(vault_dir)}[/dim]")
 

--- a/interviews/vault-cli/src/vault_cli/main.py
+++ b/interviews/vault-cli/src/vault_cli/main.py
@@ -18,6 +18,9 @@ from vault_cli.commands import (
     build as build_cmd_mod,
 )
 from vault_cli.commands import (
+    chain as chain_cmd_mod,
+)
+from vault_cli.commands import (
     check as check_cmd_mod,
 )
 from vault_cli.commands import (
@@ -42,16 +45,13 @@ from vault_cli.commands import (
     ls as ls_cmd_mod,
 )
 from vault_cli.commands import (
-    show as show_cmd_mod,
-)
-from vault_cli.commands import (
-    chain as chain_cmd_mod,
-)
-from vault_cli.commands import (
     promote as promote_cmd_mod,
 )
 from vault_cli.commands import (
     release as release_cmd_mod,
+)
+from vault_cli.commands import (
+    show as show_cmd_mod,
 )
 from vault_cli.commands import (
     stats as stats_cmd_mod,


### PR DESCRIPTION
## Summary

- Restore `candidate` variable in `authoring.py` — real F821 NameError from v2 ID-scheme refactor (would have crashed `vault new` at runtime)
- Fix 11 stylistic ruff violations (N803, E701×6, F541×2, UP012, I001) introduced in PR #1428

## Why

`staffml-validate-vault` is now a publish-guard on `staffml-publish-live` (added today). Without these fixes the publish workflow cannot ship — `guard-vault` blocks on validate-vault being green on dev.

## Test plan

- [x] `ruff check interviews/vault-cli/src/` — passes
- [x] CLI imports cleanly (`from vault_cli.commands import authoring, chain, ls, show`)
- [ ] validate-vault green on dev after merge
- [ ] publish-live can re-trigger successfully