### PR TITLE
staffml: chain CTR analytics + footer cleanup + ChainBadge polish

### DIFF
--- a/interviews/staffml/src/app/dashboard/page.tsx
+++ b/interviews/staffml/src/app/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import {
   BarChart3, Terminal, Activity, Users, Target, Crosshair,
   Flag, Lightbulb, Calendar, TrendingUp, Trash2, ThumbsUp, ThumbsDown, Gauge,
+  Link as LinkIcon,
 } from "lucide-react";
 import clsx from "clsx";
 import { computeSummary, getAnalyticsEvents, clearAnalytics, type AnalyticsSummary } from "@/lib/analytics";
@@ -72,6 +73,58 @@ export default function DashboardPage() {
           <StatCard label="Issues Reported" value={summary.questionsReported.toString()} icon={Flag} color="red" />
           <StatCard label="Improvements" value={summary.improvementsSuggested.toString()} icon={Lightbulb} color="amber" />
         </div>
+
+        {/* Phase-5 chain CTR. Hidden until at least one badge has been
+            shown (otherwise it would render 0/0 on first load). The 15%
+            target is from ARCHITECTURE.md §8 — clearing it is the gate
+            to building out additional chain UX (sidebar filter, /chains
+            browse, dashboard chain-completion tracking). */}
+        {summary.chainBadgesShown > 0 && (
+          <div className="mb-8">
+            <div className="p-4 rounded-xl border border-borderSubtle bg-surface/50">
+              <div className="flex items-center justify-between mb-3">
+                <div className="flex items-center gap-2">
+                  <LinkIcon className="w-3.5 h-3.5 text-textTertiary" />
+                  <span className="text-[10px] font-mono text-textTertiary uppercase">Chain Discoverability (CTR)</span>
+                </div>
+                <span
+                  className={clsx(
+                    "text-[10px] font-mono uppercase px-2 py-0.5 rounded",
+                    summary.chainBadgeCTR >= 0.15
+                      ? "bg-accentGreen/10 text-accentGreen"
+                      : "bg-textTertiary/10 text-textTertiary",
+                  )}
+                  title="Phase-5 promotion gate (ARCHITECTURE.md §8): 15%"
+                >
+                  Gate: 15%
+                </span>
+              </div>
+              <div className="flex items-baseline gap-3 mb-2">
+                <span className="text-2xl font-bold font-mono text-textPrimary">
+                  {(summary.chainBadgeCTR * 100).toFixed(1)}%
+                </span>
+                <span className="text-[11px] text-textTertiary">
+                  {summary.chainBadgesClicked} click{summary.chainBadgesClicked === 1 ? '' : 's'} / {summary.chainBadgesShown} unique chain{summary.chainBadgesShown === 1 ? '' : 's'} seen
+                </span>
+              </div>
+              <div className="h-2 bg-border rounded-full overflow-hidden relative">
+                <div
+                  className={clsx(
+                    "h-full rounded-full transition-all",
+                    summary.chainBadgeCTR >= 0.15 ? "bg-accentGreen" : "bg-accentBlue",
+                  )}
+                  style={{ width: `${Math.min(summary.chainBadgeCTR * 100, 100)}%` }}
+                />
+                {/* 15% gate marker */}
+                <div
+                  className="absolute top-0 h-full w-px bg-textPrimary/40"
+                  style={{ left: '15%' }}
+                  title="15% gate"
+                />
+              </div>
+            </div>
+          </div>
+        )}
 
         {/* Feedback summary */}
         {(summary.thumbsUp + summary.thumbsDown > 0 ||

--- a/interviews/staffml/src/app/layout.tsx
+++ b/interviews/staffml/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 import Nav from "@/components/Nav";
 import EcosystemBar from "@/components/EcosystemBar";
-import Footer from "@/components/Footer";
+import MaybeFooter from "@/components/MaybeFooter";
 import Providers from "@/components/Providers";
 import { QUESTION_COUNT_DISPLAY } from "@/lib/corpus";
 
@@ -92,7 +92,7 @@ export default function RootLayout({
           <EcosystemBar />
           <Nav />
           <main className="flex-1 flex flex-col">{children}</main>
-          <Footer />
+          <MaybeFooter />
         </Providers>
       </body>
     </html>

--- a/interviews/staffml/src/components/ChainBadge.tsx
+++ b/interviews/staffml/src/components/ChainBadge.tsx
@@ -9,10 +9,12 @@
  * 1.5× within-chain completion).
  *
  * This component displays "Part N of M — <chain name>" above the question
- * title, visible BEFORE reveal. Click navigates to the chain strip / siblings.
+ * title, visible BEFORE reveal. Click invokes the consumer-supplied
+ * onClick (today: opens an inline ChainStrip in the question panel).
  */
 
-import { Link } from "lucide-react";
+import { useEffect } from "react";
+import { Link as LinkIcon, ChevronRight } from "lucide-react";
 import clsx from "clsx";
 
 import { track } from "@/lib/analytics";
@@ -34,17 +36,14 @@ export default function ChainBadge({
   onClick,
   className,
 }: ChainBadgeProps) {
-  // Fire shown-event on mount (debounced per-session by analytics layer).
-  if (typeof window !== "undefined") {
-    queueMicrotask(() => {
-      track({
-        type: "chain_badge_shown",
-        chainId,
-        position,
-        total,
-      } as any);
-    });
-  }
+  // Fire shown-event ONCE per chain mount, not on every render. The
+  // analytics layer dedups per (chainId, sessionId) for CTR computation,
+  // but firing on every render still bloats localStorage and pending
+  // queue payloads. Deps include position/total so a true sibling
+  // navigation (new chain context) re-records.
+  useEffect(() => {
+    track({ type: "chain_badge_shown", chainId, position, total });
+  }, [chainId, position, total]);
 
   const label = `Part ${position} of ${total}${chainName ? ` — ${chainName}` : ""}`;
 
@@ -52,28 +51,29 @@ export default function ChainBadge({
     <button
       type="button"
       data-testid="chain-badge"
-      aria-label={`Chained question: ${label}. Click to view chain siblings.`}
+      aria-label={`Chained question: ${label}. Click to view related questions in this chain.`}
       onClick={() => {
-        track({
-          type: "chain_badge_clicked",
-          chainId,
-          position,
-          total,
-        } as any);
+        track({ type: "chain_badge_clicked", chainId, position, total });
         onClick?.();
       }}
       className={clsx(
-        "inline-flex items-center gap-1.5 rounded-full border border-border",
-        "bg-surfaceSubtle px-3 py-1",
-        "text-[11px] font-mono uppercase tracking-wide",
-        "text-textSecondary hover:text-textPrimary",
-        "hover:bg-surface transition-colors",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
+        "inline-flex items-center gap-1.5 rounded-full",
+        "border border-accentBlue/30 bg-accentBlue/5",
+        "px-3 py-1.5",
+        "text-xs font-mono uppercase tracking-wide",
+        "text-accentBlue",
+        "hover:bg-accentBlue/10 hover:border-accentBlue/50",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accentBlue/40",
+        "transition-colors group",
         className,
       )}
     >
-      <Link className="w-3 h-3" aria-hidden="true" />
+      <LinkIcon className="w-3 h-3" aria-hidden="true" />
       <span>{label}</span>
+      <ChevronRight
+        className="w-3 h-3 transition-transform group-hover:translate-x-0.5"
+        aria-hidden="true"
+      />
     </button>
   );
 }

--- a/interviews/staffml/src/components/MaybeFooter.tsx
+++ b/interviews/staffml/src/components/MaybeFooter.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+
+import Footer from "./Footer";
+
+/**
+ * Conditionally renders the global Footer.
+ *
+ * The footer is intentionally hidden on workspace tools (Practice,
+ * Gauntlet, Simulator, Roofline) where the page is a self-contained
+ * full-viewport surface with its own sticky bottom chrome. Showing the
+ * site footer below those pages reads as orphaned chrome and creates a
+ * visible empty band between the workspace and the footer attribution
+ * row (the footer's own `mt-12` margin shows through).
+ *
+ * Content-style routes (/about, /contribute, etc.) keep the footer.
+ *
+ * Add a route here if it becomes a workspace tool. Removing one is fine
+ * too — falling back to the footer is harmless.
+ */
+const ROUTES_WITHOUT_FOOTER = new Set<string>([
+  "/practice",
+  "/gauntlet",
+  "/simulator",
+  "/roofline",
+]);
+
+export default function MaybeFooter() {
+  const pathname = usePathname();
+  // Normalize: static exports served as flat HTML files give a pathname
+  // like "/practice.html" instead of "/practice", and some hosts add a
+  // trailing slash. Strip both before lookup. Default to rendering the
+  // footer if pathname is unavailable — a momentary footer flash on a
+  // tool page is far better than a missing footer on a content page.
+  const route = (pathname ?? "")
+    .replace(/\.html$/, "")
+    .replace(/\/+$/, "") || "/";
+  if (ROUTES_WITHOUT_FOOTER.has(route)) return null;
+  return <Footer />;
+}

--- a/interviews/staffml/src/lib/analytics.ts
+++ b/interviews/staffml/src/lib/analytics.ts
@@ -35,6 +35,10 @@ export type AnalyticsEvent =
   // Navigation
   | { type: 'page_view'; page: string }
   | { type: 'search_query'; query: string; topicResults: number; questionResults: number }
+  // Chain discoverability — Phase-5 single-intervention CTR gate
+  // (ARCHITECTURE.md §8: promote multi-intervention only if shown→clicked > 15%).
+  | { type: 'chain_badge_shown'; chainId: string; position: number; total: number }
+  | { type: 'chain_badge_clicked'; chainId: string; position: number; total: number }
   // Star gate
   | { type: 'star_gate_shown' }
   | { type: 'star_gate_verified' }
@@ -215,6 +219,12 @@ export interface AnalyticsSummary {
   thumbsUp: number;
   thumbsDown: number;
   difficultyDistribution: Record<'too_easy' | 'about_right' | 'too_hard', number>;
+  // Phase-5 chain CTR. shown counts dedup per (chainId, sessionId) so
+  // navigating across siblings within a single session doesn't inflate
+  // the denominator. clicked is a raw click count (intent signal).
+  chainBadgesShown: number;
+  chainBadgesClicked: number;
+  chainBadgeCTR: number; // 0..1, 0 if shown == 0
   scoresByZone: Record<string, { total: number; count: number; avg: number }>;
   scoresByTopic: Record<string, { total: number; count: number; avg: number }>;
   scoresByLevel: Record<string, { total: number; count: number; avg: number }>;
@@ -240,6 +250,12 @@ export function computeSummary(events?: StoredEvent[]): AnalyticsSummary {
   // Dedup feedback: only count latest per (questionId, sessionId)
   const latestThumbs = new Map<string, 'up' | 'down'>();
   const latestDifficulty = new Map<string, 'too_easy' | 'about_right' | 'too_hard'>();
+  // Dedup chain badge impressions per (chainId, sessionId). A user
+  // bouncing across siblings in one session shouldn't inflate the
+  // denominator of CTR. Clicks stay raw — repeated clicks DO matter
+  // because each is a fresh intent signal.
+  const chainShownKeys = new Set<string>();
+  let chainBadgesClicked = 0;
 
   const scoresByZone: Record<string, { total: number; count: number; avg: number }> = {};
   const scoresByTopic: Record<string, { total: number; count: number; avg: number }> = {};
@@ -291,8 +307,18 @@ export function computeSummary(events?: StoredEvent[]): AnalyticsSummary {
       case 'question_difficulty_feedback':
         latestDifficulty.set(`${event.questionId}:${sessionId}`, event.perceived);
         break;
+      case 'chain_badge_shown':
+        chainShownKeys.add(`${event.chainId}:${sessionId}`);
+        break;
+      case 'chain_badge_clicked':
+        chainBadgesClicked++;
+        break;
     }
   }
+  const chainBadgesShown = chainShownKeys.size;
+  const chainBadgeCTR = chainBadgesShown > 0
+    ? chainBadgesClicked / chainBadgesShown
+    : 0;
 
   // Aggregate deduplicated feedback (last-write-wins per question+session)
   Array.from(latestThumbs.values()).forEach(value => {
@@ -325,6 +351,9 @@ export function computeSummary(events?: StoredEvent[]): AnalyticsSummary {
     thumbsUp,
     thumbsDown,
     difficultyDistribution,
+    chainBadgesShown,
+    chainBadgesClicked,
+    chainBadgeCTR,
     scoresByZone,
     scoresByTopic,
     scoresByLevel,


### PR DESCRIPTION
Three connected follow-ups to PR #1450 (the dead-click ChainBadge fix).

## 1. Type the chain analytics events properly

`chain_badge_shown` and `chain_badge_clicked` were emitted from `ChainBadge` as \`track({...} as any)\` because they weren't in the \`AnalyticsEvent\` discriminated union. They flowed through to localStorage and the remote endpoint, but \`computeSummary()\` ignored them — so the Phase-5 promotion gate (ARCHITECTURE.md §8: 15% CTR over two weeks) was uncomputable from the in-app dashboard.

- Added both events to the typed union with \`{chainId, position, total}\` payload.
- \`computeSummary()\` now produces \`chainBadgesShown\`, \`chainBadgesClicked\`, \`chainBadgeCTR\`. Shown is deduped per \`(chainId, sessionId)\` so navigating across siblings doesn't inflate the denominator. Clicks stay raw.
- New **Chain Discoverability** card on the dashboard with the 15% gate marker, hidden until first impression so it doesn't render 0/0 on first load.

## 2. Stop over-counting `chain_badge_shown`

Reading the existing ChainBadge source revealed the shown event was firing on **every render**, not just on mount — the README claimed mount-debouncing but the code lived inside a top-level \`if (typeof window !== 'undefined')\` block. Each parent re-render therefore inflated the shown count and deflated CTR.

Moved into a \`useEffect\` keyed on \`[chainId, position, total]\` so a true sibling navigation (new position) re-records, but stable renders don't.

## 3. Make the badge prominent enough to actually be clicked

User feedback: the badge was hard to spot among the four bolder badges in the question header (Level + Area + Zone + Track), undermining the CTR signal even now that the click target is wired.

- Bumped to \`text-xs\`, \`accentBlue\` text + tinted \`accentBlue/30\` border on \`accentBlue/5\` background.
- Added a \`ChevronRight\` that translates on hover to read as a CTA.
- Updated the aria-label to match the actual click behavior ("view related questions in this chain").

## 4. Hide the global Footer on workspace tool pages

The site \`<Footer>\` rendered on every page including the full-viewport tools (\`/practice\`, \`/gauntlet\`, \`/simulator\`, \`/roofline\`), which already own their own sticky bottom chrome. The footer's \`mt-12\` margin showed as a ~48px empty band between the tool's sticky bar and the attribution row — orphaned chrome.

- New \`<MaybeFooter />\` client wrapper consults \`usePathname()\` and skips the four workspace routes.
- Pathname is normalized (strip \`.html\` and trailing slash) so the check works on both the dev server and the static export.
- Content pages (about, contribute, dashboard, progress, plans, framework, welcome, /) keep the footer.

## Verified locally

- \`npm run build\` from \`interviews/staffml/\` — passes.
- Headless probe against the local static export at \`http://127.0.0.1:18761\`:
  - \`/practice?q=tinyml-0000\`: footer absent ✓, badge accentBlue (rgb(37,99,235)) ✓, badge box widened to 145×30 (was 120×27) ✓
  - \`/about\`: footer present ✓
- After deploy, will re-run \`/tmp/probe_chain_nav3.py\` against prod.

## Commits

1. \`feat(staffml): type chain badge events and surface CTR on dashboard\`
2. \`fix(staffml): polish ChainBadge prominence and stop over-counting shown\`
3. \`fix(staffml): hide global Footer on workspace tool pages\`

Each is independently buildable in order (commit 2 depends on the typed union from commit 1; commit 3 is independent).