### PR TITLE
chore(vault): refresh exemplar-gaps.yaml after today's corpus shifts

### DIFF
--- a/interviews/vault/exemplar-gaps.yaml
+++ b/interviews/vault/exemplar-gaps.yaml
@@ -1,97 +1,85 @@
 phase: 0
 note: "Phase-0 audit: no provenance field exists yet. eligible_exemplars=0 for every cell until Phase-1 backfill. 'total_questions' is the authoring pool from which exemplars will be selected."
 exemplar_minimum_per_cell: 3
-total_cells: 190
-cells_with_gap: 190
+total_cells: 167
+cells_with_gap: 167
 cells:
   - {track: cloud, level: l1, zone: recall, total_questions: 139, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l2, zone: analyze, total_questions: 4, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l2, zone: design, total_questions: 3, eligible_exemplars: 0, gap: 3}
+  - {track: cloud, level: l2, zone: analyze, total_questions: 2, eligible_exemplars: 0, gap: 3}
   - {track: cloud, level: l2, zone: diagnosis, total_questions: 1, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l2, zone: evaluation, total_questions: 1, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l2, zone: fluency, total_questions: 8, eligible_exemplars: 0, gap: 3}
+  - {track: cloud, level: l2, zone: fluency, total_questions: 13, eligible_exemplars: 0, gap: 3}
   - {track: cloud, level: l2, zone: implement, total_questions: 80, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l2, zone: recall, total_questions: 215, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l2, zone: specification, total_questions: 4, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l3, zone: analyze, total_questions: 46, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l3, zone: design, total_questions: 2, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l3, zone: diagnosis, total_questions: 121, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l3, zone: evaluation, total_questions: 39, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l3, zone: fluency, total_questions: 602, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l3, zone: implement, total_questions: 79, eligible_exemplars: 0, gap: 3}
+  - {track: cloud, level: l2, zone: recall, total_questions: 217, eligible_exemplars: 0, gap: 3}
+  - {track: cloud, level: l3, zone: analyze, total_questions: 47, eligible_exemplars: 0, gap: 3}
+  - {track: cloud, level: l3, zone: diagnosis, total_questions: 123, eligible_exemplars: 0, gap: 3}
+  - {track: cloud, level: l3, zone: evaluation, total_questions: 22, eligible_exemplars: 0, gap: 3}
+  - {track: cloud, level: l3, zone: fluency, total_questions: 643, eligible_exemplars: 0, gap: 3}
+  - {track: cloud, level: l3, zone: implement, total_questions: 80, eligible_exemplars: 0, gap: 3}
   - {track: cloud, level: l3, zone: optimization, total_questions: 10, eligible_exemplars: 0, gap: 3}
   - {track: cloud, level: l3, zone: realization, total_questions: 11, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l3, zone: recall, total_questions: 47, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l3, zone: specification, total_questions: 10, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l4, zone: analyze, total_questions: 125, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l4, zone: design, total_questions: 62, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l4, zone: diagnosis, total_questions: 454, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l4, zone: evaluation, total_questions: 252, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l4, zone: fluency, total_questions: 22, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l4, zone: implement, total_questions: 37, eligible_exemplars: 0, gap: 3}
+  - {track: cloud, level: l3, zone: recall, total_questions: 33, eligible_exemplars: 0, gap: 3}
+  - {track: cloud, level: l3, zone: specification, total_questions: 2, eligible_exemplars: 0, gap: 3}
+  - {track: cloud, level: l4, zone: analyze, total_questions: 156, eligible_exemplars: 0, gap: 3}
+  - {track: cloud, level: l4, zone: design, total_questions: 69, eligible_exemplars: 0, gap: 3}
+  - {track: cloud, level: l4, zone: diagnosis, total_questions: 573, eligible_exemplars: 0, gap: 3}
+  - {track: cloud, level: l4, zone: evaluation, total_questions: 64, eligible_exemplars: 0, gap: 3}
+  - {track: cloud, level: l4, zone: fluency, total_questions: 29, eligible_exemplars: 0, gap: 3}
+  - {track: cloud, level: l4, zone: implement, total_questions: 38, eligible_exemplars: 0, gap: 3}
   - {track: cloud, level: l4, zone: mastery, total_questions: 2, eligible_exemplars: 0, gap: 3}
   - {track: cloud, level: l4, zone: optimization, total_questions: 151, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l4, zone: realization, total_questions: 33, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l4, zone: recall, total_questions: 8, eligible_exemplars: 0, gap: 3}
