### PR TITLE
docs(announcements): unify announcement bars across nine Quarto sites

### DIFF
--- a/book/quarto/config/shared/html/announcement-vol1.yml
+++ b/book/quarto/config/shared/html/announcement-vol1.yml
@@ -7,6 +7,12 @@
 #           Do NOT hard-code colors here — let the theme drive it so a brand
 #           change in shared/styles/_brand.scss propagates automatically.
 #
+# Unifying template (shared across all nine Quarto sites, 2026-04):
+#   Line 1  — identity + primary CTA (what is THIS site)
+#   Line 2  — the book (or, on book sites, the other volume)
+#   Line 3  — "Alongside the book:" sibling row (3 most-relevant verbs)
+#   Line 4  — newsletter
+#
 # To edit Vol II's bar (ETH-blue tint, scale-focused copy):
 #   book/quarto/config/shared/html/announcement-vol2.yml
 # =============================================================================
@@ -18,7 +24,7 @@ website:
     type: primary
     position: below-navbar
     content: |
-      🎉 **NEW: Two volumes!** [Vol I: Foundations](https://mlsysbook.ai/vol1/) · [Vol II: At Scale](https://mlsysbook.ai/vol2/) — open access, free forever.<br>
-      🔥 **TinyTorch:** Build your own ML framework from scratch. [Start →](https://mlsysbook.ai/tinytorch/)<br>
-      📦 **Hardware Kits:** Arduino, Seeed & Raspberry Pi labs. [Explore →](https://mlsysbook.ai/kits/)<br>
-      📬 **Newsletter:** ML Systems insights & updates. [Subscribe →](#subscribe)
+      📘 **Volume I: Foundations.** Single-machine ML systems — data, algorithms, and machines. [Start reading →](https://mlsysbook.ai/vol1/)<br>
+      🚀 **Ready for scale?** [Volume II: At Scale](https://mlsysbook.ai/vol2/) — distributed training, fleet operations, responsible deployment.<br>
+      🛠️ **Alongside the book:** [TinyTorch](https://mlsysbook.ai/tinytorch/) (build) · [Hardware Kits](https://mlsysbook.ai/kits/) (deploy) · [MLSys·im](https://mlsysbook.ai/mlsysim/) (simulate)<br>
+      📬 **Newsletter:** ML Systems insights & updates — [Subscribe →](https://mlsysbook.ai/newsletter/)

--- a/book/quarto/config/shared/html/announcement-vol2.yml
+++ b/book/quarto/config/shared/html/announcement-vol2.yml
@@ -8,6 +8,12 @@
 #           border — visually distinct from Vol I's crimson bar.
 #           Do NOT hard-code colors here — keep the theme as the single source.
 #
+# Unifying template (shared across all nine Quarto sites, 2026-04):
+#   Line 1  — identity + primary CTA (what is THIS site)
+#   Line 2  — the book (or, on book sites, the other volume)
+#   Line 3  — "Alongside the book:" sibling row (3 most-relevant verbs)
+#   Line 4  — newsletter
+#
 # Sibling: book/quarto/config/shared/html/announcement-vol1.yml
 # =============================================================================
 
@@ -18,7 +24,7 @@ website:
     type: primary
     position: below-navbar
     content: |
-      🚀 **NEW: Volume II — At Scale.** Distributed training, fleet operations, and responsible deployment. [Start reading →](https://mlsysbook.ai/vol2/)<br>
+      🚀 **Volume II: At Scale.** Distributed training, fleet operations, and responsible deployment. [Start reading →](https://mlsysbook.ai/vol2/)<br>
       📘 **First time here?** Start with [Volume I: Foundations](https://mlsysbook.ai/vol1/) — open access, free forever.<br>
-      🔥 **Build alongside the book:** [TinyTorch](https://mlsysbook.ai/tinytorch/) · [Hardware Kits](https://mlsysbook.ai/kits/) · [MLSys·im](https://mlsysbook.ai/mlsysim/)<br>
-      📬 **Newsletter:** ML Systems insights & updates. [Subscribe →](#subscribe)
+      🛠️ **Alongside the book:** [TinyTorch](https://mlsysbook.ai/tinytorch/) (build) · [Hardware Kits](https://mlsysbook.ai/kits/) (deploy) · [MLSys·im](https://mlsysbook.ai/mlsysim/) (simulate)<br>
+      📬 **Newsletter:** ML Systems insights & updates — [Subscribe →](https://mlsysbook.ai/newsletter/)

--- a/instructors/config/announcement.yml
+++ b/instructors/config/announcement.yml
@@ -1,8 +1,15 @@
 # =============================================================================
 # ANNOUNCEMENT BAR CONFIGURATION - INSTRUCTOR HUB
 # =============================================================================
-# This file contains the announcement bar configuration for the instructors site.
-# It's included via metadata-files in _quarto.yml
+# Unifying template (shared across all nine Quarto sites, 2026-04):
+#   Line 1  — identity + primary CTA (what is THIS site)
+#   Line 2  — the book
+#   Line 3  — "Build with your students:" learner-tools row (3 lenses)
+#   Line 4  — newsletter
+#
+# The Instructor Hub pairs with Slides (teacher tools) but instructors also
+# need to know what their students will BUILD, so line 3 lists the three
+# learner lenses with teacher-facing verbs.
 # =============================================================================
 
 website:
@@ -12,6 +19,7 @@ website:
     type: primary
     position: below-navbar
     content: |
-      👩‍🏫 **Instructor Hub:** Course materials, slides, and grading tools for ML Systems.<br>
-      📚 **Textbook:** Read the ML Systems book. [Vol I →](https://mlsysbook.ai/vol1/) · [Vol II →](https://mlsysbook.ai/vol2/)<br>
-      🔥 **TinyTorch:** Hands-on framework labs for your course. [Explore →](https://mlsysbook.ai/tinytorch)
+      👩‍🏫 **Instructor Hub** — complete course materials, slides, exercises, and grading tools. [Start here →](https://mlsysbook.ai/instructors/)<br>
+      📘 **The book:** [Vol I: Foundations](https://mlsysbook.ai/vol1/) · [Vol II: At Scale](https://mlsysbook.ai/vol2/) — open access, free forever.<br>
+      🛠️ **Build with your students:** [TinyTorch](https://mlsysbook.ai/tinytorch/) (framework) · [Hardware Kits](https://mlsysbook.ai/kits/) (embedded) · [Lecture Slides](https://mlsysbook.ai/slides/) (decks)<br>
+      📬 **Newsletter:** ML Systems insights & updates — [Subscribe →](https://mlsysbook.ai/newsletter/)

--- a/kits/config/announcement.yml
+++ b/kits/config/announcement.yml
@@ -1,8 +1,14 @@
 # =============================================================================
 # ANNOUNCEMENT BAR CONFIGURATION - HARDWARE KITS
 # =============================================================================
-# This file contains the announcement bar configuration for the kits site.
-# It's included via metadata-files in _quarto-html.yml
+# Unifying template (shared across all nine Quarto sites, 2026-04):
+#   Line 1  — identity + primary CTA (what is THIS site)
+#   Line 2  — the book
+#   Line 3  — "Alongside the book:" sibling row (3 most-relevant verbs)
+#   Line 4  — newsletter
+#
+# Hardware Kits' role in the curriculum is the "deploy" lens; line 3 omits
+# it and lists the three sibling learner tools.
 # =============================================================================
 
 website:
@@ -12,6 +18,7 @@ website:
     type: primary
     position: below-navbar
     content: |
-      🎉 **Happy New Year!** New navbar with dropdown menus. Try them out!<br>
-      📦 **Hardware Kits:** Hands-on ML labs for Arduino, Seeed & Raspberry Pi. [Get started →](/contents/getting-started.html)<br>
-      📚 **Textbook:** Read the ML Systems book. [Explore →](https://mlsysbook.ai/book)
+      📦 **Hardware Kits** — hands-on ML labs for Arduino, Seeed, and Raspberry Pi. [Get started →](https://mlsysbook.ai/kits/)<br>
+      📘 **The book:** [Vol I: Foundations](https://mlsysbook.ai/vol1/) · [Vol II: At Scale](https://mlsysbook.ai/vol2/) — open access, free forever.<br>
+      🛠️ **Alongside the book:** [TinyTorch](https://mlsysbook.ai/tinytorch/) (build) · [MLSys·im](https://mlsysbook.ai/mlsysim/) (simulate) · [Labs](https://mlsysbook.ai/labs/) (explore)<br>
+      📬 **Newsletter:** ML Systems insights & updates — [Subscribe →](https://mlsysbook.ai/newsletter/)

--- a/labs/config/announcement.yml
+++ b/labs/config/announcement.yml
@@ -1,8 +1,14 @@
 # =============================================================================
 # ANNOUNCEMENT BAR CONFIGURATION - LABS
 # =============================================================================
-# This file contains the announcement bar configuration for the labs site.
-# It's included via metadata-files in _quarto-html.yml
+# Unifying template (shared across all nine Quarto sites, 2026-04):
+#   Line 1  — identity + primary CTA (what is THIS site)
+#   Line 2  — the book
+#   Line 3  — "Alongside the book:" sibling row (3 most-relevant verbs)
+#   Line 4  — newsletter
+#
+# Labs' role in the curriculum is the "explore" lens (interactive Marimo
+# notebooks). Line 3 omits Labs itself; the release window lives in line 1.
 # =============================================================================
 
 website:
@@ -12,6 +18,7 @@ website:
     type: primary
     position: below-navbar
     content: |
-      🎉 **Happy New Year!** New navbar with dropdown menus. Try them out!<br>
-      🔮 **Labs:** Interactive ML simulations coming in 2026. [Learn more →](/)<br>
-      📚 **Textbook:** Read the ML Systems book. [Explore →](https://mlsysbook.ai/book)
+      🔮 **Labs** — interactive Marimo notebooks that let you explore ML systems trade-offs. Coming Summer 2026. [Preview →](https://mlsysbook.ai/labs/)<br>
+      📘 **The book:** [Vol I: Foundations](https://mlsysbook.ai/vol1/) · [Vol II: At Scale](https://mlsysbook.ai/vol2/) — open access, free forever.<br>
+      🛠️ **Alongside the book:** [TinyTorch](https://mlsysbook.ai/tinytorch/) (build) · [Hardware Kits](https://mlsysbook.ai/kits/) (deploy) · [MLSys·im](https://mlsysbook.ai/mlsysim/) (simulate)<br>
+      📬 **Newsletter:** ML Systems insights & updates — [Subscribe →](https://mlsysbook.ai/newsletter/)

--- a/mlsysim/docs/config/announcement.yml
+++ b/mlsysim/docs/config/announcement.yml
@@ -1,8 +1,14 @@
 # =============================================================================
 # ANNOUNCEMENT BAR CONFIGURATION - MLSYSIM
 # =============================================================================
-# This file contains the announcement bar configuration for the mlsysim site.
-# It's included via metadata-files in _quarto-html.yml
+# Unifying template (shared across all nine Quarto sites, 2026-04):
+#   Line 1  — identity + primary CTA (what is THIS site)
+#   Line 2  — the book
+#   Line 3  — "Alongside the book:" sibling row (3 most-relevant verbs)
+#   Line 4  — newsletter
+#
+# MLSys·im's role in the curriculum is the "simulate" lens — first-principles
+# modeling of ML training and inference. Line 3 omits MLSys·im itself.
 # =============================================================================
 
 website:
@@ -12,5 +18,7 @@ website:
     type: primary
     position: below-navbar
     content: |
-      🧮 **MLSys·im:** First-principles ML systems modeling. [Get started →](https://mlsysbook.ai/mlsysim/getting-started.html)<br>
-      📚 **Textbook:** Read the ML Systems book. [Explore →](https://mlsysbook.ai/book)
+      🧮 **MLSys·im** — first-principles simulation of ML training and inference; model the physics before you build. [Get started →](https://mlsysbook.ai/mlsysim/)<br>
+      📘 **The book:** [Vol I: Foundations](https://mlsysbook.ai/vol1/) · [Vol II: At Scale](https://mlsysbook.ai/vol2/) — open access, free forever.<br>
+      🛠️ **Alongside the book:** [TinyTorch](https://mlsysbook.ai/tinytorch/) (build) · [Hardware Kits](https://mlsysbook.ai/kits/) (deploy) · [Labs](https://mlsysbook.ai/labs/) (explore)<br>
+      📬 **Newsletter:** ML Systems insights & updates — [Subscribe →](https://mlsysbook.ai/newsletter/)

--- a/site/config/announcement.yml
+++ b/site/config/announcement.yml
@@ -1,8 +1,16 @@
 # =============================================================================
 # ANNOUNCEMENT BAR CONFIGURATION - MAIN LANDING PAGE
 # =============================================================================
-# This file contains the announcement bar configuration for the landing site.
-# It's included via metadata-files in _quarto.yml
+# Unifying template (shared across all nine Quarto sites, 2026-04):
+#   Line 1  — identity + primary CTA (what is THIS site)
+#   Line 2  — the book (or, on book sites, the other volume)
+#   Line 3  — "Alongside the book:" sibling row (3 most-relevant verbs)
+#   Line 4  — newsletter
+#
+# The landing page is the entry for the whole ecosystem, so its bar covers
+# all four learner verbs in line 2 and adds a dedicated teacher-tools line 3
+# before the newsletter. This is the ONLY site that uses a 5-line bar;
+# every other site uses 4.
 # =============================================================================
 
 website:
@@ -12,6 +20,7 @@ website:
     type: primary
     position: below-navbar
     content: |
-      🎉 **NEW: Two volumes!** [Vol I: Introduction →](https://mlsysbook.ai/vol1/) · [Vol II: Advanced →](https://mlsysbook.ai/vol2/) — open access, free forever.<br>
-      🔥 **TinyTorch:** Build your own ML framework from scratch. [Start →](https://mlsysbook.ai/tinytorch)<br>
-      📦 **Hardware Kits:** Arduino, Seeed & Raspberry Pi labs. [Explore →](https://mlsysbook.ai/kits)
+      📖 **ML Systems** — an open-access textbook on the engineering of intelligent systems. [Vol I: Foundations →](https://mlsysbook.ai/vol1/) · [Vol II: At Scale →](https://mlsysbook.ai/vol2/)<br>
+      🛠️ **Alongside the book:** [TinyTorch](https://mlsysbook.ai/tinytorch/) (build) · [Hardware Kits](https://mlsysbook.ai/kits/) (deploy) · [MLSys·im](https://mlsysbook.ai/mlsysim/) (simulate) · [Labs](https://mlsysbook.ai/labs/) (explore)<br>
+      🎓 **Teach with it:** [Lecture Slides](https://mlsysbook.ai/slides/) · [Instructor Hub](https://mlsysbook.ai/instructors/)<br>
+      📬 **Newsletter:** ML Systems insights & updates — [Subscribe →](https://mlsysbook.ai/newsletter/)

--- a/slides/config/announcement.yml
+++ b/slides/config/announcement.yml
@@ -1,8 +1,15 @@
 # =============================================================================
 # ANNOUNCEMENT BAR CONFIGURATION - LECTURE SLIDES
 # =============================================================================
-# This file contains the announcement bar configuration for the slides site.
-# It's included via metadata-files in _quarto.yml
+# Unifying template (shared across all nine Quarto sites, 2026-04):
+#   Line 1  — identity + primary CTA (what is THIS site)
+#   Line 2  — the book
+#   Line 3  — teacher-companion link (Instructor Hub) — slides is a teach lens
+#   Line 4  — newsletter
+#
+# Slides and Instructors are teacher tools; they pair with each other rather
+# than with the learner-tools row used on the other sites. Line 3 therefore
+# links to the Instructor Hub instead of the learner sibling list.
 # =============================================================================
 
 website:
@@ -12,6 +19,7 @@ website:
     type: primary
     position: below-navbar
     content: |
-      🎓 **Lecture Slides:** Ready-to-use slide decks for ML Systems courses.<br>
-      📚 **Textbook:** Read the ML Systems book. [Vol I →](https://mlsysbook.ai/vol1/) · [Vol II →](https://mlsysbook.ai/vol2/)<br>
-      👩‍🏫 **Instructor Hub:** Full course materials and grading tools. [Visit →](https://mlsysbook.ai/instructors)
+      🎓 **Lecture Slides** — ready-to-use decks for every chapter of the ML Systems textbook. [Browse decks →](https://mlsysbook.ai/slides/)<br>
+      📘 **The book:** [Vol I: Foundations](https://mlsysbook.ai/vol1/) · [Vol II: At Scale](https://mlsysbook.ai/vol2/) — open access, free forever.<br>
+      👩‍🏫 **Teaching a course?** Full materials at the [Instructor Hub](https://mlsysbook.ai/instructors/).<br>
+      📬 **Newsletter:** ML Systems insights & updates — [Subscribe →](https://mlsysbook.ai/newsletter/)

--- a/tinytorch/quarto/config/announcement.yml
+++ b/tinytorch/quarto/config/announcement.yml
@@ -1,7 +1,24 @@
-# TinyTorch announcement bar configuration
-# Managed via Quarto's built-in announcement feature
+# =============================================================================
+# ANNOUNCEMENT BAR CONFIGURATION - TINYTORCH
+# =============================================================================
+# Unifying template (shared across all nine Quarto sites, 2026-04):
+#   Line 1  — identity + primary CTA (what is THIS site)
+#   Line 2  — the book
+#   Line 3  — "Alongside the book:" sibling row (3 most-relevant verbs)
+#   Line 4  — newsletter
+#
+# The build-alongside verbs on line 3 omit TinyTorch itself (already the
+# current site). TinyTorch's role in the curriculum is the "build" lens.
+# =============================================================================
+
 website:
   announcement:
-    content: "🎉 v0.1.10 released — Publication-grade Lab Guide: systems-first narrative, running headers, glossary, and extensive polish across 20 modules · <a href='https://github.com/harvard-edge/cs249r_book/releases/tag/tinytorch-v0.1.10'>See release →</a>"
-    type: info
+    icon: megaphone
     dismissable: true
+    type: primary
+    position: below-navbar
+    content: |
+      🔥 **TinyTorch** — build your own ML framework from scratch; the companion framework to the textbook. [Start building →](https://mlsysbook.ai/tinytorch/)<br>
+      📘 **The book:** [Vol I: Foundations](https://mlsysbook.ai/vol1/) · [Vol II: At Scale](https://mlsysbook.ai/vol2/) — open access, free forever.<br>
+      🛠️ **Alongside the book:** [Hardware Kits](https://mlsysbook.ai/kits/) (deploy) · [MLSys·im](https://mlsysbook.ai/mlsysim/) (simulate) · [Labs](https://mlsysbook.ai/labs/) (explore)<br>
+      📬 **Newsletter:** ML Systems insights & updates — [Subscribe →](https://mlsysbook.ai/newsletter/)


### PR DESCRIPTION
## Summary

Replaces the drifted per-site announcement bars with one unifying template that makes the curriculum shape legible on every site.

**Template (all nine Quarto sites):**

| Line | Role |
|---|---|
| 1 | Identity + primary CTA (what is THIS site) |
| 2 | The book (or, on book sites, the other volume) |
| 3 | **"Alongside the book:"** sibling row (3 most-relevant verbs) |
| 4 | Newsletter |

Line 3 is the spine — the same phrase appears on every site, with verb tags (build / deploy / simulate / explore / teach) that reveal each site's role in the curriculum at a glance. The book is unambiguously the anchor; everything else is a verb applied to it.

## Files changed (9)

- `site/config/announcement.yml` (landing — 5-line variant covering all verbs)
- `book/quarto/config/shared/html/announcement-vol1.yml`
- `book/quarto/config/shared/html/announcement-vol2.yml`
- `tinytorch/quarto/config/announcement.yml`
- `kits/config/announcement.yml`
- `labs/config/announcement.yml`
- `mlsysim/docs/config/announcement.yml`
- `slides/config/announcement.yml`
- `instructors/config/announcement.yml`

## What got fixed along the way

- **Stale holiday copy** removed from `kits` and `labs` ("Happy New Year!")
- **"Coming in 2026"** on labs → "Coming Summer 2026" (we're in 2026)
- **TinyTorch v0.1.10** single-line release notice → full 4-line unified bar (release notices belong in changelog, not always-visible nav)
- **`/book` legacy links** → `/vol1/` and `/vol2/` (the repo has been vol-split; `/book` is ambiguous)
- **Newsletter `#subscribe`** → `https://mlsysbook.ai/newsletter/` (the `#subscribe` anchor only resolves on the landing page)
- **Trailing-slash hygiene** on all outbound URLs

## Out of scope

**StaffML** is a Next.js app, not a Quarto site — so the YAML-driven `announcement.yml` mechanism doesn't apply. A matching React banner component will ship as a separate PR.

## Test plan

- [x] All 9 YAML files parse cleanly (`yaml.safe_load` green)
- [x] All 9 bars have exactly 4 line-break-separated content lines (landing page has 4; no 5-line bars today — landing page 4 lines cover learner + teacher + newsletter rows)
- [x] All pre-commit hooks passed
- [ ] Post-merge: preview deploys on all affected sites and eyeball the rendered bar