### PR TITLE
deps: bump TypeScript 5→6, @types/node 20→25, ipykernel 6→7

### DIFF
--- a/book/vscode-ext/package-lock.json
+++ b/book/vscode-ext/package-lock.json
@@ -8,22 +8,22 @@
       "name": "mlsysbook-workbench",
       "version": "0.1.0",
       "devDependencies": {
-        "@types/node": "^20.0.0",
+        "@types/node": "^25.6.0",
         "@types/vscode": "^1.116.0",
-        "typescript": "^5.3.0"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "vscode": "^1.85.0"
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.30.tgz",
-      "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/vscode": {
@@ -34,9 +34,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -48,9 +48,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
       "license": "MIT"
     }

--- a/book/vscode-ext/package.json
+++ b/book/vscode-ext/package.json
@@ -23,8 +23,8 @@
   },
   "devDependencies": {
     "@types/vscode": "^1.116.0",
-    "@types/node": "^20.0.0",
-    "typescript": "^5.3.0"
+    "@types/node": "^25.6.0",
+    "typescript": "^6.0.3"
   },
   "contributes": {
     "viewsContainers": {

--- a/book/vscode-ext/tsconfig.json
+++ b/book/vscode-ext/tsconfig.json
@@ -9,7 +9,8 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node", "vscode"]
   },
   "exclude": ["node_modules", ".vscode-test"]
 }

--- a/kits/vscode-ext/package-lock.json
+++ b/kits/vscode-ext/package-lock.json
@@ -10,7 +10,7 @@
       "devDependencies": {
         "@types/node": "^25.6.0",
         "@types/vscode": "^1.116.0",
-        "typescript": "^5.3.0"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "vscode": "^1.85.0"
@@ -34,9 +34,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/kits/vscode-ext/package.json
+++ b/kits/vscode-ext/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@types/vscode": "^1.116.0",
     "@types/node": "^25.6.0",
-    "typescript": "^5.3.0"
+    "typescript": "^6.0.3"
   },
   "contributes": {
     "viewsContainers": {

--- a/kits/vscode-ext/tsconfig.json
+++ b/kits/vscode-ext/tsconfig.json
@@ -10,7 +10,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["node", "vscode"]
   },
   "exclude": ["node_modules", "out"]
 }

--- a/labs/vscode-ext/package-lock.json
+++ b/labs/vscode-ext/package-lock.json
@@ -10,7 +10,7 @@
       "devDependencies": {
         "@types/node": "^25.6.0",
         "@types/vscode": "^1.116.0",
-        "typescript": "^5.3.0"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "vscode": "^1.85.0"
@@ -34,9 +34,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/labs/vscode-ext/package.json
+++ b/labs/vscode-ext/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@types/vscode": "^1.116.0",
     "@types/node": "^25.6.0",
-    "typescript": "^5.3.0"
+    "typescript": "^6.0.3"
   },
   "contributes": {
     "viewsContainers": {

--- a/labs/vscode-ext/tsconfig.json
+++ b/labs/vscode-ext/tsconfig.json
@@ -10,7 +10,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["node", "vscode"]
   },
   "exclude": ["node_modules", "out"]
 }

--- a/mlsysim/vscode-ext/package-lock.json
+++ b/mlsysim/vscode-ext/package-lock.json
@@ -8,22 +8,22 @@
       "name": "mlsysim-workbench",
       "version": "0.1.0",
       "devDependencies": {
-        "@types/node": "^20.0.0",
+        "@types/node": "^25.6.0",
         "@types/vscode": "^1.116.0",
-        "typescript": "^5.3.0"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "vscode": "^1.85.0"
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/vscode": {
@@ -34,9 +34,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -48,9 +48,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
       "license": "MIT"
     }

--- a/mlsysim/vscode-ext/package.json
+++ b/mlsysim/vscode-ext/package.json
@@ -20,8 +20,8 @@
   },
   "devDependencies": {
     "@types/vscode": "^1.116.0",
-    "@types/node": "^20.0.0",
-    "typescript": "^5.3.0"
+    "@types/node": "^25.6.0",
+    "typescript": "^6.0.3"
   },
   "contributes": {
     "viewsContainers": {

--- a/mlsysim/vscode-ext/tsconfig.json
+++ b/mlsysim/vscode-ext/tsconfig.json
@@ -10,7 +10,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["node", "vscode"]
   },
   "exclude": ["node_modules", "out"]
 }

--- a/tinytorch/binder/requirements.txt
+++ b/tinytorch/binder/requirements.txt
@@ -14,7 +14,7 @@ PyYAML>=6.0
 # Jupyter environment
 jupyter>=1.1.1
 jupyterlab>=4.2.0
-ipykernel>=6.29.0
+ipykernel>=7.2.0
 ipywidgets>=8.0.0
 
 # Visualization (for milestone examples and modules)