+  - {track: cloud, level: l4, zone: realization, total_questions: 17, eligible_exemplars: 0, gap: 3}
+  - {track: cloud, level: l4, zone: recall, total_questions: 4, eligible_exemplars: 0, gap: 3}
   - {track: cloud, level: l4, zone: specification, total_questions: 22, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l5, zone: analyze, total_questions: 20, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l5, zone: design, total_questions: 160, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l5, zone: diagnosis, total_questions: 133, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l5, zone: evaluation, total_questions: 379, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l5, zone: fluency, total_questions: 4, eligible_exemplars: 0, gap: 3}
+  - {track: cloud, level: l5, zone: analyze, total_questions: 8, eligible_exemplars: 0, gap: 3}
+  - {track: cloud, level: l5, zone: design, total_questions: 183, eligible_exemplars: 0, gap: 3}
+  - {track: cloud, level: l5, zone: diagnosis, total_questions: 96, eligible_exemplars: 0, gap: 3}
+  - {track: cloud, level: l5, zone: evaluation, total_questions: 452, eligible_exemplars: 0, gap: 3}
+  - {track: cloud, level: l5, zone: fluency, total_questions: 3, eligible_exemplars: 0, gap: 3}
   - {track: cloud, level: l5, zone: implement, total_questions: 17, eligible_exemplars: 0, gap: 3}
   - {track: cloud, level: l5, zone: mastery, total_questions: 29, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l5, zone: optimization, total_questions: 124, eligible_exemplars: 0, gap: 3}
+  - {track: cloud, level: l5, zone: optimization, total_questions: 127, eligible_exemplars: 0, gap: 3}
   - {track: cloud, level: l5, zone: realization, total_questions: 47, eligible_exemplars: 0, gap: 3}
   - {track: cloud, level: l5, zone: specification, total_questions: 326, eligible_exemplars: 0, gap: 3}
   - {track: cloud, level: l6+, zone: analyze, total_questions: 3, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l6+, zone: design, total_questions: 120, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l6+, zone: diagnosis, total_questions: 24, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l6+, zone: evaluation, total_questions: 41, eligible_exemplars: 0, gap: 3}
+  - {track: cloud, level: l6+, zone: design, total_questions: 7, eligible_exemplars: 0, gap: 3}
+  - {track: cloud, level: l6+, zone: diagnosis, total_questions: 20, eligible_exemplars: 0, gap: 3}
+  - {track: cloud, level: l6+, zone: evaluation, total_questions: 50, eligible_exemplars: 0, gap: 3}
   - {track: cloud, level: l6+, zone: implement, total_questions: 1, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l6+, zone: mastery, total_questions: 156, eligible_exemplars: 0, gap: 3}
+  - {track: cloud, level: l6+, zone: mastery, total_questions: 260, eligible_exemplars: 0, gap: 3}
   - {track: cloud, level: l6+, zone: optimization, total_questions: 1, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l6+, zone: realization, total_questions: 49, eligible_exemplars: 0, gap: 3}
-  - {track: cloud, level: l6+, zone: specification, total_questions: 4, eligible_exemplars: 0, gap: 3}
+  - {track: cloud, level: l6+, zone: realization, total_questions: 50, eligible_exemplars: 0, gap: 3}
   - {track: edge, level: l1, zone: recall, total_questions: 160, eligible_exemplars: 0, gap: 3}
-  - {track: edge, level: l2, zone: design, total_questions: 1, eligible_exemplars: 0, gap: 3}
   - {track: edge, level: l2, zone: fluency, total_questions: 4, eligible_exemplars: 0, gap: 3}
   - {track: edge, level: l2, zone: implement, total_questions: 51, eligible_exemplars: 0, gap: 3}
