### PR TITLE
fix(book/vol2): escape LaTeX underscore bug in inference index entries

### DIFF
--- a/book/quarto/contents/vol2/inference/inference.qmd
+++ b/book/quarto/contents/vol2/inference/inference.qmd
@@ -1906,9 +1906,9 @@ Production serving infrastructure embodies these adaptive principles. The *NVIDI
 
 Triton Inference Server implements adaptive batching with three configurable parameters:
 
-1. **max_batch_size**\index{Max_batch_size}: Upper bound on batch size
-2. **batching_timeout_ms**\index{Batching_timeout_ms}: Maximum time to wait for batch formation
-3. **preferred_batch_size**\index{Preferred_batch_size}: Target batch sizes that align with kernel efficiency
+1. **max_batch_size**\index{Batching!max batch size}: Upper bound on batch size
+2. **batching_timeout_ms**\index{Batching!timeout parameter}: Maximum time to wait for batch formation
+3. **preferred_batch_size**\index{Batching!preferred batch size}: Target batch sizes that align with kernel efficiency
 
 The scheduler maintains separate queues for each preferred batch size and routes requests to minimize total latency:
 


### PR DESCRIPTION
## Summary

Fixes the current failing Book Validate (Dev) workflow (Vol II PDF Linux build).

LuaLaTeX fails on `\item Batching_timeout_ms` in the generated index, because underscores in `\index{}` keys are treated as subscript in math mode. The Linux PDF pipeline surfaces this; Windows doesn't trip the same path.

**Root cause** (line 1909-1911 of `book/quarto/contents/vol2/inference/inference.qmd`):

```
\index{Max_batch_size}
\index{Batching_timeout_ms}
\index{Preferred_batch_size}
```

**Fix**: move to lowercase subentries under the existing `Batching` main entry, per `.claude/rules/index.md` (Title Case main, lowercase subentries, plain text in keys — no reserved LaTeX chars):

```
\index{Batching!max batch size}
\index{Batching!timeout parameter}
\index{Batching!preferred batch size}
```

This also consolidates three orphan entries under the already-used `Batching` entry for better index navigation.

## Test plan

- [x] Pre-commit hooks pass locally (51 hooks, all green)
- [x] `grep -rn '\\index{[A-Za-z][A-Za-z0-9]*_[A-Za-z]' book/quarto/contents` returns zero matches (no other underscore-in-index entries remain book-wide)
- [ ] Book Validate (Dev) workflow succeeds on this PR