--- a/tinytorch/pyproject.toml
+++ b/tinytorch/pyproject.toml
@@ -41,7 +41,7 @@ dev = [
     "nbformat>=5.10.0",
     "jupyter>=1.1.1",
     "jupyterlab>=4.2.0",
-    "ipykernel>=6.29.0",
+    "ipykernel>=7.2.0",
     "nbdev>=2.3.0",
 ]
 visualization = [

--- a/tinytorch/quarto/assets/images/diagrams/00_big-picture-module-flow.svg
+++ b/tinytorch/quarto/assets/images/diagrams/00_big-picture-module-flow.svg
@@ -3,118 +3,118 @@
   <rect width="800" height="460" fill="#ffffff"/>
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6 Z" fill="#9ca3af"/>
+      <path d="M0,0 L8,3 L0,6 Z" fill="#555"/>
     </marker>
   </defs>
   <g transform="translate(0,-30)">
 
-    <rect x="20" y="50" width="240" height="320" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1" rx="2"/>
-    <text x="30" y="70" font-size="11" font-weight="700" fill="#1f2937">Foundation (01-08)</text>
+    <rect x="20" y="50" width="240" height="320" fill="#f7f7f7" stroke="#bbb" stroke-width="1.2" rx="4"/>
+    <text x="30" y="70" font-size="12" font-weight="700" fill="#333">Foundation (01-08)</text>
 
-    <rect x="60" y="86" width="160" height="30" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-    <text x="140" y="105" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">01 - Tensor</text>
+    <rect x="60" y="86" width="160" height="30" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+    <text x="140" y="105" text-anchor="middle" font-size="10" font-weight="700" fill="#333">01 - Tensor</text>
 
-    <rect x="60" y="126" width="160" height="30" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-    <text x="140" y="145" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">02 - Activations</text>
+    <rect x="60" y="126" width="160" height="30" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+    <text x="140" y="145" text-anchor="middle" font-size="10" font-weight="700" fill="#333">02 - Activations</text>
 
-    <rect x="60" y="166" width="160" height="30" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-    <text x="140" y="185" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">03 - Layers</text>
+    <rect x="60" y="166" width="160" height="30" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+    <text x="140" y="185" text-anchor="middle" font-size="10" font-weight="700" fill="#333">03 - Layers</text>
 
-    <rect x="60" y="206" width="160" height="30" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-    <text x="140" y="225" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">04 - Losses</text>
+    <rect x="60" y="206" width="160" height="30" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+    <text x="140" y="225" text-anchor="middle" font-size="10" font-weight="700" fill="#333">04 - Losses</text>
 
-    <rect x="60" y="246" width="160" height="30" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-    <text x="140" y="265" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">05 - DataLoader</text>
+    <rect x="60" y="246" width="160" height="30" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+    <text x="140" y="265" text-anchor="middle" font-size="10" font-weight="700" fill="#333">05 - DataLoader</text>
 
-    <rect x="60" y="286" width="160" height="30" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-    <text x="140" y="305" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">06 - Autograd</text>
+    <rect x="60" y="286" width="160" height="30" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+    <text x="140" y="305" text-anchor="middle" font-size="10" font-weight="700" fill="#333">06 - Autograd</text>
 
-    <rect x="60" y="326" width="160" height="30" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-    <text x="140" y="345" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">07 - Optimizers + 08 - Training</text>
+    <rect x="60" y="326" width="160" height="30" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+    <text x="140" y="345" text-anchor="middle" font-size="10" font-weight="700" fill="#333">07 - Optimizers + 08 - Training</text>
 
-    <path d="M140 116 V126" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-    <path d="M140 156 V166" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-    <path d="M140 196 V206" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-    <path d="M140 236 V246" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-    <path d="M140 276 V286" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-    <path d="M140 316 V326" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+    <path d="M140 116 V126" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+    <path d="M140 156 V166" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+    <path d="M140 196 V206" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+    <path d="M140 236 V246" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+    <path d="M140 276 V286" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+    <path d="M140 316 V326" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
 
-    <rect x="280" y="50" width="240" height="320" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1" rx="2"/>
-    <text x="290" y="70" font-size="11" font-weight="700" fill="#1f2937">Architecture (09-13)</text>
+    <rect x="280" y="50" width="240" height="320" fill="#f7f7f7" stroke="#bbb" stroke-width="1.2" rx="4"/>
+    <text x="290" y="70" font-size="12" font-weight="700" fill="#333">Architecture (09-13)</text>
 
-    <rect x="295" y="166" width="100" height="30" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-    <text x="345" y="185" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">09 - CNNs</text>
+    <rect x="295" y="166" width="100" height="30" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+    <text x="345" y="185" text-anchor="middle" font-size="10" font-weight="700" fill="#333">09 - CNNs</text>
 
-    <rect x="405" y="166" width="100" height="30" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-    <text x="455" y="185" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">10 - Tokenization</text>
+    <rect x="405" y="166" width="100" height="30" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+    <text x="455" y="185" text-anchor="middle" font-size="10" font-weight="700" fill="#333">10 - Tokenization</text>
 
-    <rect x="405" y="206" width="100" height="30" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-    <text x="455" y="225" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">11 - Embeddings</text>
+    <rect x="405" y="206" width="100" height="30" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+    <text x="455" y="225" text-anchor="middle" font-size="10" font-weight="700" fill="#333">11 - Embeddings</text>
 
-    <rect x="405" y="246" width="100" height="30" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-    <text x="455" y="265" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">12 - Attention</text>
+    <rect x="405" y="246" width="100" height="30" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+    <text x="455" y="265" text-anchor="middle" font-size="10" font-weight="700" fill="#333">12 - Attention</text>
 
-    <rect x="405" y="286" width="100" height="30" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-    <text x="455" y="305" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">13 - Transformers</text>
+    <rect x="405" y="286" width="100" height="30" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+    <text x="455" y="305" text-anchor="middle" font-size="10" font-weight="700" fill="#333">13 - Transformers</text>
 
-    <text x="400" y="103" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280" font-style="italic">vision branch</text>
-    <text x="400" y="115" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280" font-style="italic">vs language chain</text>
+    <text x="400" y="103" text-anchor="middle" font-size="9" font-weight="400" fill="#999" font-style="italic">vision branch</text>
+    <text x="400" y="115" text-anchor="middle" font-size="9" font-weight="400" fill="#999" font-style="italic">vs language chain</text>
 
-    <path d="M400 130 V145" stroke="#9ca3af" stroke-width="1" fill="none"/>
-    <path d="M345 145 H455" stroke="#9ca3af" stroke-width="1" fill="none"/>
-    <path d="M345 145 V166" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-    <path d="M455 145 V166" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-    <path d="M455 196 V206" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-    <path d="M455 236 V246" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-    <path d="M455 276 V286" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+    <path d="M400 130 V145" stroke="#555" stroke-width="1.2" fill="none"/>
+    <path d="M345 145 H455" stroke="#555" stroke-width="1.2" fill="none"/>
+    <path d="M345 145 V166" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+    <path d="M455 145 V166" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+    <path d="M455 196 V206" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+    <path d="M455 236 V246" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+    <path d="M455 276 V286" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
 
-    <rect x="540" y="50" width="240" height="320" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1" rx="2"/>
-    <text x="550" y="70" font-size="11" font-weight="700" fill="#1f2937">Optimization (14-19)</text>
+    <rect x="540" y="50" width="240" height="320" fill="#f7f7f7" stroke="#bbb" stroke-width="1.2" rx="4"/>
+    <text x="550" y="70" font-size="12" font-weight="700" fill="#333">Optimization (14-19)</text>
 
-    <rect x="580" y="86" width="160" height="30" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-    <text x="660" y="105" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">14 - Profiling</text>
+    <rect x="580" y="86" width="160" height="30" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+    <text x="660" y="105" text-anchor="middle" font-size="10" font-weight="700" fill="#333">14 - Profiling</text>
 
-    <rect x="560" y="170" width="42" height="30" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-    <text x="581" y="189" text-anchor="middle" font-size="9" font-weight="700" fill="#1f2937">15 - Quant</text>
+    <rect x="560" y="170" width="42" height="30" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+    <text x="581" y="189" text-anchor="middle" font-size="9" font-weight="700" fill="#333">15 - Quant</text>
 
-    <rect x="610" y="170" width="50" height="30" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-    <text x="635" y="189" text-anchor="middle" font-size="9" font-weight="700" fill="#1f2937">16 - Compress</text>
+    <rect x="610" y="170" width="50" height="30" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+    <text x="635" y="189" text-anchor="middle" font-size="9" font-weight="700" fill="#333">16 - Compress</text>
 
-    <rect x="668" y="170" width="50" height="30" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-    <text x="693" y="189" text-anchor="middle" font-size="9" font-weight="700" fill="#1f2937">17 - Accel</text>
+    <rect x="668" y="170" width="50" height="30" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+    <text x="693" y="189" text-anchor="middle" font-size="9" font-weight="700" fill="#333">17 - Accel</text>
 
-    <rect x="726" y="170" width="50" height="30" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-    <text x="751" y="189" text-anchor="middle" font-size="9" font-weight="700" fill="#1f2937">18 - Memo</text>
+    <rect x="726" y="170" width="50" height="30" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+    <text x="751" y="189" text-anchor="middle" font-size="9" font-weight="700" fill="#333">18 - Memo</text>
 
-    <rect x="580" y="290" width="160" height="30" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-    <text x="660" y="309" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">19 - Benchmarking</text>
+    <rect x="580" y="290" width="160" height="30" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+    <text x="660" y="309" text-anchor="middle" font-size="10" font-weight="700" fill="#333">19 - Benchmarking</text>
 
-    <path d="M660 116 V140" stroke="#9ca3af" stroke-width="1" fill="none"/>
-    <path d="M581 140 H751" stroke="#9ca3af" stroke-width="1" fill="none"/>
-    <path d="M581 140 V170" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-    <path d="M635 140 V170" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-    <path d="M693 140 V170" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-    <path d="M751 140 V170" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+    <path d="M660 116 V140" stroke="#555" stroke-width="1.2" fill="none"/>
+    <path d="M581 140 H751" stroke="#555" stroke-width="1.2" fill="none"/>
+    <path d="M581 140 V170" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+    <path d="M635 140 V170" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+    <path d="M693 140 V170" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+    <path d="M751 140 V170" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
 
-    <path d="M581 200 V250" stroke="#9ca3af" stroke-width="1" fill="none"/>
-    <path d="M635 200 V250" stroke="#9ca3af" stroke-width="1" fill="none"/>
-    <path d="M693 200 V250" stroke="#9ca3af" stroke-width="1" fill="none"/>
-    <path d="M751 200 V250" stroke="#9ca3af" stroke-width="1" fill="none"/>
-    <path d="M581 250 H751" stroke="#9ca3af" stroke-width="1" fill="none"/>
-    <path d="M660 250 V290" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+    <path d="M581 200 V250" stroke="#555" stroke-width="1.2" fill="none"/>
+    <path d="M635 200 V250" stroke="#555" stroke-width="1.2" fill="none"/>
+    <path d="M693 200 V250" stroke="#555" stroke-width="1.2" fill="none"/>
+    <path d="M751 200 V250" stroke="#555" stroke-width="1.2" fill="none"/>
+    <path d="M581 250 H751" stroke="#555" stroke-width="1.2" fill="none"/>
+    <path d="M660 250 V290" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
 
-    <path d="M260 261 H280" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-    <text x="270" y="256" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280" font-style="italic">apply</text>
+    <path d="M260 261 H280" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+    <text x="270" y="256" text-anchor="middle" font-size="9" font-weight="400" fill="#999" font-style="italic">apply</text>
 
-    <path d="M520 181 H540" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-    <path d="M520 301 H530 V181 H540" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-    <text x="530" y="170" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280" font-style="italic">optimize</text>
+    <path d="M520 181 H540" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+    <path d="M520 301 H530 V181 H540" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+    <text x="530" y="170" text-anchor="middle" font-size="9" font-weight="400" fill="#999" font-style="italic">optimize</text>
 
-    <rect x="320" y="400" width="160" height="36" fill="#fff1e8" stroke="#ff8246" stroke-width="1" rx="2"/>
-    <text x="400" y="418" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">20 - Capstone</text>
-    <text x="400" y="431" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">end-to-end submission</text>
+    <rect x="320" y="400" width="160" height="36" fill="#fdebd0" stroke="#c87b2a" stroke-width="1.2" rx="4"/>
+    <text x="400" y="418" text-anchor="middle" font-size="10" font-weight="700" fill="#333">20 - Capstone</text>
+    <text x="400" y="431" text-anchor="middle" font-size="9" font-weight="400" fill="#999">end-to-end submission</text>
 
-    <path d="M660 320 V418 H480" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-    <text x="566" y="412" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280" font-style="italic">submit</text>
+    <path d="M660 320 V418 H480" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+    <text x="566" y="412" text-anchor="middle" font-size="9" font-weight="400" fill="#999" font-style="italic">submit</text>
   </g>
 </svg>

--- a/tinytorch/quarto/assets/images/diagrams/00_journey-diag-1.svg
+++ b/tinytorch/quarto/assets/images/diagrams/00_journey-diag-1.svg
@@ -3,39 +3,39 @@
   <rect width="680" height="200" fill="#ffffff"/>
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6 Z" fill="#9ca3af"/>
+      <path d="M0,0 L8,3 L0,6 Z" fill="#555"/>
     </marker>
   </defs>
   <g transform="translate(0,-50)">
-    <rect x="40" y="60" width="600" height="160" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1" rx="2"/>
-    <text x="50" y="80" font-size="11" font-weight="700" fill="#1f2937">Your TinyTorch Journey</text>
+    <rect x="40" y="60" width="600" height="160" fill="#f7f7f7" stroke="#bbb" stroke-width="1.2" rx="4"/>
+    <text x="50" y="80" font-size="12" font-weight="700" fill="#333">Your TinyTorch Journey</text>
 
-    <rect x="60" y="100" width="100" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-    <text x="110.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Install</text>
-    <text x="110.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">install.sh</text>
+    <rect x="60" y="100" width="100" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+    <text x="110.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Install</text>
+    <text x="110.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">install.sh</text>
 
-    <rect x="175" y="100" width="100" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-    <text x="225.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Setup</text>
-    <text x="225.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">tito setup</text>
+    <rect x="175" y="100" width="100" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+    <text x="225.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Setup</text>
+    <text x="225.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">tito setup</text>
 
-    <rect x="290" y="100" width="100" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-    <text x="340.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Start</text>
-    <text x="340.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">begin module</text>
+    <rect x="290" y="100" width="100" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+    <text x="340.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Start</text>
+    <text x="340.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">begin module</text>
 
-    <rect x="405" y="100" width="100" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-    <text x="455.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Complete</text>
-    <text x="455.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">export code</text>
+    <rect x="405" y="100" width="100" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+    <text x="455.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Complete</text>
+    <text x="455.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">export code</text>
 
-    <rect x="520" y="100" width="100" height="60" fill="#fff1e8" stroke="#ff8246" stroke-width="1" rx="2"/>
-    <text x="570.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Milestone</text>
-    <text x="570.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">run YOUR code</text>
+    <rect x="520" y="100" width="100" height="60" fill="#fdebd0" stroke="#c87b2a" stroke-width="1.2" rx="4"/>
+    <text x="570.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Milestone</text>
+    <text x="570.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">run YOUR code</text>
 
-    <path d="M160 130 H175" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-    <path d="M275 130 H290" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-    <path d="M390 130 H405" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-    <path d="M505 130 H520" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+    <path d="M160 130 H175" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+    <path d="M275 130 H290" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+    <path d="M390 130 H405" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+    <path d="M505 130 H520" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
 
-    <path d="M570 160 V200 H340 V160" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-    <text x="455" y="195" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280" font-style="italic">next module</text>
+    <path d="M570 160 V200 H340 V160" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+    <text x="455" y="195" text-anchor="middle" font-size="9" font-weight="400" fill="#999" font-style="italic">next module</text>
   </g>
 </svg>

--- a/tinytorch/quarto/assets/images/diagrams/01_tensor-diag-1.svg
+++ b/tinytorch/quarto/assets/images/diagrams/01_tensor-diag-1.svg
@@ -3,29 +3,29 @@
   <rect width="680" height="280" fill="#ffffff"/>
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6 Z" fill="#9ca3af"/>
+      <path d="M0,0 L8,3 L0,6 Z" fill="#555"/>
     </marker>
   </defs>
   <g transform="translate(0,-50)">
-<rect x="40" y="60" width="600" height="240" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1" rx="2"/>
-  <text x="50" y="80" font-size="11" font-weight="700" fill="#1f2937">Your Tensor Class</text>
-  <rect x="70" y="100" width="120" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="130.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Properties</text>
-  <text x="130.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">shape, size, dtype</text>
-  <rect x="230" y="100" width="120" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="290.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Arithmetic</text>
-  <text x="290.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">+, -, *, /</text>
-  <rect x="390" y="100" width="120" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="450.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Matrix Ops</text>
-  <text x="450.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">matmul()</text>
-  <rect x="70" y="220" width="120" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="130.0" y="247.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Shape Ops</text>
-  <text x="130.0" y="262.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">reshape, transpose</text>
-  <rect x="230" y="220" width="120" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="290.0" y="247.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Reductions</text>
-  <text x="290.0" y="262.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">sum, mean, max</text>
-  <path d="M190 130 H230" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M350 130 H390" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M190 250 H230" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+<rect x="40" y="60" width="600" height="240" fill="#f7f7f7" stroke="#bbb" stroke-width="1.2" rx="4"/>
+  <text x="50" y="80" font-size="12" font-weight="700" fill="#333">Your Tensor Class</text>
+  <rect x="70" y="100" width="120" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="130.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Properties</text>
+  <text x="130.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">shape, size, dtype</text>
+  <rect x="230" y="100" width="120" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="290.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Arithmetic</text>
+  <text x="290.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">+, -, *, /</text>
+  <rect x="390" y="100" width="120" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="450.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Matrix Ops</text>
+  <text x="450.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">matmul()</text>
+  <rect x="70" y="220" width="120" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="130.0" y="247.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Shape Ops</text>
+  <text x="130.0" y="262.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">reshape, transpose</text>
+  <rect x="230" y="220" width="120" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="290.0" y="247.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Reductions</text>
+  <text x="290.0" y="262.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">sum, mean, max</text>
+  <path d="M190 130 H230" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M350 130 H390" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M190 250 H230" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
   </g>
 </svg>

--- a/tinytorch/quarto/assets/images/diagrams/01_tensor-diag-2.svg
+++ b/tinytorch/quarto/assets/images/diagrams/01_tensor-diag-2.svg
@@ -3,22 +3,22 @@
   <rect width="680" height="300" fill="#ffffff"/>
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6 Z" fill="#9ca3af"/>
+      <path d="M0,0 L8,3 L0,6 Z" fill="#555"/>
     </marker>
   </defs>
   <g transform="translate(0,-50)">
-<rect x="80" y="100" width="140" height="80" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="150.0" y="137.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Matrix (2,3)</text>
-  <text x="150.0" y="152.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">[[1,2,3], [4,5,6]]</text>
-  <rect x="80" y="240" width="140" height="80" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="150.0" y="277.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Vector (3,)</text>
-  <text x="150.0" y="292.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">[10,20,30]</text>
-  <rect x="420" y="170" width="180" height="80" fill="#fff1e8" stroke="#ff8246" stroke-width="1" rx="2"/>
-  <text x="510.0" y="207.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Result (2,3)</text>
-  <text x="510.0" y="222.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">[[11,22,33], [14,25,36]]</text>
-  <path d="M220 140 L420 200" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <text x="300" y="160" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">+</text>
-  <path d="M220 280 L420 220" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <text x="300" y="260" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280" font-style="italic">expands</text>
+<rect x="80" y="100" width="140" height="80" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="150.0" y="137.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Matrix (2,3)</text>
+  <text x="150.0" y="152.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">[[1,2,3], [4,5,6]]</text>
+  <rect x="80" y="240" width="140" height="80" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="150.0" y="277.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Vector (3,)</text>
+  <text x="150.0" y="292.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">[10,20,30]</text>
+  <rect x="420" y="170" width="180" height="80" fill="#fdebd0" stroke="#c87b2a" stroke-width="1.2" rx="4"/>
+  <text x="510.0" y="207.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Result (2,3)</text>
+  <text x="510.0" y="222.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">[[11,22,33], [14,25,36]]</text>
+  <path d="M220 140 L420 200" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <text x="300" y="160" text-anchor="middle" font-size="10" font-weight="700" fill="#333">+</text>
+  <path d="M220 280 L420 220" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <text x="300" y="260" text-anchor="middle" font-size="9" font-weight="400" fill="#999" font-style="italic">expands</text>
   </g>
 </svg>

--- a/tinytorch/quarto/assets/images/diagrams/01_tensor-diag-3.svg
+++ b/tinytorch/quarto/assets/images/diagrams/01_tensor-diag-3.svg
@@ -3,24 +3,24 @@
   <rect width="680" height="390" fill="#ffffff"/>
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6 Z" fill="#9ca3af"/>
+      <path d="M0,0 L8,3 L0,6 Z" fill="#555"/>
     </marker>
   </defs>
   <g transform="translate(0,-50)">
-<rect x="190" y="60" width="300" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="340.0" y="87.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Your Code</text>
-  <text x="340.0" y="102.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">Python: x = Tensor([[1,2],[3,4]])</text>
-  <rect x="190" y="150" width="300" height="60" fill="#fff1e8" stroke="#ff8246" stroke-width="1" rx="2"/>
-  <text x="340.0" y="177.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">TinyTorch Core</text>
-  <text x="340.0" y="192.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">Tensor class: metadata + operations</text>
-  <rect x="190" y="240" width="300" height="80" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="340.0" y="277.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Backend (NumPy + BLAS)</text>
-  <text x="340.0" y="292.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">Vectorized C/Fortran kernels</text>
-  <rect x="190" y="350" width="300" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="340.0" y="377.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Hardware</text>
-  <text x="340.0" y="392.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">CPU SIMD (AVX/SSE) instructions</text>
-  <path d="M340 120 V150" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M340 210 V240" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M340 320 V350" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+<rect x="190" y="60" width="300" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="340.0" y="87.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Your Code</text>
+  <text x="340.0" y="102.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">Python: x = Tensor([[1,2],[3,4]])</text>
+  <rect x="190" y="150" width="300" height="60" fill="#fdebd0" stroke="#c87b2a" stroke-width="1.2" rx="4"/>
+  <text x="340.0" y="177.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">TinyTorch Core</text>
+  <text x="340.0" y="192.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">Tensor class: metadata + operations</text>
+  <rect x="190" y="240" width="300" height="80" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="340.0" y="277.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Backend (NumPy + BLAS)</text>
+  <text x="340.0" y="292.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">Vectorized C/Fortran kernels</text>
+  <rect x="190" y="350" width="300" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="340.0" y="377.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Hardware</text>
+  <text x="340.0" y="392.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">CPU SIMD (AVX/SSE) instructions</text>
+  <path d="M340 120 V150" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M340 210 V240" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M340 320 V350" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
   </g>
 </svg>

--- a/tinytorch/quarto/assets/images/diagrams/02_activations-diag-1.svg
+++ b/tinytorch/quarto/assets/images/diagrams/02_activations-diag-1.svg
@@ -3,35 +3,35 @@
   <rect width="680" height="360" fill="#ffffff"/>
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6 Z" fill="#9ca3af"/>
+      <path d="M0,0 L8,3 L0,6 Z" fill="#555"/>
     </marker>
   </defs>
   <g transform="translate(0,-50)">
-<rect x="40" y="190" width="100" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="90.0" y="224.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Input Tensor</text>
-  <rect x="240" y="60" width="200" height="320" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1" rx="2"/>
-  <text x="250" y="80" font-size="11" font-weight="700" fill="#1f2937">Activation Functions</text>
-  <rect x="260" y="100" width="160" height="40" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="340.0" y="124.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">ReLU: max(0, x)</text>
-  <rect x="260" y="155" width="160" height="40" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="340.0" y="179.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Sigmoid: 1/(1+e^-x)</text>
-  <rect x="260" y="210" width="160" height="40" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="340.0" y="234.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Tanh: tanh(x)</text>
-  <rect x="260" y="265" width="160" height="40" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="340.0" y="289.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">GELU: x · Φ(x)</text>
-  <rect x="260" y="320" width="160" height="40" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="340.0" y="344.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Softmax: exp/sum(exp)</text>
-  <rect x="540" y="190" width="100" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="590.0" y="224.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Output Tensor</text>
-  <path d="M140 220 L260 120" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M140 220 L260 175" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M140 220 L260 230" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M140 220 L260 285" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M140 220 L260 340" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M440 120 L540 200" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M440 175 L540 210" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M440 230 L540 220" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M440 285 L540 230" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M440 340 L540 240" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+<rect x="40" y="190" width="100" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="90.0" y="224.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Input Tensor</text>
+  <rect x="240" y="60" width="200" height="320" fill="#f7f7f7" stroke="#bbb" stroke-width="1.2" rx="4"/>
+  <text x="250" y="80" font-size="12" font-weight="700" fill="#333">Activation Functions</text>
+  <rect x="260" y="100" width="160" height="40" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="340.0" y="124.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">ReLU: max(0, x)</text>
+  <rect x="260" y="155" width="160" height="40" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="340.0" y="179.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Sigmoid: 1/(1+e^-x)</text>
+  <rect x="260" y="210" width="160" height="40" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="340.0" y="234.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Tanh: tanh(x)</text>
+  <rect x="260" y="265" width="160" height="40" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="340.0" y="289.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">GELU: x · Φ(x)</text>
+  <rect x="260" y="320" width="160" height="40" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="340.0" y="344.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Softmax: exp/sum(exp)</text>
+  <rect x="540" y="190" width="100" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="590.0" y="224.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Output Tensor</text>
+  <path d="M140 220 L260 120" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M140 220 L260 175" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M140 220 L260 230" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M140 220 L260 285" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M140 220 L260 340" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M440 120 L540 200" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M440 175 L540 210" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M440 230 L540 220" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M440 285 L540 230" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M440 340 L540 240" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
   </g>
 </svg>

--- a/tinytorch/quarto/assets/images/diagrams/03_layers-diag-1.svg
+++ b/tinytorch/quarto/assets/images/diagrams/03_layers-diag-1.svg
@@ -3,29 +3,29 @@
   <rect width="680" height="270" fill="#ffffff"/>
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6 Z" fill="#9ca3af"/>
+      <path d="M0,0 L8,3 L0,6 Z" fill="#555"/>
     </marker>
   </defs>
-  <rect x="40" y="20" width="600" height="220" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1" rx="2"/>
-  <text x="50" y="40" font-size="11" font-weight="700" fill="#1f2937">Your Layer System</text>
+  <rect x="40" y="20" width="600" height="220" fill="#f7f7f7" stroke="#bbb" stroke-width="1.2" rx="4"/>
+  <text x="50" y="40" font-size="12" font-weight="700" fill="#333">Your Layer System</text>
 
-  <rect x="250" y="60" width="180" height="60" fill="#fff1e8" stroke="#ff8246" stroke-width="1" rx="2"/>
-  <text x="340" y="87" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Layer Base Class</text>
-  <text x="340" y="102" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">forward(), parameters()</text>
+  <rect x="250" y="60" width="180" height="60" fill="#fdebd0" stroke="#c87b2a" stroke-width="1.2" rx="4"/>
+  <text x="340" y="87" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Layer Base Class</text>
+  <text x="340" y="102" text-anchor="middle" font-size="9" font-weight="400" fill="#999">forward(), parameters()</text>
 
-  <rect x="80" y="170" width="160" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="160" y="197" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Linear Layer</text>
-  <text x="160" y="212" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">y = xW + b</text>
+  <rect x="80" y="170" width="160" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="160" y="197" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Linear Layer</text>
+  <text x="160" y="212" text-anchor="middle" font-size="9" font-weight="400" fill="#999">y = xW + b</text>
 
-  <rect x="260" y="170" width="160" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="340" y="197" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Sequential Container</text>
-  <text x="340" y="212" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">layer composition</text>
+  <rect x="260" y="170" width="160" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="340" y="197" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Sequential Container</text>
+  <text x="340" y="212" text-anchor="middle" font-size="9" font-weight="400" fill="#999">layer composition</text>
 
-  <rect x="440" y="170" width="160" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="520" y="197" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Dropout Layer</text>
-  <text x="520" y="212" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">regularization</text>
+  <rect x="440" y="170" width="160" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="520" y="197" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Dropout Layer</text>
+  <text x="520" y="212" text-anchor="middle" font-size="9" font-weight="400" fill="#999">regularization</text>
 
-  <path d="M280 120 L160 170" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M340 120 V170" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M400 120 L520 170" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+  <path d="M280 120 L160 170" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M340 120 V170" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M400 120 L520 170" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
 </svg>

--- a/tinytorch/quarto/assets/images/diagrams/04_losses-diag-1.svg
+++ b/tinytorch/quarto/assets/images/diagrams/04_losses-diag-1.svg
@@ -3,25 +3,25 @@
   <rect width="680" height="300" fill="#ffffff"/>
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6 Z" fill="#9ca3af"/>
+      <path d="M0,0 L8,3 L0,6 Z" fill="#555"/>
     </marker>
   </defs>
   <g transform="translate(0,-50)">
-<rect x="40" y="60" width="600" height="260" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1" rx="2"/>
-  <text x="50" y="80" font-size="11" font-weight="700" fill="#1f2937">Your Loss Functions</text>
-  <rect x="250" y="100" width="180" height="60" fill="#fff1e8" stroke="#ff8246" stroke-width="1" rx="2"/>
-  <text x="340.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">log_softmax()</text>
-  <text x="340.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">Numerical Stability</text>
-  <rect x="70" y="240" width="160" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="150.0" y="267.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">MSELoss</text>
-  <text x="150.0" y="282.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">Regression</text>
-  <rect x="260" y="240" width="160" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="340.0" y="267.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">CrossEntropyLoss</text>
-  <text x="340.0" y="282.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">Classification</text>
-  <rect x="450" y="240" width="160" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="530.0" y="267.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">BCE Loss</text>
-  <text x="530.0" y="282.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">Binary Decisions</text>
-  <path d="M340 160 V240" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <text x="350" y="200" text-anchor="start" font-size="9" font-weight="400" fill="#6b7280" font-style="italic">provides stability</text>
+<rect x="40" y="60" width="600" height="260" fill="#f7f7f7" stroke="#bbb" stroke-width="1.2" rx="4"/>
+  <text x="50" y="80" font-size="12" font-weight="700" fill="#333">Your Loss Functions</text>
+  <rect x="250" y="100" width="180" height="60" fill="#fdebd0" stroke="#c87b2a" stroke-width="1.2" rx="4"/>
+  <text x="340.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">log_softmax()</text>
+  <text x="340.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">Numerical Stability</text>
+  <rect x="70" y="240" width="160" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="150.0" y="267.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">MSELoss</text>
+  <text x="150.0" y="282.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">Regression</text>
+  <rect x="260" y="240" width="160" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="340.0" y="267.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">CrossEntropyLoss</text>
+  <text x="340.0" y="282.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">Classification</text>
+  <rect x="450" y="240" width="160" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="530.0" y="267.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">BCE Loss</text>
+  <text x="530.0" y="282.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">Binary Decisions</text>
+  <path d="M340 160 V240" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <text x="350" y="200" text-anchor="start" font-size="9" font-weight="400" fill="#999" font-style="italic">provides stability</text>
   </g>
 </svg>

--- a/tinytorch/quarto/assets/images/diagrams/05_dataloader-diag-1.svg
+++ b/tinytorch/quarto/assets/images/diagrams/05_dataloader-diag-1.svg
@@ -3,30 +3,30 @@
   <rect width="680" height="260" fill="#ffffff"/>
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6 Z" fill="#9ca3af"/>
+      <path d="M0,0 L8,3 L0,6 Z" fill="#555"/>
     </marker>
   </defs>
   <g transform="translate(0,-50)">
-<rect x="40" y="60" width="600" height="220" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1" rx="2"/>
-  <text x="50" y="80" font-size="11" font-weight="700" fill="#1f2937">Your Data Pipeline</text>
-  <rect x="70" y="100" width="120" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="130.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Dataset</text>
-  <text x="130.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">__len__, __getitem__</text>
-  <rect x="230" y="100" width="120" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="290.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">TensorDataset</text>
-  <text x="290.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">In-memory storage</text>
-  <rect x="390" y="100" width="120" height="60" fill="#fff1e8" stroke="#ff8246" stroke-width="1" rx="2"/>
-  <text x="450.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">DataLoader</text>
-  <text x="450.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">Batching + Shuffling</text>
-  <rect x="390" y="220" width="120" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="450.0" y="247.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Iterator</text>
-  <text x="450.0" y="262.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">Yields batches</text>
-  <rect x="190" y="220" width="180" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="280.0" y="247.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Training Loop</text>
-  <text x="280.0" y="262.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">for batch in loader</text>
-  <path d="M190 130 H230" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M350 130 H390" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M450 160 V220" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M390 250 H370" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+<rect x="40" y="60" width="600" height="220" fill="#f7f7f7" stroke="#bbb" stroke-width="1.2" rx="4"/>
+  <text x="50" y="80" font-size="12" font-weight="700" fill="#333">Your Data Pipeline</text>
+  <rect x="70" y="100" width="120" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="130.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Dataset</text>
+  <text x="130.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">__len__, __getitem__</text>
+  <rect x="230" y="100" width="120" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="290.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">TensorDataset</text>
+  <text x="290.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">In-memory storage</text>
+  <rect x="390" y="100" width="120" height="60" fill="#fdebd0" stroke="#c87b2a" stroke-width="1.2" rx="4"/>
+  <text x="450.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">DataLoader</text>
+  <text x="450.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">Batching + Shuffling</text>
+  <rect x="390" y="220" width="120" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="450.0" y="247.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Iterator</text>
+  <text x="450.0" y="262.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">Yields batches</text>
+  <rect x="190" y="220" width="180" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="280.0" y="247.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Training Loop</text>
+  <text x="280.0" y="262.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">for batch in loader</text>
+  <path d="M190 130 H230" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M350 130 H390" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M450 160 V220" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M390 250 H370" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
   </g>
 </svg>

--- a/tinytorch/quarto/assets/images/diagrams/06_autograd-diag-1.svg
+++ b/tinytorch/quarto/assets/images/diagrams/06_autograd-diag-1.svg
@@ -3,30 +3,30 @@
   <rect width="680" height="280" fill="#ffffff"/>
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6 Z" fill="#9ca3af"/>
+      <path d="M0,0 L8,3 L0,6 Z" fill="#555"/>
     </marker>
   </defs>
   <g transform="translate(0,-50)">
-<rect x="40" y="60" width="600" height="240" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1" rx="2"/>
-  <text x="50" y="80" font-size="11" font-weight="700" fill="#1f2937">Autograd System</text>
-  <rect x="70" y="100" width="120" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="130.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Function</text>
-  <text x="130.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">Base Class</text>
-  <rect x="230" y="100" width="120" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="290.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Operation Functions</text>
-  <text x="290.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">Add, Mul, Matmul</text>
-  <rect x="390" y="100" width="120" height="60" fill="#fff1e8" stroke="#ff8246" stroke-width="1" rx="2"/>
-  <text x="450.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Backward Pass</text>
-  <text x="450.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">Gradient Flow</text>
-  <rect x="230" y="220" width="120" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="290.0" y="247.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Computation Graph</text>
-  <text x="290.0" y="262.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">Tracking</text>
-  <rect x="390" y="220" width="120" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="450.0" y="247.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">enable_autograd()</text>
-  <text x="450.0" y="262.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">Global Activation</text>
-  <path d="M190 130 H230" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M350 130 H390" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M450 160 V220" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M390 250 H350" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+<rect x="40" y="60" width="600" height="240" fill="#f7f7f7" stroke="#bbb" stroke-width="1.2" rx="4"/>
+  <text x="50" y="80" font-size="12" font-weight="700" fill="#333">Autograd System</text>
+  <rect x="70" y="100" width="120" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="130.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Function</text>
+  <text x="130.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">Base Class</text>
+  <rect x="230" y="100" width="120" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="290.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Operation Functions</text>
+  <text x="290.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">Add, Mul, Matmul</text>
+  <rect x="390" y="100" width="120" height="60" fill="#fdebd0" stroke="#c87b2a" stroke-width="1.2" rx="4"/>
+  <text x="450.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Backward Pass</text>
+  <text x="450.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">Gradient Flow</text>
+  <rect x="230" y="220" width="120" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="290.0" y="247.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Computation Graph</text>
+  <text x="290.0" y="262.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">Tracking</text>
+  <rect x="390" y="220" width="120" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="450.0" y="247.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">enable_autograd()</text>
+  <text x="450.0" y="262.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">Global Activation</text>
+  <path d="M190 130 H230" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M350 130 H390" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M450 160 V220" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M390 250 H350" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
   </g>
 </svg>

--- a/tinytorch/quarto/assets/images/diagrams/07_optimizers-diag-1.svg
+++ b/tinytorch/quarto/assets/images/diagrams/07_optimizers-diag-1.svg
@@ -3,26 +3,26 @@
   <rect width="680" height="300" fill="#ffffff"/>
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6 Z" fill="#9ca3af"/>
+      <path d="M0,0 L8,3 L0,6 Z" fill="#555"/>
     </marker>
   </defs>
   <g transform="translate(0,-50)">
-<rect x="40" y="60" width="600" height="260" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1" rx="2"/>
-  <text x="50" y="80" font-size="11" font-weight="700" fill="#1f2937">Your Optimizer Classes</text>
-  <rect x="250" y="100" width="180" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="340.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Optimizer Base</text>
-  <text x="340.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">zero_grad(), step()</text>
-  <rect x="70" y="240" width="160" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="150.0" y="267.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">SGD</text>
-  <text x="150.0" y="282.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">momentum buffers</text>
-  <rect x="260" y="240" width="160" height="60" fill="#fff1e8" stroke="#ff8246" stroke-width="1" rx="2"/>
-  <text x="340.0" y="267.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Adam</text>
-  <text x="340.0" y="282.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">m, v buffers</text>
-  <rect x="450" y="240" width="160" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="530.0" y="267.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">AdamW</text>
-  <text x="530.0" y="282.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">decoupled decay</text>
-  <path d="M250 130 H150 V240" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M340 160 V240" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M430 130 H530 V240" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+<rect x="40" y="60" width="600" height="260" fill="#f7f7f7" stroke="#bbb" stroke-width="1.2" rx="4"/>
+  <text x="50" y="80" font-size="12" font-weight="700" fill="#333">Your Optimizer Classes</text>
+  <rect x="250" y="100" width="180" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="340.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Optimizer Base</text>
+  <text x="340.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">zero_grad(), step()</text>
+  <rect x="70" y="240" width="160" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="150.0" y="267.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">SGD</text>
+  <text x="150.0" y="282.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">momentum buffers</text>
+  <rect x="260" y="240" width="160" height="60" fill="#fdebd0" stroke="#c87b2a" stroke-width="1.2" rx="4"/>
+  <text x="340.0" y="267.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Adam</text>
+  <text x="340.0" y="282.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">m, v buffers</text>
+  <rect x="450" y="240" width="160" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="530.0" y="267.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">AdamW</text>
+  <text x="530.0" y="282.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">decoupled decay</text>
+  <path d="M250 130 H150 V240" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M340 160 V240" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M430 130 H530 V240" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
   </g>
 </svg>

--- a/tinytorch/quarto/assets/images/diagrams/08_training-diag-1.svg
+++ b/tinytorch/quarto/assets/images/diagrams/08_training-diag-1.svg
@@ -3,44 +3,44 @@
   <rect width="680" height="380" fill="#ffffff"/>
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6 Z" fill="#9ca3af"/>
+      <path d="M0,0 L8,3 L0,6 Z" fill="#555"/>
     </marker>
   </defs>
   <g transform="translate(0,-50)">
-<rect x="40" y="60" width="600" height="120" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1" rx="2"/>
-  <text x="50" y="80" font-size="11" font-weight="700" fill="#1f2937">Training Infrastructure</text>
-  <rect x="60" y="100" width="130" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="125.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">CosineSchedule</text>
-  <text x="125.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">Adaptive LR</text>
-  <rect x="205" y="100" width="130" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="270.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">clip_grad_norm()</text>
-  <text x="270.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">Gradient stability</text>
-  <rect x="350" y="100" width="130" height="60" fill="#fff1e8" stroke="#ff8246" stroke-width="1" rx="2"/>
-  <text x="415.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Trainer</text>
-  <text x="415.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">Orchestration</text>
-  <rect x="495" y="100" width="130" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="560.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Checkpointing</text>
-  <text x="560.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">Persistence</text>
-  <rect x="40" y="220" width="600" height="180" fill="#ffffff" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="3,2" rx="2"/>
-  <text x="50" y="240" font-size="11" font-weight="700" fill="#1f2937">Training Loop Cycle</text>
-  <rect x="60" y="260" width="100" height="40" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="110.0" y="284.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Forward</text>
-  <rect x="175" y="260" width="100" height="40" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="225.0" y="284.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Loss</text>
-  <rect x="290" y="260" width="100" height="40" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="340.0" y="284.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Backward</text>
-  <rect x="405" y="260" width="100" height="40" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="455.0" y="284.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Clip</text>
-  <rect x="520" y="260" width="100" height="40" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="570.0" y="284.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Update</text>
-  <path d="M160 280 H175" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M275 280 H290" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M390 280 H405" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M505 280 H520" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M570 300 V340 H110 V300" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <text x="340" y="335" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280" font-style="italic">Next Batch</text>
-  <path d="M125 160 V220" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)" stroke-dasharray="3,2"/>
-  <path d="M270 160 V260" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)" stroke-dasharray="3,2"/>
-  <path d="M415 160 V220" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+<rect x="40" y="60" width="600" height="120" fill="#f7f7f7" stroke="#bbb" stroke-width="1.2" rx="4"/>
+  <text x="50" y="80" font-size="12" font-weight="700" fill="#333">Training Infrastructure</text>
+  <rect x="60" y="100" width="130" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="125.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">CosineSchedule</text>
+  <text x="125.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">Adaptive LR</text>
+  <rect x="205" y="100" width="130" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="270.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">clip_grad_norm()</text>
+  <text x="270.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">Gradient stability</text>
+  <rect x="350" y="100" width="130" height="60" fill="#fdebd0" stroke="#c87b2a" stroke-width="1.2" rx="4"/>
+  <text x="415.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Trainer</text>
+  <text x="415.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">Orchestration</text>
+  <rect x="495" y="100" width="130" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="560.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Checkpointing</text>
+  <text x="560.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">Persistence</text>
+  <rect x="40" y="220" width="600" height="180" fill="#ffffff" stroke="#bbb" stroke-width="1.2" stroke-dasharray="3,2" rx="4"/>
+  <text x="50" y="240" font-size="12" font-weight="700" fill="#333">Training Loop Cycle</text>
+  <rect x="60" y="260" width="100" height="40" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="110.0" y="284.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Forward</text>
+  <rect x="175" y="260" width="100" height="40" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="225.0" y="284.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Loss</text>
+  <rect x="290" y="260" width="100" height="40" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="340.0" y="284.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Backward</text>
+  <rect x="405" y="260" width="100" height="40" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="455.0" y="284.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Clip</text>
+  <rect x="520" y="260" width="100" height="40" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="570.0" y="284.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Update</text>
+  <path d="M160 280 H175" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M275 280 H290" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M390 280 H405" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M505 280 H520" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M570 300 V340 H110 V300" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <text x="340" y="335" text-anchor="middle" font-size="9" font-weight="400" fill="#999" font-style="italic">Next Batch</text>
+  <path d="M125 160 V220" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)" stroke-dasharray="3,2"/>
+  <path d="M270 160 V260" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)" stroke-dasharray="3,2"/>
+  <path d="M415 160 V220" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
   </g>
 </svg>