-  - {track: edge, level: l2, zone: recall, total_questions: 127, eligible_exemplars: 0, gap: 3}
+  - {track: edge, level: l2, zone: recall, total_questions: 128, eligible_exemplars: 0, gap: 3}
   - {track: edge, level: l3, zone: analyze, total_questions: 110, eligible_exemplars: 0, gap: 3}
-  - {track: edge, level: l3, zone: design, total_questions: 2, eligible_exemplars: 0, gap: 3}
-  - {track: edge, level: l3, zone: diagnosis, total_questions: 44, eligible_exemplars: 0, gap: 3}
-  - {track: edge, level: l3, zone: evaluation, total_questions: 16, eligible_exemplars: 0, gap: 3}
-  - {track: edge, level: l3, zone: fluency, total_questions: 207, eligible_exemplars: 0, gap: 3}
+  - {track: edge, level: l3, zone: diagnosis, total_questions: 48, eligible_exemplars: 0, gap: 3}
+  - {track: edge, level: l3, zone: evaluation, total_questions: 11, eligible_exemplars: 0, gap: 3}
+  - {track: edge, level: l3, zone: fluency, total_questions: 213, eligible_exemplars: 0, gap: 3}
   - {track: edge, level: l3, zone: implement, total_questions: 118, eligible_exemplars: 0, gap: 3}
   - {track: edge, level: l3, zone: optimization, total_questions: 15, eligible_exemplars: 0, gap: 3}
   - {track: edge, level: l3, zone: realization, total_questions: 15, eligible_exemplars: 0, gap: 3}
-  - {track: edge, level: l3, zone: recall, total_questions: 1, eligible_exemplars: 0, gap: 3}
-  - {track: edge, level: l3, zone: specification, total_questions: 4, eligible_exemplars: 0, gap: 3}
-  - {track: edge, level: l4, zone: analyze, total_questions: 45, eligible_exemplars: 0, gap: 3}
-  - {track: edge, level: l4, zone: design, total_questions: 28, eligible_exemplars: 0, gap: 3}
-  - {track: edge, level: l4, zone: diagnosis, total_questions: 146, eligible_exemplars: 0, gap: 3}
-  - {track: edge, level: l4, zone: evaluation, total_questions: 103, eligible_exemplars: 0, gap: 3}
+  - {track: edge, level: l3, zone: specification, total_questions: 2, eligible_exemplars: 0, gap: 3}
+  - {track: edge, level: l4, zone: analyze, total_questions: 51, eligible_exemplars: 0, gap: 3}
+  - {track: edge, level: l4, zone: design, total_questions: 31, eligible_exemplars: 0, gap: 3}
+  - {track: edge, level: l4, zone: diagnosis, total_questions: 176, eligible_exemplars: 0, gap: 3}
+  - {track: edge, level: l4, zone: evaluation, total_questions: 77, eligible_exemplars: 0, gap: 3}
   - {track: edge, level: l4, zone: implement, total_questions: 12, eligible_exemplars: 0, gap: 3}
   - {track: edge, level: l4, zone: mastery, total_questions: 1, eligible_exemplars: 0, gap: 3}
-  - {track: edge, level: l4, zone: optimization, total_questions: 114, eligible_exemplars: 0, gap: 3}
-  - {track: edge, level: l4, zone: realization, total_questions: 26, eligible_exemplars: 0, gap: 3}
+  - {track: edge, level: l4, zone: optimization, total_questions: 116, eligible_exemplars: 0, gap: 3}
+  - {track: edge, level: l4, zone: realization, total_questions: 9, eligible_exemplars: 0, gap: 3}
   - {track: edge, level: l4, zone: specification, total_questions: 46, eligible_exemplars: 0, gap: 3}
