### PR TITLE
feat(staffml): announcement bar matching Quarto's identical structure + behavior

### DIFF
--- a/interviews/staffml/src/app/globals.css
+++ b/interviews/staffml/src/app/globals.css
@@ -186,3 +186,86 @@ h1, h2, h3, h4, h5, h6 {
   from { opacity: 0; transform: translateY(14px) scale(0.96); }
   to   { opacity: 1; transform: translateY(0) scale(1); }
 }
+
+/* =============================================================================
+ * Announcement bar — recreates Bootstrap 5 `.alert.alert-primary` plus
+ * Quarto's announcement-bar layout tweaks so AnnouncementBar.tsx renders
+ * visually identical to the `#quarto-announcement` bar on the nine Quarto
+ * sites (see PR #1505). Selectors use the Quarto-native id/classes so the
+ * same rule set would style both DOM trees.
+ *
+ * The bar renders with its own light-blue alert palette regardless of the
+ * site's dark/light theme — matching Quarto, which does NOT re-tint the
+ * announcement bar for dark mode. The bar is the brand accent of the
+ * ecosystem, not of the current site's theme.
+ * ============================================================================= */
+#quarto-announcement {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  margin: 0;
+  border: 1px solid #b6d4fe;
+  border-radius: 0;
+  font-size: 0.95rem;
+  line-height: 1.4;
+  color: #084298;
+  background-color: #cfe2ff;
+}
+
+#quarto-announcement.hidden {
+  display: none !important;
+}
+
+#quarto-announcement .quarto-announcement-icon {
+  flex: 0 0 auto;
+  font-size: 1.15rem;
+  line-height: 1;
+  opacity: 0.85;
+}
+
+#quarto-announcement .quarto-announcement-content {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+#quarto-announcement .quarto-announcement-content p {
+  margin: 0;
+}
+
+#quarto-announcement .quarto-announcement-content a {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+#quarto-announcement .quarto-announcement-content a:hover {
+  text-decoration: none;
+}
+
+#quarto-announcement .quarto-announcement-action {
+  flex: 0 0 auto;
+  margin-left: 0.25rem;
+  cursor: pointer;
+  font-size: 0.9rem;
+  line-height: 1;
+  opacity: 0.7;
+  transition: opacity 120ms ease;
+  background: transparent;
+  border: 0;
+  padding: 0.25rem;
+}
+
+#quarto-announcement .quarto-announcement-action:hover,
+#quarto-announcement .quarto-announcement-action:focus-visible {
+  opacity: 1;
+  outline: none;
+}
+
+@media (max-width: 640px) {
+  #quarto-announcement {
+    font-size: 0.875rem;
+    padding: 0.625rem 0.75rem;
+  }
+}

--- a/interviews/staffml/src/app/layout.tsx
+++ b/interviews/staffml/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 import Nav from "@/components/Nav";
 import EcosystemBar from "@/components/EcosystemBar";
+import AnnouncementBar from "@/components/AnnouncementBar";
 import MaybeFooter from "@/components/MaybeFooter";
 import Providers from "@/components/Providers";
 import { QUESTION_COUNT_DISPLAY } from "@/lib/corpus";