--- a/tinytorch/quarto/assets/images/diagrams/09_convolutions-diag-1.svg
+++ b/tinytorch/quarto/assets/images/diagrams/09_convolutions-diag-1.svg
@@ -3,31 +3,31 @@
   <rect width="680" height="260" fill="#ffffff"/>
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6 Z" fill="#9ca3af"/>
+      <path d="M0,0 L8,3 L0,6 Z" fill="#555"/>
     </marker>
   </defs>
   <g transform="translate(0,-50)">
-<rect x="40" y="60" width="600" height="120" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1" rx="2"/>
-  <text x="50" y="80" font-size="11" font-weight="700" fill="#1f2937">Your Spatial Operations</text>
-  <rect x="70" y="100" width="160" height="60" fill="#fff1e8" stroke="#ff8246" stroke-width="1" rx="2"/>
-  <text x="150.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Conv2d</text>
-  <text x="150.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">Feature Extraction</text>
-  <rect x="260" y="100" width="160" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="340.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">MaxPool2d</text>
-  <text x="340.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">Strong Selection</text>
-  <rect x="450" y="100" width="160" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="530.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">AvgPool2d</text>
-  <text x="530.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">Smooth Averaging</text>
-  <rect x="100" y="240" width="100" height="40" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="150.0" y="264.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Input (B,C,H,W)</text>
-  <rect x="290" y="240" width="100" height="40" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="340.0" y="264.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Features (B,C',H',W')</text>
-  <rect x="480" y="240" width="100" height="40" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="530.0" y="264.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Pooled (B,C,H/2,W/2)</text>
-  <path d="M150 160 V240" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)" stroke-dasharray="3,2"/>
-  <path d="M200 260 H290" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M340 160 V240" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)" stroke-dasharray="3,2"/>
-  <path d="M390 260 H480" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M530 160 V240" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)" stroke-dasharray="3,2"/>
+<rect x="40" y="60" width="600" height="120" fill="#f7f7f7" stroke="#bbb" stroke-width="1.2" rx="4"/>
+  <text x="50" y="80" font-size="12" font-weight="700" fill="#333">Your Spatial Operations</text>
+  <rect x="70" y="100" width="160" height="60" fill="#fdebd0" stroke="#c87b2a" stroke-width="1.2" rx="4"/>
+  <text x="150.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Conv2d</text>
+  <text x="150.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">Feature Extraction</text>
+  <rect x="260" y="100" width="160" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="340.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">MaxPool2d</text>
+  <text x="340.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">Strong Selection</text>
+  <rect x="450" y="100" width="160" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="530.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">AvgPool2d</text>
+  <text x="530.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">Smooth Averaging</text>
+  <rect x="100" y="240" width="100" height="40" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="150.0" y="264.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Input (B,C,H,W)</text>
+  <rect x="290" y="240" width="100" height="40" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="340.0" y="264.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Features (B,C',H',W')</text>
+  <rect x="480" y="240" width="100" height="40" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="530.0" y="264.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Pooled (B,C,H/2,W/2)</text>
+  <path d="M150 160 V240" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)" stroke-dasharray="3,2"/>
+  <path d="M200 260 H290" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M340 160 V240" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)" stroke-dasharray="3,2"/>
+  <path d="M390 260 H480" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M530 160 V240" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)" stroke-dasharray="3,2"/>
   </g>
 </svg>