-  - {track: edge, level: l5, zone: analyze, total_questions: 1, eligible_exemplars: 0, gap: 3}
-  - {track: edge, level: l5, zone: design, total_questions: 115, eligible_exemplars: 0, gap: 3}
-  - {track: edge, level: l5, zone: diagnosis, total_questions: 29, eligible_exemplars: 0, gap: 3}
-  - {track: edge, level: l5, zone: evaluation, total_questions: 129, eligible_exemplars: 0, gap: 3}
+  - {track: edge, level: l5, zone: design, total_questions: 123, eligible_exemplars: 0, gap: 3}
+  - {track: edge, level: l5, zone: diagnosis, total_questions: 15, eligible_exemplars: 0, gap: 3}
+  - {track: edge, level: l5, zone: evaluation, total_questions: 134, eligible_exemplars: 0, gap: 3}
   - {track: edge, level: l5, zone: mastery, total_questions: 10, eligible_exemplars: 0, gap: 3}
-  - {track: edge, level: l5, zone: optimization, total_questions: 37, eligible_exemplars: 0, gap: 3}
+  - {track: edge, level: l5, zone: optimization, total_questions: 38, eligible_exemplars: 0, gap: 3}
   - {track: edge, level: l5, zone: realization, total_questions: 56, eligible_exemplars: 0, gap: 3}
   - {track: edge, level: l5, zone: specification, total_questions: 87, eligible_exemplars: 0, gap: 3}
-  - {track: edge, level: l6+, zone: design, total_questions: 67, eligible_exemplars: 0, gap: 3}
   - {track: edge, level: l6+, zone: diagnosis, total_questions: 15, eligible_exemplars: 0, gap: 3}
   - {track: edge, level: l6+, zone: evaluation, total_questions: 9, eligible_exemplars: 0, gap: 3}
-  - {track: edge, level: l6+, zone: mastery, total_questions: 99, eligible_exemplars: 0, gap: 3}
-  - {track: edge, level: l6+, zone: optimization, total_questions: 1, eligible_exemplars: 0, gap: 3}
+  - {track: edge, level: l6+, zone: mastery, total_questions: 173, eligible_exemplars: 0, gap: 3}
   - {track: edge, level: l6+, zone: realization, total_questions: 35, eligible_exemplars: 0, gap: 3}
-  - {track: edge, level: l6+, zone: specification, total_questions: 3, eligible_exemplars: 0, gap: 3}
   - {track: global, level: l1, zone: recall, total_questions: 36, eligible_exemplars: 0, gap: 3}
   - {track: global, level: l2, zone: diagnosis, total_questions: 1, eligible_exemplars: 0, gap: 3}
   - {track: global, level: l2, zone: implement, total_questions: 4, eligible_exemplars: 0, gap: 3}
@@ -101,96 +89,85 @@ cells:
   - {track: global, level: l4, zone: design, total_questions: 4, eligible_exemplars: 0, gap: 3}
   - {track: global, level: l4, zone: diagnosis, total_questions: 64, eligible_exemplars: 0, gap: 3}
   - {track: global, level: l4, zone: evaluation, total_questions: 15, eligible_exemplars: 0, gap: 3}
-  - {track: global, level: l4, zone: optimization, total_questions: 13, eligible_exemplars: 0, gap: 3}
-  - {track: global, level: l4, zone: realization, total_questions: 1, eligible_exemplars: 0, gap: 3}
+  - {track: global, level: l4, zone: optimization, total_questions: 14, eligible_exemplars: 0, gap: 3}
   - {track: global, level: l4, zone: specification, total_questions: 3, eligible_exemplars: 0, gap: 3}
   - {track: global, level: l5, zone: design, total_questions: 3, eligible_exemplars: 0, gap: 3}
   - {track: global, level: l5, zone: diagnosis, total_questions: 2, eligible_exemplars: 0, gap: 3}
   - {track: global, level: l5, zone: evaluation, total_questions: 28, eligible_exemplars: 0, gap: 3}
   - {track: global, level: l5, zone: optimization, total_questions: 1, eligible_exemplars: 0, gap: 3}
   - {track: global, level: l5, zone: specification, total_questions: 3, eligible_exemplars: 0, gap: 3}
