### PR TITLE
fix(staffml/announcement): top-align megaphone icon + gate dismiss on live

### DIFF
--- a/interviews/staffml/src/app/globals.css
+++ b/interviews/staffml/src/app/globals.css
@@ -202,7 +202,11 @@ h1, h2, h3, h4, h5, h6 {
 #quarto-announcement {
   position: relative;
   display: flex;
-  align-items: center;
+  /* flex-start keeps the megaphone icon top-aligned with line 1 of the
+     content; with 3–4 content lines (the common case) align-items: center
+     floats the icon to the middle and reads as a layout bug. Matches the
+     Quarto sibling sites' presentation. */
+  align-items: flex-start;
   gap: 0.75rem;
   padding: 0.75rem 1rem;
   margin: 0;

--- a/interviews/staffml/src/components/AnnouncementBar.tsx
+++ b/interviews/staffml/src/components/AnnouncementBar.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { ANNOUNCEMENT } from "@/lib/announcement";
+import { IS_LIVE_DEPLOY } from "@/lib/env";
 
 /**
  * StaffML announcement bar — DOM-identical to Quarto's #quarto-announcement
@@ -41,7 +42,13 @@ function hashContent(content: string): string {
 const SS_KEY_PREFIX = "quarto-announcement-dismissed-";
 
 export default function AnnouncementBar() {
-  const { icon, dismissable, type, lines } = ANNOUNCEMENT;
+  const { icon, dismissable: configDismissable, type, lines } = ANNOUNCEMENT;
+
+  // Dismiss is gated on the live-deploy flag: on the dev-preview deploy
+  // (harvard-edge.github.io/cs249r_book_dev) the bar is intentionally
+  // persistent so every pageview sees the ecosystem pitch; the live site
+  // respects the author's `dismissable: true` config and offers the ×.
+  const dismissable = configDismissable && IS_LIVE_DEPLOY;
 
   // Quarto joins multi-line content with <br> inside a single <p>.
   const innerHTML = useMemo(

--- a/interviews/staffml/src/lib/env.ts
+++ b/interviews/staffml/src/lib/env.ts
@@ -8,3 +8,15 @@
  */
 export const ECOSYSTEM_BASE =
   process.env.NEXT_PUBLIC_ECOSYSTEM_BASE || "https://mlsysbook.ai";
+
+/**
+ * True iff this build targets the live (production) deploy at mlsysbook.ai.
+ * Derived from ECOSYSTEM_BASE — dev deploys point at harvard-edge.github.io,
+ * so anything else is treated as live.
+ *
+ * Used by AnnouncementBar.tsx to keep the dismiss button off the dev-preview
+ * build: on dev the announcement bar is intentionally persistent so each
+ * pageview sees the ecosystem pitch; on live it becomes dismissable so
+ * returning visitors aren't nagged.
+ */
+export const IS_LIVE_DEPLOY = !/cs249r_book_dev/.test(ECOSYSTEM_BASE);


### PR DESCRIPTION
## Summary

Two follow-ups to the `AnnouncementBar` merged in PR #1506:

1. **CSS**: switch `#quarto-announcement` from `align-items: center` to `align-items: flex-start`. With the 3–4 content lines the bar typically carries, centering floated the megaphone icon to the middle of the bar and read as a layout bug. Now matches the Quarto sibling sites' presentation where the megaphone sits on line 1's baseline.

2. **Dismiss gated on live deploy**: the × is now shown only when `IS_LIVE_DEPLOY` (new boolean in `src/lib/env.ts`) is true. On the dev-preview deploy (`harvard-edge.github.io/cs249r_book_dev`) the bar is intentionally persistent — every pageview during development should see the ecosystem pitch. On live (`mlsysbook.ai`) the bar becomes dismissable so returning visitors aren't nagged. Piggybacks on the existing `NEXT_PUBLIC_ECOSYSTEM_BASE` — no new env var.

## Files

- `interviews/staffml/src/app/globals.css` — one-line CSS change
- `interviews/staffml/src/lib/env.ts` — add `IS_LIVE_DEPLOY` boolean
- `interviews/staffml/src/components/AnnouncementBar.tsx` — consume `IS_LIVE_DEPLOY` to gate dismiss

## Verification (Playwright)

Dev mode (`NEXT_PUBLIC_ECOSYSTEM_BASE=https://harvard-edge.github.io/cs249r_book_dev`):
- `has × action in DOM? false` ✓
- Bar renders with megaphone top-aligned on line 1 ✓

Live mode (default):
- `has × action in DOM? true` ✓
- × sits at top-right, aligned with line 1 ✓
- Click × → `.hidden` class → `sessionStorage["quarto-announcement-dismissed-{hash}"] = "1"` → persists across reload ✓

## Test plan

- [x] TypeScript `tsc --noEmit` clean
- [x] Dev-mode Playwright screenshot: megaphone top-aligned, no ×
- [x] Live-mode Playwright screenshot: megaphone top-aligned, × visible
- [x] Dismiss + persistence still works on live