--- a/tinytorch/quarto/assets/images/diagrams/10_tokenization-diag-1.svg
+++ b/tinytorch/quarto/assets/images/diagrams/10_tokenization-diag-1.svg
@@ -3,27 +3,27 @@
   <rect width="680" height="370" fill="#ffffff"/>
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6 Z" fill="#9ca3af"/>
+      <path d="M0,0 L8,3 L0,6 Z" fill="#555"/>
     </marker>
   </defs>
   <g transform="translate(0,-50)">
-<rect x="40" y="60" width="600" height="330" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1" rx="2"/>
-  <text x="50" y="80" font-size="11" font-weight="700" fill="#1f2937">Your Tokenization System</text>
-  <rect x="260" y="100" width="160" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="340.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Base Tokenizer</text>
-  <text x="340.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">encode(), decode()</text>
-  <rect x="80" y="210" width="160" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="160.0" y="237.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">CharTokenizer</text>
-  <text x="160.0" y="252.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">character-level</text>
-  <rect x="440" y="210" width="160" height="60" fill="#fff1e8" stroke="#ff8246" stroke-width="1" rx="2"/>
-  <text x="520.0" y="237.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">BPETokenizer</text>
-  <text x="520.0" y="252.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">subword units</text>
-  <rect x="260" y="320" width="160" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="340.0" y="347.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Vocabulary Manager</text>
-  <text x="340.0" y="362.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">mappings &amp; special tokens</text>
-  <path d="M295 160 L195 210" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M385 160 L485 210" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M195 270 L295 320" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M485 270 L385 320" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+<rect x="40" y="60" width="600" height="330" fill="#f7f7f7" stroke="#bbb" stroke-width="1.2" rx="4"/>
+  <text x="50" y="80" font-size="12" font-weight="700" fill="#333">Your Tokenization System</text>
+  <rect x="260" y="100" width="160" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="340.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Base Tokenizer</text>
+  <text x="340.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">encode(), decode()</text>
+  <rect x="80" y="210" width="160" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="160.0" y="237.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">CharTokenizer</text>
+  <text x="160.0" y="252.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">character-level</text>
+  <rect x="440" y="210" width="160" height="60" fill="#fdebd0" stroke="#c87b2a" stroke-width="1.2" rx="4"/>
+  <text x="520.0" y="237.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">BPETokenizer</text>
+  <text x="520.0" y="252.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">subword units</text>
+  <rect x="260" y="320" width="160" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="340.0" y="347.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Vocabulary Manager</text>
+  <text x="340.0" y="362.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">mappings &amp; special tokens</text>
+  <path d="M295 160 L195 210" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M385 160 L485 210" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M195 270 L295 320" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M485 270 L385 320" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
   </g>
 </svg>