-  - {track: global, level: l6+, zone: design, total_questions: 25, eligible_exemplars: 0, gap: 3}
-  - {track: global, level: l6+, zone: diagnosis, total_questions: 8, eligible_exemplars: 0, gap: 3}
+  - {track: global, level: l6+, zone: diagnosis, total_questions: 7, eligible_exemplars: 0, gap: 3}
   - {track: global, level: l6+, zone: evaluation, total_questions: 14, eligible_exemplars: 0, gap: 3}
-  - {track: global, level: l6+, zone: mastery, total_questions: 3, eligible_exemplars: 0, gap: 3}
-  - {track: global, level: l6+, zone: specification, total_questions: 2, eligible_exemplars: 0, gap: 3}
+  - {track: global, level: l6+, zone: mastery, total_questions: 31, eligible_exemplars: 0, gap: 3}
   - {track: mobile, level: l1, zone: recall, total_questions: 132, eligible_exemplars: 0, gap: 3}
-  - {track: mobile, level: l2, zone: design, total_questions: 2, eligible_exemplars: 0, gap: 3}
-  - {track: mobile, level: l2, zone: fluency, total_questions: 4, eligible_exemplars: 0, gap: 3}
+  - {track: mobile, level: l2, zone: fluency, total_questions: 6, eligible_exemplars: 0, gap: 3}
   - {track: mobile, level: l2, zone: implement, total_questions: 56, eligible_exemplars: 0, gap: 3}
-  - {track: mobile, level: l2, zone: optimization, total_questions: 1, eligible_exemplars: 0, gap: 3}
   - {track: mobile, level: l2, zone: realization, total_questions: 1, eligible_exemplars: 0, gap: 3}
   - {track: mobile, level: l2, zone: recall, total_questions: 133, eligible_exemplars: 0, gap: 3}
   - {track: mobile, level: l3, zone: analyze, total_questions: 92, eligible_exemplars: 0, gap: 3}
-  - {track: mobile, level: l3, zone: design, total_questions: 3, eligible_exemplars: 0, gap: 3}
-  - {track: mobile, level: l3, zone: diagnosis, total_questions: 63, eligible_exemplars: 0, gap: 3}
-  - {track: mobile, level: l3, zone: evaluation, total_questions: 18, eligible_exemplars: 0, gap: 3}
-  - {track: mobile, level: l3, zone: fluency, total_questions: 149, eligible_exemplars: 0, gap: 3}
+  - {track: mobile, level: l3, zone: design, total_questions: 1, eligible_exemplars: 0, gap: 3}
+  - {track: mobile, level: l3, zone: diagnosis, total_questions: 65, eligible_exemplars: 0, gap: 3}
+  - {track: mobile, level: l3, zone: evaluation, total_questions: 13, eligible_exemplars: 0, gap: 3}
+  - {track: mobile, level: l3, zone: fluency, total_questions: 154, eligible_exemplars: 0, gap: 3}
   - {track: mobile, level: l3, zone: implement, total_questions: 71, eligible_exemplars: 0, gap: 3}
-  - {track: mobile, level: l3, zone: optimization, total_questions: 17, eligible_exemplars: 0, gap: 3}
-  - {track: mobile, level: l3, zone: realization, total_questions: 17, eligible_exemplars: 0, gap: 3}
+  - {track: mobile, level: l3, zone: optimization, total_questions: 18, eligible_exemplars: 0, gap: 3}
+  - {track: mobile, level: l3, zone: realization, total_questions: 10, eligible_exemplars: 0, gap: 3}
   - {track: mobile, level: l3, zone: recall, total_questions: 2, eligible_exemplars: 0, gap: 3}
