### PR TITLE
fix(staffml): wire ChainBadge click to a pre-reveal sibling strip

### DIFF
--- a/interviews/staffml/src/app/practice/page.tsx
+++ b/interviews/staffml/src/app/practice/page.tsx
@@ -121,6 +121,26 @@ function PracticePage() {
   // Chain tracking — update when current question changes
   const chainInfo = current ? getChainForQuestion(current.id) : null;
 
+  // Pre-reveal chain sibling preview. Off by default; toggled open by
+  // ChainBadge so the badge's "view chain siblings" affordance does
+  // something visible without forcing answer reveal. Reset per question
+  // so a new question starts clean.
+  const [chainPreviewOpen, setChainPreviewOpen] = useState(false);
+  useEffect(() => {
+    setChainPreviewOpen(false);
+  }, [current?.id]);
+
+  const handleChainNavigate = useCallback((qId: string) => {
+    const q = getQuestionById(qId);
+    if (!q) return;
+    skipFilterCount.current = 3;
+    setCurrent(q);
+    setShowAnswer(false);
+    setUserAnswer("");
+    setNapkinResult(null);
+    setRubricItems([]);
+  }, []);
+
   const tracks = getTracks().filter(t => t !== "global");
   const levels = getLevels();
   const areas = getCompetencyAreas();
@@ -782,6 +802,7 @@ function PracticePage() {
                           chainId={chainInfo.chainId}
                           position={chainInfo.position + 1}  /* 1-indexed for display */
                           total={chainInfo.total}
+                          onClick={() => setChainPreviewOpen((v) => !v)}
                         />
                       </div>
                     )}
@@ -797,6 +818,11 @@ function PracticePage() {
                         <ScenarioSkeleton />
                       )}
                     </div>
+                    {chainInfo && !showAnswer && chainPreviewOpen && (
+                      <div className="mt-6" data-testid="chain-preview-prereveal">
+                        <ChainStrip chain={chainInfo} onNavigate={handleChainNavigate} />
+                      </div>
+                    )}
 
                   </motion.div>
                 </AnimatePresence>
@@ -1035,20 +1061,7 @@ function PracticePage() {
 
                       {/* Chain navigation — go deeper */}
                       {chainInfo && (
-                        <ChainStrip
-                          chain={chainInfo}
-                          onNavigate={(qId) => {
-                            const q = getQuestionById(qId);
-                            if (q) {
-                              skipFilterCount.current = 3;
-                              setCurrent(q);
-                              setShowAnswer(false);
-                              setUserAnswer("");
-                              setNapkinResult(null);
-                              setRubricItems([]);
-                            }
-                          }}
-                        />
+                        <ChainStrip chain={chainInfo} onNavigate={handleChainNavigate} />
                       )}
                     </div>
                   </motion.div>


### PR DESCRIPTION
## The bug

`interviews/staffml/src/app/practice/page.tsx:781` rendered `<ChainBadge>` without an `onClick` prop. The component's own click handler still fired the `chain_badge_clicked` analytics event, but produced no user-visible action. Meanwhile its `aria-label` promised *"Click to view chain siblings"* — misleading assistive-tech users.

Verified with `/tmp/probe_chain_nav2.py` against prod:

```
TEST A (click ChainBadge pre-reveal):    title changed: False
TEST B (click "Next in chain" post-reveal): title changed: True
TEST C (progress dots post-reveal):      titles tooltipped correctly
```

Only TEST A is broken.

## Why this fix (Option C)

Two simpler fixes were on the table:

- **Option A** — `onClick={() => setShowAnswer(true)}`. One line, but reveals the answer in response to a *navigation* click. Surprise + spoiler, in exchange for fixing the dead click. Net negative for learning quality.
- **Option B** — build a sibling drawer. Right shape long-term; new component + state, not a same-day fix.

This PR ships **Option C**: surface the existing `ChainStrip` *pre-reveal* in the question panel, gated by a click on the badge. The strip's contents (progress dots + a "Next in chain" preview card) are pure navigation — they don't disclose the current question's answer. The component is already battle-tested in the post-reveal codepath.

## Changes

- New `chainPreviewOpen` toggle, reset on `current.id` change so a fresh question starts closed.
- `ChainBadge.onClick` flips that toggle.
- When open, the question panel renders `<ChainStrip>` below the scenario.
- Extracted `handleChainNavigate` so the new pre-reveal strip and the existing post-reveal strip share one navigation handler (drops 14 lines of duplicated state-reset boilerplate).

Analytics (`chain_badge_clicked`) is unchanged — `ChainBadge` fires it before our `onClick` runs.

## Verified

- `npm run build` from `interviews/staffml/` — succeeds (Next.js 15.5.15, all 15 routes generated).
- No new lints in `practice/page.tsx`.
- An updated probe will be run against prod after publish-live deploys this PR.

## Out of scope (logged for follow-up)

- `chains.name` is null in D1 → badge says "Part 1 of 2" instead of "Part 1 of 2 — OTA Firmware Updates". Fix lives in `compiler.py:_populate_chains`.
- 54 multi-chain questions only expose `chain_ids[0]` via `lib/corpus.ts:368`.
- No `/chains` browse page (gated on Phase-5 CTR).