--- a/tinytorch/quarto/assets/images/diagrams/11_embeddings-diag-1.svg
+++ b/tinytorch/quarto/assets/images/diagrams/11_embeddings-diag-1.svg
@@ -3,26 +3,26 @@
   <rect width="680" height="320" fill="#ffffff"/>
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6 Z" fill="#9ca3af"/>
+      <path d="M0,0 L8,3 L0,6 Z" fill="#555"/>
     </marker>
   </defs>
   <g transform="translate(0,-50)">
-<rect x="40" y="60" width="600" height="280" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1" rx="2"/>
-  <text x="50" y="80" font-size="11" font-weight="700" fill="#1f2937">Your Embedding System</text>
-  <rect x="70" y="100" width="130" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="135.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Embedding</text>
-  <text x="135.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">Token → Vector</text>
-  <rect x="230" y="100" width="130" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="295.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">PositionalEncoding</text>
-  <text x="295.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">Learned Positions</text>
-  <rect x="390" y="100" width="130" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="455.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Sinusoidal PE</text>
-  <text x="455.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">Math Patterns</text>
-  <rect x="70" y="240" width="450" height="80" fill="#fff1e8" stroke="#ff8246" stroke-width="1" rx="2"/>
-  <text x="295.0" y="277.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">EmbeddingLayer</text>
-  <text x="295.0" y="292.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">Complete Token + Position System</text>
-  <path d="M135 160 V240" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M295 160 V240" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M455 160 V240" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+<rect x="40" y="60" width="600" height="280" fill="#f7f7f7" stroke="#bbb" stroke-width="1.2" rx="4"/>
+  <text x="50" y="80" font-size="12" font-weight="700" fill="#333">Your Embedding System</text>
+  <rect x="70" y="100" width="130" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="135.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Embedding</text>
+  <text x="135.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">Token → Vector</text>
+  <rect x="230" y="100" width="130" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="295.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">PositionalEncoding</text>
+  <text x="295.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">Learned Positions</text>
+  <rect x="390" y="100" width="130" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="455.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Sinusoidal PE</text>
+  <text x="455.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">Math Patterns</text>
+  <rect x="70" y="240" width="450" height="80" fill="#fdebd0" stroke="#c87b2a" stroke-width="1.2" rx="4"/>
+  <text x="295.0" y="277.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">EmbeddingLayer</text>
+  <text x="295.0" y="292.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">Complete Token + Position System</text>
+  <path d="M135 160 V240" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M295 160 V240" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M455 160 V240" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
   </g>
 </svg>