-  - {track: mobile, level: l4, zone: analyze, total_questions: 26, eligible_exemplars: 0, gap: 3}
-  - {track: mobile, level: l4, zone: design, total_questions: 21, eligible_exemplars: 0, gap: 3}
-  - {track: mobile, level: l4, zone: diagnosis, total_questions: 178, eligible_exemplars: 0, gap: 3}
-  - {track: mobile, level: l4, zone: evaluation, total_questions: 66, eligible_exemplars: 0, gap: 3}
+  - {track: mobile, level: l4, zone: analyze, total_questions: 36, eligible_exemplars: 0, gap: 3}
+  - {track: mobile, level: l4, zone: design, total_questions: 30, eligible_exemplars: 0, gap: 3}
+  - {track: mobile, level: l4, zone: diagnosis, total_questions: 206, eligible_exemplars: 0, gap: 3}
+  - {track: mobile, level: l4, zone: evaluation, total_questions: 43, eligible_exemplars: 0, gap: 3}
   - {track: mobile, level: l4, zone: implement, total_questions: 15, eligible_exemplars: 0, gap: 3}
   - {track: mobile, level: l4, zone: optimization, total_questions: 99, eligible_exemplars: 0, gap: 3}
-  - {track: mobile, level: l4, zone: realization, total_questions: 16, eligible_exemplars: 0, gap: 3}
+  - {track: mobile, level: l4, zone: realization, total_questions: 7, eligible_exemplars: 0, gap: 3}
   - {track: mobile, level: l4, zone: specification, total_questions: 45, eligible_exemplars: 0, gap: 3}
   - {track: mobile, level: l5, zone: analyze, total_questions: 2, eligible_exemplars: 0, gap: 3}
   - {track: mobile, level: l5, zone: design, total_questions: 112, eligible_exemplars: 0, gap: 3}
-  - {track: mobile, level: l5, zone: diagnosis, total_questions: 20, eligible_exemplars: 0, gap: 3}
-  - {track: mobile, level: l5, zone: evaluation, total_questions: 86, eligible_exemplars: 0, gap: 3}
-  - {track: mobile, level: l5, zone: fluency, total_questions: 1, eligible_exemplars: 0, gap: 3}
+  - {track: mobile, level: l5, zone: diagnosis, total_questions: 12, eligible_exemplars: 0, gap: 3}
+  - {track: mobile, level: l5, zone: evaluation, total_questions: 88, eligible_exemplars: 0, gap: 3}
+  - {track: mobile, level: l5, zone: fluency, total_questions: 2, eligible_exemplars: 0, gap: 3}
   - {track: mobile, level: l5, zone: mastery, total_questions: 8, eligible_exemplars: 0, gap: 3}
   - {track: mobile, level: l5, zone: optimization, total_questions: 21, eligible_exemplars: 0, gap: 3}
   - {track: mobile, level: l5, zone: realization, total_questions: 45, eligible_exemplars: 0, gap: 3}
   - {track: mobile, level: l5, zone: specification, total_questions: 61, eligible_exemplars: 0, gap: 3}
-  - {track: mobile, level: l6+, zone: design, total_questions: 45, eligible_exemplars: 0, gap: 3}
-  - {track: mobile, level: l6+, zone: diagnosis, total_questions: 1, eligible_exemplars: 0, gap: 3}
+  - {track: mobile, level: l6+, zone: design, total_questions: 14, eligible_exemplars: 0, gap: 3}
   - {track: mobile, level: l6+, zone: evaluation, total_questions: 2, eligible_exemplars: 0, gap: 3}
-  - {track: mobile, level: l6+, zone: implement, total_questions: 1, eligible_exemplars: 0, gap: 3}
-  - {track: mobile, level: l6+, zone: mastery, total_questions: 90, eligible_exemplars: 0, gap: 3}
-  - {track: mobile, level: l6+, zone: realization, total_questions: 18, eligible_exemplars: 0, gap: 3}
-  - {track: mobile, level: l6+, zone: specification, total_questions: 2, eligible_exemplars: 0, gap: 3}
+  - {track: mobile, level: l6+, zone: mastery, total_questions: 121, eligible_exemplars: 0, gap: 3}
+  - {track: mobile, level: l6+, zone: realization, total_questions: 19, eligible_exemplars: 0, gap: 3}
   - {track: tinyml, level: l1, zone: fluency, total_questions: 3, eligible_exemplars: 0, gap: 3}
   - {track: tinyml, level: l1, zone: recall, total_questions: 100, eligible_exemplars: 0, gap: 3}
