### PR TITLE
fix(tinytorch/announcement): restore unified ecosystem template

### DIFF
--- a/tinytorch/quarto/config/announcement.yml
+++ b/tinytorch/quarto/config/announcement.yml
@@ -1,7 +1,31 @@
-# TinyTorch announcement bar configuration
-# Managed via Quarto's built-in announcement feature
+# =============================================================================
+# ANNOUNCEMENT BAR CONFIGURATION - TINYTORCH
+# =============================================================================
+# Unifying template (shared across all nine Quarto sites, 2026-04):
+#   Line 1  — identity + primary CTA (what is THIS site)
+#   Line 2  — the book
+#   Line 3  — "Alongside the book:" sibling row (3 most-relevant verbs)
+#   Line 4  — newsletter
+#
+# TinyTorch's role in the curriculum is the "build" lens, so line 3 omits
+# TinyTorch itself and lists the three sibling learner tools.
+#
+# History: this file was briefly reverted to a v0.1.10 release notice by
+# the v0.1.10 publish merge (commit 0009f55a9 on 2026-04-22). Release news
+# belongs in a changelog, not in the always-visible nav bar — restored to
+# the ecosystem template on 2026-04-24. If a future release warrants a
+# top-of-bar mention, add a release_note field to the shared schema so it
+# auto-expires rather than silently replacing the ecosystem message.
+# =============================================================================
+
 website:
   announcement:
-    content: "🎉 v0.1.10 released — v0.1.10 (retry after TINYTORCH_SITE path fix) · <a href='https://github.com/harvard-edge/cs249r_book/releases/tag/tinytorch-v0.1.10'>See release →</a>"
-    type: info
+    icon: megaphone
     dismissable: true
+    type: primary
+    position: below-navbar
+    content: |
+      🔥 **TinyTorch** — build your own ML framework from scratch; the companion framework to the textbook. [Start building →](https://mlsysbook.ai/tinytorch/)<br>
+      📘 **The book:** [Vol I: Foundations](https://mlsysbook.ai/vol1/) · [Vol II: At Scale](https://mlsysbook.ai/vol2/) — open access, free forever.<br>
+      🛠️ **Alongside the book:** [Hardware Kits](https://mlsysbook.ai/kits/) (deploy) · [MLSys·im](https://mlsysbook.ai/mlsysim/) (simulate) · [Labs](https://mlsysbook.ai/labs/) (explore)<br>
+      📬 **Newsletter:** ML Systems insights & updates — [Subscribe →](https://mlsysbook.ai/newsletter/)


### PR DESCRIPTION
## Summary

The TinyTorch announcement bar was reverted during the v0.1.10 publish merge (commit \`0009f55a9\` on 2026-04-22) from the unified 4-line template shipped in PR #1505 back to a single-line release notice:

\`\`\`
🎉 v0.1.10 released — v0.1.10 (retry after TINYTORCH_SITE path fix) · See release →
\`\`\`

Restores to the template used by all eight other Quarto sites (and the StaffML React banner).

## What the bar now says

\`\`\`
🔥 TinyTorch — build your own ML framework from scratch; the companion framework to the textbook. [Start building →]
📘 The book: [Vol I: Foundations] · [Vol II: At Scale] — open access, free forever.
🛠️ Alongside the book: Hardware Kits (deploy) · MLSys·im (simulate) · Labs (explore)
📬 Newsletter: ML Systems insights & updates — [Subscribe →]
\`\`\`

Also:
- \`type: info\` → \`type: primary\` (matches the eight sibling bars' color)
- adds \`icon: megaphone\` + \`position: below-navbar\` to match the shared schema
- file header now documents the reversion so a future release publish doesn't silently overwrite again

## Why not keep a release notice

- Single-line + \`type: info\` breaks visual consistency with the other eight Quarto bars
- "retry after TINYTORCH_SITE path fix" is commit-message-ese, not user-facing copy
- Release news persists long after the release — "v0.1.10" is already stale-sounding and will look abandoned when v0.1.11 ships

If a release ever genuinely needs a top-of-bar mention, the clean way is an optional \`release_note\` field on the shared schema that auto-expires — not overwriting the ecosystem-navigation copy.

## Test plan

- [x] YAML parses cleanly (4 content lines, \`type: primary\`, \`dismissable: true\`, \`position: below-navbar\`)
- [x] All pre-commit hooks passed
- [ ] Post-merge: preview deploy on tinytorch site and visually confirm bar matches vol1/vol2/kits/etc.