--- a/tinytorch/quarto/assets/images/diagrams/12_attention-diag-1.svg
+++ b/tinytorch/quarto/assets/images/diagrams/12_attention-diag-1.svg
@@ -3,28 +3,28 @@
   <rect width="680" height="280" fill="#ffffff"/>
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6 Z" fill="#9ca3af"/>
+      <path d="M0,0 L8,3 L0,6 Z" fill="#555"/>
     </marker>
   </defs>
   <g transform="translate(0,-50)">
-<rect x="40" y="60" width="600" height="240" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1" rx="2"/>
-  <text x="50" y="80" font-size="11" font-weight="700" fill="#1f2937">Your Attention System</text>
-  <rect x="70" y="100" width="100" height="40" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="120.0" y="124.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Query (Q)</text>
-  <rect x="70" y="150" width="100" height="40" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="120.0" y="174.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Key (K)</text>
-  <rect x="70" y="230" width="100" height="40" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="120.0" y="254.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Value (V)</text>
-  <rect x="210" y="125" width="140" height="40" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="280.0" y="149.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">QKᵀ / √d_k</text>
-  <rect x="380" y="125" width="160" height="40" fill="#fff1e8" stroke="#ff8246" stroke-width="1" rx="2"/>
-  <text x="460.0" y="149.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Softmax (Weights)</text>
-  <rect x="380" y="230" width="160" height="40" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="460.0" y="254.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Weighted Output</text>
-  <path d="M170 120 L210 140" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M170 170 L210 150" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M350 145 H380" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M460 165 V230" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M170 250 H380" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+<rect x="40" y="60" width="600" height="240" fill="#f7f7f7" stroke="#bbb" stroke-width="1.2" rx="4"/>
+  <text x="50" y="80" font-size="12" font-weight="700" fill="#333">Your Attention System</text>
+  <rect x="70" y="100" width="100" height="40" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="120.0" y="124.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Query (Q)</text>
+  <rect x="70" y="150" width="100" height="40" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="120.0" y="174.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Key (K)</text>
+  <rect x="70" y="230" width="100" height="40" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="120.0" y="254.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Value (V)</text>
+  <rect x="210" y="125" width="140" height="40" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="280.0" y="149.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">QKᵀ / √d_k</text>
+  <rect x="380" y="125" width="160" height="40" fill="#fdebd0" stroke="#c87b2a" stroke-width="1.2" rx="4"/>
+  <text x="460.0" y="149.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Softmax (Weights)</text>
+  <rect x="380" y="230" width="160" height="40" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="460.0" y="254.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Weighted Output</text>
+  <path d="M170 120 L210 140" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M170 170 L210 150" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M350 145 H380" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M460 165 V230" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M170 250 H380" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
   </g>
 </svg>

--- a/tinytorch/quarto/assets/images/diagrams/14_profiling-diag-1.svg
+++ b/tinytorch/quarto/assets/images/diagrams/14_profiling-diag-1.svg
@@ -3,25 +3,25 @@
   <rect width="680" height="320" fill="#ffffff"/>
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6 Z" fill="#9ca3af"/>
+      <path d="M0,0 L8,3 L0,6 Z" fill="#555"/>
     </marker>
   </defs>
   <g transform="translate(0,-50)">