-  - {track: tinyml, level: l1, zone: specification, total_questions: 1, eligible_exemplars: 0, gap: 3}
-  - {track: tinyml, level: l2, zone: analyze, total_questions: 1, eligible_exemplars: 0, gap: 3}
-  - {track: tinyml, level: l2, zone: evaluation, total_questions: 4, eligible_exemplars: 0, gap: 3}
-  - {track: tinyml, level: l2, zone: fluency, total_questions: 6, eligible_exemplars: 0, gap: 3}
+  - {track: tinyml, level: l2, zone: fluency, total_questions: 13, eligible_exemplars: 0, gap: 3}
   - {track: tinyml, level: l2, zone: implement, total_questions: 65, eligible_exemplars: 0, gap: 3}
   - {track: tinyml, level: l2, zone: realization, total_questions: 4, eligible_exemplars: 0, gap: 3}
-  - {track: tinyml, level: l2, zone: recall, total_questions: 76, eligible_exemplars: 0, gap: 3}
-  - {track: tinyml, level: l2, zone: specification, total_questions: 7, eligible_exemplars: 0, gap: 3}
+  - {track: tinyml, level: l2, zone: recall, total_questions: 77, eligible_exemplars: 0, gap: 3}
   - {track: tinyml, level: l3, zone: analyze, total_questions: 60, eligible_exemplars: 0, gap: 3}
-  - {track: tinyml, level: l3, zone: design, total_questions: 8, eligible_exemplars: 0, gap: 3}
+  - {track: tinyml, level: l3, zone: design, total_questions: 5, eligible_exemplars: 0, gap: 3}
   - {track: tinyml, level: l3, zone: diagnosis, total_questions: 45, eligible_exemplars: 0, gap: 3}
-  - {track: tinyml, level: l3, zone: evaluation, total_questions: 9, eligible_exemplars: 0, gap: 3}
-  - {track: tinyml, level: l3, zone: fluency, total_questions: 105, eligible_exemplars: 0, gap: 3}
-  - {track: tinyml, level: l3, zone: implement, total_questions: 40, eligible_exemplars: 0, gap: 3}
-  - {track: tinyml, level: l3, zone: optimization, total_questions: 14, eligible_exemplars: 0, gap: 3}
-  - {track: tinyml, level: l3, zone: realization, total_questions: 17, eligible_exemplars: 0, gap: 3}
-  - {track: tinyml, level: l3, zone: recall, total_questions: 41, eligible_exemplars: 0, gap: 3}
+  - {track: tinyml, level: l3, zone: evaluation, total_questions: 6, eligible_exemplars: 0, gap: 3}
+  - {track: tinyml, level: l3, zone: fluency, total_questions: 128, eligible_exemplars: 0, gap: 3}
+  - {track: tinyml, level: l3, zone: implement, total_questions: 42, eligible_exemplars: 0, gap: 3}
+  - {track: tinyml, level: l3, zone: optimization, total_questions: 15, eligible_exemplars: 0, gap: 3}
+  - {track: tinyml, level: l3, zone: realization, total_questions: 9, eligible_exemplars: 0, gap: 3}
+  - {track: tinyml, level: l3, zone: recall, total_questions: 29, eligible_exemplars: 0, gap: 3}
   - {track: tinyml, level: l3, zone: specification, total_questions: 1, eligible_exemplars: 0, gap: 3}
