### PR TITLE
fix(lab04): remove answer spoilers from prediction prompts in lab_04_data_engr

### DIFF
--- a/labs/vol1/lab_04_data_engr.py
+++ b/labs/vol1/lab_04_data_engr.py
@@ -502,11 +502,12 @@ When $t_{\\text{IO}} \\gg t_{\\text{compute}}$, the GPU starves regardless of it
         items.append(mo.md("""
         ## Data Gravity: Move the Compute, Not the Data
 
-        Moving 50 TB costs $4,000 in egress fees alone -- 20x the compute cost.
+        Moving data across regions is slow and expensive. Use the formulas below
+        to estimate the cost before making your prediction:
 
         ```
-        Transfer time  = Dataset / Bandwidth = 50 TB / 10 Gbps = ~11 hours
-        Egress cost    = 50,000 GB * $0.08/GB = $4,000
+        Transfer time  = Dataset / Bandwidth
+        Egress cost    = Data size (GB) * rate per GB
         ```
         """))
 
@@ -663,15 +664,10 @@ data is cheaper than moving data to compute.
         ## Data Cascades: The 2% Error That Ate 15% Accuracy
 
         Errors at early pipeline stages amplify through downstream stages.
+        Use the formula to estimate the output error before making your prediction:
 
         ```
         error_stage_n = error_0 * amplification_factor^n
-        ```
-
-        A 2% error at ingestion with amplification factor 1.4 over 5 stages:
-
-        ```
-        error = 0.02 * 1.4^5 = 0.02 * 5.38 = 10.8%
         ```
 
         Plus the 4-week detection delay: silent degradation on every request.


### PR DESCRIPTION
Fixes #1417

## Problem

Parts B and C of `labs/vol1/lab_04_data_engr.py` showed the numerical answer directly above the prediction radio button, allowing learners to read the answer before making their prediction:

- **Part B**: The pre-prediction text included `Transfer time = Dataset / Bandwidth = 50 TB / 10 Gbps = ~11 hours` — the exact value of answer option C.
- **Part C**: The pre-prediction text included `error = 0.02 * 1.4^5 = 0.02 * 5.38 = 10.8%` — giving away the ~15% answer.

## Solution

Remove the worked numerical examples from the context shown **before** the prediction radio button in Parts B and C. Replace with formula-only scaffolding so learners apply the formula themselves.

The full worked calculations remain available after the prediction is submitted:
- Interactive calculator (sliders)
- Feedback callout with the correct value
- Math Peek accordion with the derivation

Part A and Part D are not changed — Part A only shows the formula structure (not the numerical GPU utilization), and Part D shows that 99% is insufficient without revealing the required precision level.

## Testing

Visually verified the diff: prediction radio buttons now appear before any numerical answer for Parts B and C. The post-prediction sections are unchanged.