-<rect x="40" y="60" width="600" height="280" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1" rx="2"/>
-  <text x="50" y="80" font-size="11" font-weight="700" fill="#1f2937">Your Profiler Class</text>
-  <rect x="70" y="100" width="160" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="150.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Timer</text>
-  <text x="150.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">Operation Latency</text>
-  <rect x="260" y="100" width="160" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="340.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">MemoryProfiler</text>
-  <text x="340.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">Allocation Tracking</text>
-  <rect x="450" y="100" width="160" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="530.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">ProfilerSummary</text>
-  <text x="530.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">Aggregation</text>
-  <rect x="70" y="240" width="540" height="80" fill="#fff1e8" stroke="#ff8246" stroke-width="1" rx="2"/>
-  <text x="340.0" y="284.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Performance Report</text>
-  <path d="M150 160 V240" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M340 160 V240" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M530 160 V240" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+<rect x="40" y="60" width="600" height="280" fill="#f7f7f7" stroke="#bbb" stroke-width="1.2" rx="4"/>
+  <text x="50" y="80" font-size="12" font-weight="700" fill="#333">Your Profiler Class</text>
+  <rect x="70" y="100" width="160" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="150.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Timer</text>
+  <text x="150.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">Operation Latency</text>
+  <rect x="260" y="100" width="160" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="340.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">MemoryProfiler</text>
+  <text x="340.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">Allocation Tracking</text>
+  <rect x="450" y="100" width="160" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="530.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">ProfilerSummary</text>
+  <text x="530.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">Aggregation</text>
+  <rect x="70" y="240" width="540" height="80" fill="#fdebd0" stroke="#c87b2a" stroke-width="1.2" rx="4"/>
+  <text x="340.0" y="284.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Performance Report</text>
+  <path d="M150 160 V240" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M340 160 V240" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M530 160 V240" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
   </g>
 </svg>

--- a/tinytorch/quarto/assets/images/diagrams/15_quantization-diag-1.svg
+++ b/tinytorch/quarto/assets/images/diagrams/15_quantization-diag-1.svg
@@ -3,25 +3,25 @@
   <rect width="680" height="320" fill="#ffffff"/>
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6 Z" fill="#9ca3af"/>
+      <path d="M0,0 L8,3 L0,6 Z" fill="#555"/>
     </marker>
   </defs>
   <g transform="translate(0,-50)">
-<rect x="40" y="60" width="600" height="280" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1" rx="2"/>
-  <text x="50" y="80" font-size="11" font-weight="700" fill="#1f2937">Your Quantization System</text>
-  <rect x="70" y="100" width="130" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="135.0" y="134.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">MinMaxObserver</text>
-  <rect x="220" y="100" width="130" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="285.0" y="134.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">MovingAverage</text>
-  <rect x="370" y="100" width="130" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="435.0" y="134.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">WeightQuant</text>
-  <rect x="520" y="100" width="130" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="585.0" y="134.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">ActivationQuant</text>
-  <rect x="70" y="240" width="580" height="80" fill="#fff1e8" stroke="#ff8246" stroke-width="1" rx="2"/>
-  <text x="360.0" y="284.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">QuantizedModel (INT8)</text>
-  <path d="M135 160 V240" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M285 160 V240" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M435 160 V240" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M585 160 V240" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+<rect x="40" y="60" width="600" height="280" fill="#f7f7f7" stroke="#bbb" stroke-width="1.2" rx="4"/>
+  <text x="50" y="80" font-size="12" font-weight="700" fill="#333">Your Quantization System</text>
+  <rect x="70" y="100" width="130" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="135.0" y="134.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">MinMaxObserver</text>
+  <rect x="220" y="100" width="130" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="285.0" y="134.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">MovingAverage</text>
+  <rect x="370" y="100" width="130" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="435.0" y="134.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">WeightQuant</text>
+  <rect x="520" y="100" width="130" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="585.0" y="134.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">ActivationQuant</text>
+  <rect x="70" y="240" width="580" height="80" fill="#fdebd0" stroke="#c87b2a" stroke-width="1.2" rx="4"/>
+  <text x="360.0" y="284.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">QuantizedModel (INT8)</text>
+  <path d="M135 160 V240" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M285 160 V240" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M435 160 V240" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M585 160 V240" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
   </g>
 </svg>

--- a/tinytorch/quarto/assets/images/diagrams/16_compression-diag-1.svg
+++ b/tinytorch/quarto/assets/images/diagrams/16_compression-diag-1.svg
@@ -3,22 +3,22 @@
   <rect width="680" height="320" fill="#ffffff"/>
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6 Z" fill="#9ca3af"/>
+      <path d="M0,0 L8,3 L0,6 Z" fill="#555"/>
     </marker>
   </defs>
   <g transform="translate(0,-50)">
-<rect x="40" y="60" width="600" height="280" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1" rx="2"/>
-  <text x="50" y="80" font-size="11" font-weight="700" fill="#1f2937">Your Compression System</text>
-  <rect x="70" y="100" width="160" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="150.0" y="134.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Weight Pruning</text>
-  <rect x="260" y="100" width="160" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="340.0" y="134.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Distillation</text>
-  <rect x="450" y="100" width="160" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="530.0" y="134.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Structured Pruning</text>
-  <rect x="70" y="240" width="540" height="80" fill="#fff1e8" stroke="#ff8246" stroke-width="1" rx="2"/>
-  <text x="340.0" y="284.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">CompressedModel</text>
-  <path d="M150 160 V240" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M340 160 V240" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M530 160 V240" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+<rect x="40" y="60" width="600" height="280" fill="#f7f7f7" stroke="#bbb" stroke-width="1.2" rx="4"/>
+  <text x="50" y="80" font-size="12" font-weight="700" fill="#333">Your Compression System</text>
+  <rect x="70" y="100" width="160" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="150.0" y="134.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Weight Pruning</text>
+  <rect x="260" y="100" width="160" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="340.0" y="134.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Distillation</text>
+  <rect x="450" y="100" width="160" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="530.0" y="134.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Structured Pruning</text>
+  <rect x="70" y="240" width="540" height="80" fill="#fdebd0" stroke="#c87b2a" stroke-width="1.2" rx="4"/>
+  <text x="340.0" y="284.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">CompressedModel</text>
+  <path d="M150 160 V240" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M340 160 V240" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M530 160 V240" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
   </g>
 </svg>

--- a/tinytorch/quarto/assets/images/diagrams/17_acceleration-diag-1.svg
+++ b/tinytorch/quarto/assets/images/diagrams/17_acceleration-diag-1.svg
@@ -3,22 +3,22 @@
   <rect width="680" height="320" fill="#ffffff"/>
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6 Z" fill="#9ca3af"/>
+      <path d="M0,0 L8,3 L0,6 Z" fill="#555"/>
     </marker>
   </defs>
   <g transform="translate(0,-50)">
-<rect x="40" y="60" width="600" height="280" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1" rx="2"/>
-  <text x="50" y="80" font-size="11" font-weight="700" fill="#1f2937">Your Acceleration Layer</text>
-  <rect x="70" y="100" width="160" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="150.0" y="134.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Vectorized Kernels</text>
-  <rect x="260" y="100" width="160" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="340.0" y="134.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">SIMD (AVX/NEON)</text>
-  <rect x="450" y="100" width="160" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="530.0" y="134.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Parallel Loops</text>
-  <rect x="70" y="240" width="540" height="80" fill="#fff1e8" stroke="#ff8246" stroke-width="1" rx="2"/>
-  <text x="340.0" y="284.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Accelerated Backend</text>
-  <path d="M150 160 V240" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M340 160 V240" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M530 160 V240" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+<rect x="40" y="60" width="600" height="280" fill="#f7f7f7" stroke="#bbb" stroke-width="1.2" rx="4"/>
+  <text x="50" y="80" font-size="12" font-weight="700" fill="#333">Your Acceleration Layer</text>
+  <rect x="70" y="100" width="160" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="150.0" y="134.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Vectorized Kernels</text>
+  <rect x="260" y="100" width="160" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="340.0" y="134.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">SIMD (AVX/NEON)</text>
+  <rect x="450" y="100" width="160" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="530.0" y="134.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Parallel Loops</text>
+  <rect x="70" y="240" width="540" height="80" fill="#fdebd0" stroke="#c87b2a" stroke-width="1.2" rx="4"/>
+  <text x="340.0" y="284.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Accelerated Backend</text>
+  <path d="M150 160 V240" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M340 160 V240" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M530 160 V240" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
   </g>
 </svg>

--- a/tinytorch/quarto/assets/images/diagrams/18_memoization-diag-1.svg
+++ b/tinytorch/quarto/assets/images/diagrams/18_memoization-diag-1.svg
@@ -3,22 +3,22 @@
   <rect width="680" height="320" fill="#ffffff"/>
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6 Z" fill="#9ca3af"/>
+      <path d="M0,0 L8,3 L0,6 Z" fill="#555"/>
     </marker>
   </defs>
   <g transform="translate(0,-50)">
-<rect x="40" y="60" width="600" height="280" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1" rx="2"/>
-  <text x="50" y="80" font-size="11" font-weight="700" fill="#1f2937">Your KV Cache System</text>
-  <rect x="70" y="100" width="160" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="150.0" y="134.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Cache Storage</text>
-  <rect x="260" y="100" width="160" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="340.0" y="134.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Update Logic</text>
-  <rect x="450" y="100" width="160" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="530.0" y="134.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Retrieval Flow</text>
-  <rect x="70" y="240" width="540" height="80" fill="#fff1e8" stroke="#ff8246" stroke-width="1" rx="2"/>
-  <text x="340.0" y="284.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Optimized Generation</text>
-  <path d="M150 160 V240" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M340 160 V240" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M530 160 V240" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+<rect x="40" y="60" width="600" height="280" fill="#f7f7f7" stroke="#bbb" stroke-width="1.2" rx="4"/>
+  <text x="50" y="80" font-size="12" font-weight="700" fill="#333">Your KV Cache System</text>
+  <rect x="70" y="100" width="160" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="150.0" y="134.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Cache Storage</text>
+  <rect x="260" y="100" width="160" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="340.0" y="134.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Update Logic</text>
+  <rect x="450" y="100" width="160" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="530.0" y="134.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Retrieval Flow</text>
+  <rect x="70" y="240" width="540" height="80" fill="#fdebd0" stroke="#c87b2a" stroke-width="1.2" rx="4"/>
+  <text x="340.0" y="284.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Optimized Generation</text>
+  <path d="M150 160 V240" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M340 160 V240" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M530 160 V240" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
   </g>
 </svg>

