### PR TITLE
fix(shared-sidebar): tighten vertical spacing for uniform Quarto look

### DIFF
--- a/shared/styles/partials/_sidebar.scss
+++ b/shared/styles/partials/_sidebar.scss
@@ -1,19 +1,26 @@
 // =============================================================================
 // SIDEBAR STYLES — Navigation sidebar links and section headers
 // =============================================================================
+//
+// Single source of truth for sidebar spacing across every Quarto site in the
+// ecosystem. Kept deliberately compact — the book's sidebar carries 60+ items
+// per volume and needs every vertical pixel for scanability. Horizontal
+// padding (6–8px) is still comfortable for mouse/touch targeting; it's the
+// vertical rhythm that has to stay tight. Previously this file padded links
+// more generously (4px top/bottom + explicit margin-top on section headers),
+// which left TinyTorch and the landing site looking airier than the book,
+// kits, labs, and mlsysim. Consolidated to the tight baseline on 2026-04-24
+// for a uniform look across all Quarto sites.
+//
+// Site-specific accent colors come from `$accent` defined in each site's
+// theme SCSS before this partial is imported.
 
-// Sidebar link styles - readable but secondary to main content.
-// Padding/margin here control navigation density: the book's left nav and
-// the Tinytorch / kits / labs sidebars all pick this up via the shared
-// partial, so changes affect every site. We deliberately leave a little
-// more air than CSS-reset minimums to improve scanning on long lists.
 .sidebar-navigation .sidebar-item a {
   color: #495057; // Readable but not competing with main content
-  font-weight: 400; // Normal weight - supportive not dominant
+  font-weight: 400; // Normal weight — supportive not dominant
   display: block;
-  padding: 4px 8px; // Comfortable target size without wasting space
-  margin: 1px 0;
-  line-height: 1.45; // Explicit line-height so long labels don't crowd
+  padding: 2px 6px; // Tight vertical rhythm, comfortable horizontal target
+  margin: 0.5px 0; // Minimal vertical separation between consecutive items
   border-radius: 3px;
   transition: all 0.15s ease;
 
@@ -34,14 +41,13 @@
   }
 }
 
-// Section headers - clear hierarchy but not overpowering
+// Section headers — clear hierarchy, same vertical rhythm as the items they
+// group so the sidebar reads as one continuous column (not as stacked cards).
 .sidebar-navigation .sidebar-item a[data-bs-toggle="collapse"] {
-  font-weight: 500; // Medium weight - clear but supportive
+  font-weight: 500; // Medium weight — clear but supportive
   color: #2c3e50; // Dark but not competing with main content
   font-size: 0.9rem; // Slightly larger for hierarchy
   letter-spacing: 0.01em; // Subtle spacing for readability
-  padding: 6px 8px; // Slightly taller than regular items for hierarchy
-  margin-top: 4px; // Visible separation between sections
 
   &:hover {
     color: $accent; // Accent hover
@@ -52,7 +58,7 @@
   }
 }
 
-// Part divider styling - applied by JavaScript
+// Part divider styling — applied by JavaScript
 .part-divider {
   font-size: 0.7rem;
   font-weight: 600;


### PR DESCRIPTION
## Summary

Unifies sidebar vertical rhythm across all Quarto sites. Before this PR, the shared partial was loose (padding \`4px 8px\`, margin \`1px 0\`, explicit line-height \`1.45\`, extra padding and \`margin-top\` on section headers), while book/kits/labs/mlsysim already shipped their own tight local override (padding \`2px 6px\`, margin \`0.5px 0\`). Net effect: TinyTorch and the landing site looked noticeably airier than the book.

## The comment was also wrong

The partial's own file header rationalized "more air than CSS-reset minimums to improve scanning" as a deliberate choice. That was horizontal-vs-vertical-spacing confusion:
- Horizontal 6–8px padding DOES help mouse/touch targeting → keep
- Vertical 4px padding + explicit margin-top on section headers makes a 60-item sidebar require more scrolling → remove

The book has the most items per sidebar in the ecosystem and it runs the tight form. If it's right there, it's right everywhere.

## What changes

| Selector | Before (loose) | After (tight) |
|---|---|---|
| \`.sidebar-item a\` padding | \`4px 8px\` | \`2px 6px\` |
| \`.sidebar-item a\` margin | \`1px 0\` | \`0.5px 0\` |
| \`.sidebar-item a\` line-height | \`1.45\` (explicit) | removed (Bootstrap default ~1.5) |
| Section header padding | \`6px 8px\` | removed (inherits from item rule) |
| Section header margin-top | \`4px\` | removed (no extra gap above sections) |

## Sites affected

- **TinyTorch, landing site**: now tight (they import the shared partial directly) ✓
- **book, kits, labs, mlsysim**: no visual change (their local overrides already specify these same tight values and take precedence)
- **slides, instructors**: no sidebar so N/A

## Follow-up (not in this PR)

Four sites still carry duplicate local copies of these rules. Each passes \`\$\{site\}-accent\` explicitly instead of the shared partial's \`\$accent\` variable, which is why the duplicates exist. A follow-up could either:
1. Confirm each site defines \`\$accent\` before the partial and delete the four local overrides → true single source of truth.
2. Or keep the per-site overrides but shrink them to "just the accent color" and inherit spacing from the partial.

Either option is a structural cleanup, not a visual change. Deferring until we have eyes on the deployed preview of this PR.

## Test plan

- [x] \`_sidebar.scss\` scss syntax still parses (no local SCSS build, relies on downstream Quarto builds)
- [x] Visual audit in repo: confirmed TinyTorch imports this partial, confirmed book/kits/labs/mlsysim all ship local overrides that MATCH the new tight values
- [ ] Post-merge: preview deploy on TinyTorch and eyeball the sidebar against book's sidebar side-by-side