-  - {track: tinyml, level: l4, zone: analyze, total_questions: 24, eligible_exemplars: 0, gap: 3}
-  - {track: tinyml, level: l4, zone: design, total_questions: 4, eligible_exemplars: 0, gap: 3}
-  - {track: tinyml, level: l4, zone: diagnosis, total_questions: 141, eligible_exemplars: 0, gap: 3}
-  - {track: tinyml, level: l4, zone: evaluation, total_questions: 27, eligible_exemplars: 0, gap: 3}
+  - {track: tinyml, level: l4, zone: analyze, total_questions: 26, eligible_exemplars: 0, gap: 3}
+  - {track: tinyml, level: l4, zone: design, total_questions: 9, eligible_exemplars: 0, gap: 3}
+  - {track: tinyml, level: l4, zone: diagnosis, total_questions: 162, eligible_exemplars: 0, gap: 3}
+  - {track: tinyml, level: l4, zone: evaluation, total_questions: 15, eligible_exemplars: 0, gap: 3}
+  - {track: tinyml, level: l4, zone: fluency, total_questions: 4, eligible_exemplars: 0, gap: 3}
   - {track: tinyml, level: l4, zone: implement, total_questions: 3, eligible_exemplars: 0, gap: 3}
   - {track: tinyml, level: l4, zone: mastery, total_questions: 3, eligible_exemplars: 0, gap: 3}
-  - {track: tinyml, level: l4, zone: optimization, total_questions: 58, eligible_exemplars: 0, gap: 3}
-  - {track: tinyml, level: l4, zone: realization, total_questions: 9, eligible_exemplars: 0, gap: 3}
-  - {track: tinyml, level: l4, zone: specification, total_questions: 29, eligible_exemplars: 0, gap: 3}
-  - {track: tinyml, level: l5, zone: design, total_questions: 66, eligible_exemplars: 0, gap: 3}
-  - {track: tinyml, level: l5, zone: diagnosis, total_questions: 21, eligible_exemplars: 0, gap: 3}
-  - {track: tinyml, level: l5, zone: evaluation, total_questions: 90, eligible_exemplars: 0, gap: 3}
+  - {track: tinyml, level: l4, zone: optimization, total_questions: 59, eligible_exemplars: 0, gap: 3}
+  - {track: tinyml, level: l4, zone: realization, total_questions: 4, eligible_exemplars: 0, gap: 3}
+  - {track: tinyml, level: l4, zone: specification, total_questions: 30, eligible_exemplars: 0, gap: 3}
+  - {track: tinyml, level: l5, zone: analyze, total_questions: 1, eligible_exemplars: 0, gap: 3}
+  - {track: tinyml, level: l5, zone: design, total_questions: 67, eligible_exemplars: 0, gap: 3}
+  - {track: tinyml, level: l5, zone: diagnosis, total_questions: 9, eligible_exemplars: 0, gap: 3}
+  - {track: tinyml, level: l5, zone: evaluation, total_questions: 95, eligible_exemplars: 0, gap: 3}
   - {track: tinyml, level: l5, zone: mastery, total_questions: 5, eligible_exemplars: 0, gap: 3}
   - {track: tinyml, level: l5, zone: optimization, total_questions: 17, eligible_exemplars: 0, gap: 3}
   - {track: tinyml, level: l5, zone: realization, total_questions: 28, eligible_exemplars: 0, gap: 3}
-  - {track: tinyml, level: l5, zone: specification, total_questions: 35, eligible_exemplars: 0, gap: 3}
-  - {track: tinyml, level: l6+, zone: design, total_questions: 38, eligible_exemplars: 0, gap: 3}
-  - {track: tinyml, level: l6+, zone: mastery, total_questions: 65, eligible_exemplars: 0, gap: 3}
-  - {track: tinyml, level: l6+, zone: optimization, total_questions: 1, eligible_exemplars: 0, gap: 3}
+  - {track: tinyml, level: l5, zone: specification, total_questions: 36, eligible_exemplars: 0, gap: 3}
+  - {track: tinyml, level: l6+, zone: design, total_questions: 24, eligible_exemplars: 0, gap: 3}
+  - {track: tinyml, level: l6+, zone: mastery, total_questions: 72, eligible_exemplars: 0, gap: 3}
   - {track: tinyml, level: l6+, zone: realization, total_questions: 21, eligible_exemplars: 0, gap: 3}


### PR DESCRIPTION
Mechanical refresh of the audit snapshot. Today's session added questions and rebalanced chain membership, shifting per-cell counts. Unblocks validate-vault → guard-vault → publish-live.