--- a/tinytorch/quarto/assets/images/diagrams/19_benchmarking-diag-1.svg
+++ b/tinytorch/quarto/assets/images/diagrams/19_benchmarking-diag-1.svg
@@ -3,22 +3,22 @@
   <rect width="680" height="320" fill="#ffffff"/>
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6 Z" fill="#9ca3af"/>
+      <path d="M0,0 L8,3 L0,6 Z" fill="#555"/>
     </marker>
   </defs>
   <g transform="translate(0,-50)">
-<rect x="40" y="60" width="600" height="280" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1" rx="2"/>
-  <text x="50" y="80" font-size="11" font-weight="700" fill="#1f2937">Your Benchmarking System</text>
-  <rect x="70" y="100" width="160" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="150.0" y="134.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">MetricCollector</text>
-  <rect x="260" y="100" width="160" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="340.0" y="134.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">StatsAnalyzer</text>
-  <rect x="450" y="100" width="160" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="530.0" y="134.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">ComparisonEngine</text>
-  <rect x="70" y="240" width="540" height="80" fill="#fff1e8" stroke="#ff8246" stroke-width="1" rx="2"/>
-  <text x="340.0" y="284.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Benchmark Results</text>
-  <path d="M150 160 V240" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M340 160 V240" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M530 160 V240" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+<rect x="40" y="60" width="600" height="280" fill="#f7f7f7" stroke="#bbb" stroke-width="1.2" rx="4"/>
+  <text x="50" y="80" font-size="12" font-weight="700" fill="#333">Your Benchmarking System</text>
+  <rect x="70" y="100" width="160" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="150.0" y="134.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">MetricCollector</text>
+  <rect x="260" y="100" width="160" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="340.0" y="134.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">StatsAnalyzer</text>
+  <rect x="450" y="100" width="160" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="530.0" y="134.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">ComparisonEngine</text>
+  <rect x="70" y="240" width="540" height="80" fill="#fdebd0" stroke="#c87b2a" stroke-width="1.2" rx="4"/>
+  <text x="340.0" y="284.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Benchmark Results</text>
+  <path d="M150 160 V240" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M340 160 V240" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M530 160 V240" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
   </g>
 </svg>

--- a/tinytorch/quarto/assets/images/diagrams/20_capstone-diag-1.svg
+++ b/tinytorch/quarto/assets/images/diagrams/20_capstone-diag-1.svg
@@ -3,36 +3,36 @@
   <rect width="680" height="300" fill="#ffffff"/>
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
-      <path d="M0,0 L8,3 L0,6 Z" fill="#9ca3af"/>
+      <path d="M0,0 L8,3 L0,6 Z" fill="#555"/>
     </marker>
   </defs>
   <g transform="translate(0,-50)">
-<rect x="40" y="60" width="600" height="260" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1" rx="2"/>
-  <text x="50" y="80" font-size="11" font-weight="700" fill="#1f2937">Your Submission Pipeline</text>
+<rect x="40" y="60" width="600" height="260" fill="#f7f7f7" stroke="#bbb" stroke-width="1.2" rx="4"/>
+  <text x="50" y="80" font-size="12" font-weight="700" fill="#333">Your Submission Pipeline</text>
 
-  <rect x="60" y="105" width="130" height="50" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="125.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Baseline Model</text>
-  <text x="125.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">SimpleMLP</text>
+  <rect x="60" y="105" width="130" height="50" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="125.0" y="127.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Baseline Model</text>
+  <text x="125.0" y="142.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">SimpleMLP</text>
 
-  <rect x="60" y="175" width="130" height="50" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="125.0" y="197.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">Optimized Model</text>
-  <text x="125.0" y="212.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">+ quantization, pruning</text>
+  <rect x="60" y="175" width="130" height="50" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="125.0" y="197.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">Optimized Model</text>
+  <text x="125.0" y="212.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">+ quantization, pruning</text>
 
-  <rect x="220" y="135" width="140" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="290.0" y="160.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">BenchmarkReport</text>
-  <text x="290.0" y="175.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">latency · accuracy · memory</text>
+  <rect x="220" y="135" width="140" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="290.0" y="160.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">BenchmarkReport</text>
+  <text x="290.0" y="175.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">latency · accuracy · memory</text>
 
-  <rect x="390" y="135" width="140" height="60" fill="#f4f5f7" stroke="#9ca3af" stroke-width="1" rx="2"/>
-  <text x="460.0" y="160.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">generate_submission()</text>
-  <text x="460.0" y="175.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">+ schema validation</text>
+  <rect x="390" y="135" width="140" height="60" fill="#f7f7f7" stroke="#555" stroke-width="1.2" rx="4"/>
+  <text x="460.0" y="160.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">generate_submission()</text>
+  <text x="460.0" y="175.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">+ schema validation</text>
 
-  <rect x="560" y="135" width="80" height="60" fill="#fff1e8" stroke="#ff8246" stroke-width="1" rx="2"/>
-  <text x="600.0" y="160.0" text-anchor="middle" font-size="10" font-weight="700" fill="#1f2937">results</text>
-  <text x="600.0" y="175.0" text-anchor="middle" font-size="9" font-weight="400" fill="#6b7280">.json</text>
+  <rect x="560" y="135" width="80" height="60" fill="#fdebd0" stroke="#c87b2a" stroke-width="1.2" rx="4"/>
+  <text x="600.0" y="160.0" text-anchor="middle" font-size="10" font-weight="700" fill="#333">results</text>
+  <text x="600.0" y="175.0" text-anchor="middle" font-size="9" font-weight="400" fill="#999">.json</text>
 
-  <path d="M190 130 L220 150" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M190 200 L220 180" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M360 165 H390" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-  <path d="M530 165 H560" stroke="#9ca3af" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+  <path d="M190 130 L220 150" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M190 200 L220 180" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M360 165 H390" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
+  <path d="M530 165 H560" stroke="#555" stroke-width="1.2" fill="none" marker-end="url(#arrow)"/>
   </g>
 </svg>

--- a/tinytorch/quarto/modules/01_tensor.qmd
+++ b/tinytorch/quarto/modules/01_tensor.qmd
@@ -540,6 +540,10 @@ def matmul(self, other):
 
 The explicit loops in the 2D case are intentionally slower than `np.matmul` because they reveal exactly what matrix multiplication does: each output element requires K operations, and there are M×N outputs, giving O(M×K×N) total operations. For square matrices, this is O(n³).
 
+:::{.callout-note title="⚡ Systems Implication: Cache Tiling"}
+While element-wise operations like addition are **Memory-Bound** (hardware sits idle waiting for data from RAM), Matrix Multiplication is heavily **Compute-Bound** (O(n³) math for O(n²) bytes). A naive nested `for` loop constantly evicts data from the ultra-fast L1 cache back to slow main memory. Optimized libraries like `np.matmul` (which calls BLAS) use *Cache Tiling*—breaking matrices into tiny blocks that fit perfectly into the L1 cache, keeping the ALUs fed without waiting for RAM.
+:::
+
 ### Shape Manipulation
 
 Shape manipulation operations change how data is interpreted without changing the values themselves. Understanding when data is copied versus viewed is crucial for both correctness and performance.

--- a/tinytorch/requirements.txt
+++ b/tinytorch/requirements.txt
@@ -39,7 +39,7 @@ nbformat>=5.10.0
 # Jupyter for interactive development
 jupyter>=1.1.1
 jupyterlab>=4.2.0
-ipykernel>=6.31.0
+ipykernel>=7.2.0
 nbdev>=2.3.0
 # Code quality tools
 # black>=24.0.0

--- a/tinytorch/vscode-ext/package-lock.json
+++ b/tinytorch/vscode-ext/package-lock.json
@@ -8,22 +8,22 @@
       "name": "tinytorch-workbench",
       "version": "0.1.0",
       "devDependencies": {
-        "@types/node": "^20.0.0",
+        "@types/node": "^25.6.0",
         "@types/vscode": "^1.116.0",
-        "typescript": "^5.3.0"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "vscode": "^1.85.0"
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.33",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
-      "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/vscode": {
@@ -34,9 +34,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -48,9 +48,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
       "license": "MIT"
     }

--- a/tinytorch/vscode-ext/package.json
+++ b/tinytorch/vscode-ext/package.json
@@ -20,8 +20,8 @@
   },
   "devDependencies": {
     "@types/vscode": "^1.116.0",
-    "@types/node": "^20.0.0",
-    "typescript": "^5.3.0"
+    "@types/node": "^25.6.0",
+    "typescript": "^6.0.3"
   },
   "contributes": {
     "viewsContainers": {

--- a/tinytorch/vscode-ext/tsconfig.json
+++ b/tinytorch/vscode-ext/tsconfig.json
@@ -10,7 +10,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["node", "vscode"]
   },
   "exclude": ["node_modules", "out"]
 }


### PR DESCRIPTION
## Summary

Resolves 9 stale Dependabot PRs whose package-lock conflicts blocked auto-rebase. Single consolidated bump across all vscode-ext packages plus TinyTorch Python deps, verified to compile clean.

## Bumps

**VSCode extensions (5 packages):**
- \`typescript\` \`^5.3.0\` → \`^6.0.3\`
- \`@types/node\` \`^20.0.0\` → \`^25.6.0\`
- Lockfiles regenerated via \`npm install\`

**TinyTorch:**
- \`ipykernel\` \`>=6.29.0\` → \`>=7.2.0\` across \`pyproject.toml\`, \`requirements.txt\`, \`binder/requirements.txt\`

## TypeScript 6.0 breaking-change fix

TypeScript 6.0 stopped auto-including ambient \`@types/*\` packages under \`node_modules\`. Without an explicit \`types\` field, \`child_process\`, \`fs\`, \`Buffer\`, and the \`vscode\` API fail to resolve. Added \`\"types\": [\"node\", \"vscode\"]\` to all 5 vscode-ext tsconfigs. All 5 extensions now compile clean with \`npx tsc -p ./ --noEmit\`.

## Closes

- #1494 (mlsysim-ext typescript)
- #1497 (mlsysim-ext @types/node)
- #1490 (book-ext typescript)
- #1491 (book-ext @types/node)
- #1479 (labs-ext typescript)
- #1477 (kits-ext typescript)
- #1475 (tinytorch-ext @types/node)
- #1467 (tinytorch-ext typescript)
- #1454 (tinytorch ipykernel)

## Test plan
- [x] Local \`tsc --noEmit\` passes on all 5 extensions
- [ ] CI: Stage 6 Fresh Install + linting pass