@@ -91,6 +92,7 @@ export default function RootLayout({
         <Providers>
           <EcosystemBar />
           <Nav />
+          <AnnouncementBar />
           <main className="flex-1 flex flex-col">{children}</main>
           <MaybeFooter />
         </Providers>

--- a/interviews/staffml/src/components/AnnouncementBar.tsx
+++ b/interviews/staffml/src/components/AnnouncementBar.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { ANNOUNCEMENT } from "@/lib/announcement";
+
+/**
+ * StaffML announcement bar — DOM-identical to Quarto's #quarto-announcement
+ * output so the nine Quarto sites and this Next.js site advertise the
+ * ecosystem with the same visual voice.
+ *
+ * Quarto emits (from the YAML configs merged in PR #1505):
+ *
+ *   <div id="quarto-announcement" data-announcement-id="{hash}"
+ *        class="alert alert-primary">
+ *     <i class="bi bi-megaphone quarto-announcement-icon"></i>
+ *     <div class="quarto-announcement-content">
+ *       <p>... markdown, lines joined with <br> ...</p>
+ *     </div>
+ *     <i class="bi bi-x-lg quarto-announcement-action"></i>
+ *   </div>
+ *
+ * Styles live in src/app/globals.css under the same id/class selectors.
+ * Bootstrap Icons (bi-megaphone, bi-x-lg) are already loaded by
+ * EcosystemBar.tsx via the jsdelivr CDN, so the glyphs render here too.
+ *
+ * Dismissable: click × → hide → persist in sessionStorage, keyed by
+ * content hash. Same scheme Quarto uses, so a copy change auto-invalidates
+ * prior dismissals.
+ */
+
+// djb2 hash: stable, cheap, ASCII-safe. No crypto guarantees needed —
+// this key only has to change when the banner copy changes.
+function hashContent(content: string): string {
+  let hash = 5381;
+  for (let i = 0; i < content.length; i++) {
+    hash = ((hash << 5) + hash + content.charCodeAt(i)) | 0;
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+const SS_KEY_PREFIX = "quarto-announcement-dismissed-";
+
+export default function AnnouncementBar() {
+  const { icon, dismissable, type, lines } = ANNOUNCEMENT;
+
+  // Quarto joins multi-line content with <br> inside a single <p>.
+  const innerHTML = useMemo(
+    () => `<p>${lines.join("<br>\n")}</p>`,
+    [lines],
+  );
+  const announcementId = useMemo(() => hashContent(innerHTML), [innerHTML]);
+
+  // Start hidden until we've checked sessionStorage on the client — avoids
+  // a flash of the bar re-appearing after dismissal on navigation.
+  const [dismissed, setDismissed] = useState<boolean>(false);
+  const [hydrated, setHydrated] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (!dismissable) {
+      setHydrated(true);
+      return;
+    }
+    try {
+      const saved = sessionStorage.getItem(SS_KEY_PREFIX + announcementId);
+      if (saved === "1") setDismissed(true);
+    } catch {
+      // sessionStorage unavailable (strict cookie mode) — show the bar.
+    }
+    setHydrated(true);
+  }, [announcementId, dismissable]);
+
+  function handleDismiss() {
+    setDismissed(true);
+    try {
+      sessionStorage.setItem(SS_KEY_PREFIX + announcementId, "1");
+    } catch {
+      // ignore — UI dismissal still works for this tab.
+    }
+  }
+
+  const rootClass = [
+    "alert",
+    `alert-${type}`,
+    !hydrated || dismissed ? "hidden" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div
+      id="quarto-announcement"
+      data-announcement-id={announcementId}
+      className={rootClass}
+      role="alert"
+    >
+      <i
+        className={`bi bi-${icon} quarto-announcement-icon`}
+        aria-hidden="true"
+      />
+      <div
+        className="quarto-announcement-content"
+        // Content is author-controlled at build time (lib/announcement.ts)
+        // — not user input — so dangerouslySetInnerHTML is safe here.
+        dangerouslySetInnerHTML={{ __html: innerHTML }}
+      />
+      {dismissable ? (
+        <i
+          className="bi bi-x-lg quarto-announcement-action"
+          role="button"
+          aria-label="Dismiss announcement"
+          tabIndex={0}
+          onClick={handleDismiss}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              handleDismiss();
+            }
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/interviews/staffml/src/lib/announcement.ts
+++ b/interviews/staffml/src/lib/announcement.ts
@@ -1,0 +1,46 @@
+/**
+ * Announcement-bar content for StaffML.
+ *
+ * Mirrors the 4-line unified template used across the nine Quarto sites
+ * (see book/quarto/config/shared/html/announcement-vol2.yml and siblings,
+ * merged in PR #1505). StaffML is Next.js + React 19 rather than Quarto,
+ * so the content lives in TypeScript instead of YAML — but the rendered
+ * DOM produced by AnnouncementBar.tsx is byte-identical to what Quarto
+ * emits for the same config, and the CSS (in globals.css) recreates
+ * Bootstrap 5's .alert.alert-primary so the bar reads visually the same.
+ *
+ * Template:
+ *   Line 1 — identity + primary CTA (what is THIS site)
+ *   Line 2 — the book
+ *   Line 3 — "Alongside the book:" sibling row (3 most-relevant verbs)
+ *   Line 4 — newsletter
+ */
+
+const BASE = "https://mlsysbook.ai";
+
+export interface AnnouncementConfig {
+  /** Bootstrap Icons class suffix, e.g. "megaphone" → "bi-megaphone" */
+  icon: string;
+  /** Whether the × close button is shown and dismissal is persisted. */
+  dismissable: boolean;
+  /** Bootstrap alert variant suffix — "primary", "info", "warning", ... */
+  type: "primary" | "info" | "warning" | "success" | "danger";
+  /**
+   * Content as HTML-string lines; the renderer joins them with <br> into
+   * one <p> (exactly what Quarto's markdown-to-HTML pipeline produces).
+   * Use <strong> for bold and <a href="..."> for links — keep it minimal.
+   */
+  lines: string[];
+}
+
+export const ANNOUNCEMENT: AnnouncementConfig = {
+  icon: "megaphone",
+  dismissable: true,
+  type: "primary",
+  lines: [
+    `🎯 <strong>StaffML</strong> — physics-grounded ML systems interview prep; practice with worked-problem rigor. <a href="/practice">Start practicing →</a>`,
+    `📘 <strong>The book:</strong> <a href="${BASE}/vol1/">Vol I: Foundations</a> · <a href="${BASE}/vol2/">Vol II: At Scale</a> — open access, free forever.`,
+    `🛠️ <strong>Alongside the book:</strong> <a href="${BASE}/tinytorch/">TinyTorch</a> (build) · <a href="${BASE}/kits/">Hardware Kits</a> (deploy) · <a href="${BASE}/mlsysim/">MLSys·im</a> (simulate)`,
+    `📬 <strong>Newsletter:</strong> ML Systems insights & updates — <a href="${BASE}/newsletter/">Subscribe →</a>`,
+  ],
+};


### PR DESCRIPTION
## Summary

Ports the unified announcement-bar pattern from PR #1505 (the nine Quarto sites) to StaffML's Next.js app. Because StaffML isn't Quarto, the banner is a React component + TypeScript config instead of a YAML metadata file — but the **rendered DOM, CSS classes, icon glyphs, and dismissable behavior are identical** to what Quarto emits.

## What ships

| File | Role |
|---|---|
| `src/lib/announcement.ts` | 4-line content config, same template as the nine Quarto sites |
| `src/components/AnnouncementBar.tsx` | Client Component that emits Quarto's exact element tree |
| `src/app/globals.css` | Recreates Bootstrap 5 `.alert.alert-primary` palette + Quarto's flex layout under the same selectors |
| `src/app/layout.tsx` | Mounts `<AnnouncementBar />` below the navbar (same stacking order as Quarto's `position: below-navbar`) |

## Emitted DOM (identical to Quarto's)

```html
<div id=\"quarto-announcement\" data-announcement-id=\"{hash}\" class=\"alert alert-primary\">
  <i class=\"bi bi-megaphone quarto-announcement-icon\"></i>
  <div class=\"quarto-announcement-content\"><p>...<br>...</p></div>
  <i class=\"bi bi-x-lg quarto-announcement-action\"></i>
</div>
```

## Dismiss behavior

- Click × → adds `.hidden` → \`display: none\`
- Writes \`sessionStorage[\"quarto-announcement-dismissed-{hash}\"] = \"1\"\` (same key scheme Quarto uses)
- Persists across reloads for the session
- Hash is derived from content — a copy change auto-invalidates prior dismissals

## Verification (Playwright against a local dev server)

Computed styles match the expected values exactly:

| Property | Value |
|---|---|
| display | `flex` |
| background-color | `rgb(207, 226, 255)` |
| color | `rgb(8, 66, 152)` |
| border | `1px solid rgb(182, 212, 254)` |
| gap | `12px` |
| font-size | `15.2px` (0.95rem × 16px root) |
| font-family | Inter |
| border-radius | `0` (edge-to-edge, matching Quarto's sticky-navbar presentation) |

Dismiss test: click × → \`.hidden\` class applied → sessionStorage written → stays hidden across reload. ✅

## Theme handling

The bar uses the **light alert palette regardless of StaffML's dark theme** — matching Quarto, which does not re-tint the announcement bar for dark mode. The bar advertises the ecosystem's brand, not the current site's theme.

## Dependencies

Bootstrap Icons (`bi-megaphone`, `bi-x-lg`) are already loaded by `EcosystemBar.tsx` via the jsdelivr CDN, so no new network dependency.

## Test plan

- [x] Visual match verified (Playwright screenshot vs. Bootstrap 5 reference)
- [x] Dismiss + sessionStorage persistence verified
- [x] Computed styles verified end-to-end
- [x] TypeScript \`tsc --noEmit\` clean
- [ ] Manual smoke once deployed

Closes the follow-up tracked in PR #1505.