### PR TITLE
fix(tinytorch): LayerNorm gamma/beta missing requires_grad=True

### DIFF
--- a/tinytorch/src/13_transformers/13_transformers.py
+++ b/tinytorch/src/13_transformers/13_transformers.py
@@ -532,8 +532,8 @@ class LayerNorm:
         self.eps = eps
 
         # Learnable parameters: scale and shift
-        self.gamma = Tensor(np.ones(normalized_shape))  # Scale parameter
-        self.beta = Tensor(np.zeros(normalized_shape))  # Shift parameter
+        self.gamma = Tensor(np.ones(normalized_shape), requires_grad=True)  # Scale parameter
+        self.beta = Tensor(np.zeros(normalized_shape), requires_grad=True)  # Shift parameter
         ### END SOLUTION
 
     def forward(self, x):

--- a/tinytorch/tests/13_transformers/test_transformer_gradient_flow.py
+++ b/tinytorch/tests/13_transformers/test_transformer_gradient_flow.py
@@ -67,10 +67,6 @@ def test_layernorm_gradient_flow():
     # Create LayerNorm
     ln = LayerNorm(embed_dim)
 
-    # Enable gradient tracking on parameters
-    for param in ln.parameters():
-        param.requires_grad = True
-
     # Forward pass
     x = Tensor(rng.standard_normal((batch_size, seq_len, embed_dim)))
     output = ln.forward(x)


### PR DESCRIPTION
## What

`LayerNorm.__init__` creates `gamma` and `beta` as plain `Tensor(np.ones(n))` and `Tensor(np.zeros(n))` -- no `requires_grad` flag. After `enable_autograd()` patches `Tensor.__init__`, the default is `requires_grad=False`.

`_LayerNormBackward.apply()` guards gradient computation on `beta.requires_grad` and `gamma.requires_grad` (lines 475, 482). Since both are `False`, `grad_gamma` and `grad_beta` are always `None` -- LayerNorm silently never learns its scale and shift parameters during training.

## Why it was hidden

`test_layernorm_gradient_flow()` worked around the bug by manually setting `param.requires_grad = True` after construction:

```python
for param in ln.parameters():
    param.requires_grad = True  # workaround masking the bug
```

This meant the test passed but the actual source code was still broken for any real training run that didn't manually patch the parameters.

## Fix

Pass `requires_grad=True` at construction in `LayerNorm.__init__`:

```python
self.gamma = Tensor(np.ones(normalized_shape), requires_grad=True)
self.beta = Tensor(np.zeros(normalized_shape), requires_grad=True)
```

Also removes the manual workaround from `test_layernorm_gradient_flow()` so the test now validates the source code directly.

## Verification

The backward math in `_LayerNormBackward.apply()` is correct -- the only thing missing was the flag that gates it. With `requires_grad=True` set at construction, `grad_gamma` and `grad_beta` are computed and populated on every backward pass.