### PR TITLE
mlsysim: v0.1.1 + automated PyPI publish workflow

### DIFF
--- a/.github/workflows/mlsysim-pypi-publish.yml
+++ b/.github/workflows/mlsysim-pypi-publish.yml
@@ -1,0 +1,305 @@
+name: '🧮 MLSYSIM · 📦 PyPI Publish'
+
+# =============================================================================
+# MLSYSIM — PyPI Release
+# =============================================================================
+#
+# Builds and uploads the mlsysim Python package to PyPI when a tag matching
+# `mlsysim-v*` is pushed. Uses Trusted Publishing (OIDC), so no PyPI API
+# token is stored anywhere in the repo or in GitHub Secrets.
+#
+# Flow:
+#   1. VERIFY      — tag format, version coherence across files, CHANGELOG
+#                    entry, reachable from dev
+#   2. TEST        — full pytest suite in a clean venv
+#   3. BUILD       — python -m build → wheel + sdist
+#   4. CHECK       — twine check on both artifacts
+#   5. PUBLISH     — upload to PyPI via pypa/gh-action-pypi-publish (OIDC)
+#   6. RELEASE     — create GitHub Release with wheel + sdist attached
+#   7. DOCS        — dispatch mlsysim-publish-live.yml to refresh docs site
+#
+# Triggers:
+#   - push: tags matching 'mlsysim-v*'
+#   - workflow_dispatch: manual trigger (for re-running docs or release-only)
+#
+# Publishes to: https://pypi.org/project/mlsysim/
+# Secrets:      GITHUB_TOKEN (for GH Release + docs trigger)
+#               No PyPI secret required (Trusted Publishing via OIDC)
+# Environment:  pypi-mlsysim (for deployment tracking + protection rules)
+#
+# Related:
+#   - mlsysim-validate-dev.yml — Test & docs validation (runs on PRs)
+#   - mlsysim-publish-live.yml — Docs site publish (dispatched by this)
+#
+# Trusted Publishing setup (one-time, via pypi.org web UI):
+#   https://pypi.org/manage/account/publishing/
+#     Project:     mlsysim
+#     Owner:       harvard-edge
+#     Repository:  cs249r_book
+#     Workflow:    mlsysim-pypi-publish.yml
+#     Environment: pypi-mlsysim
+#
+# =============================================================================
+
+on:
+  push:
+    tags:
+      - 'mlsysim-v*'
+  workflow_dispatch:
+    inputs:
+      skip_pypi:
+        description: 'Skip the PyPI upload (useful for re-running docs + release)'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write    # needed to create the GitHub Release
+  id-token: write    # needed for Trusted Publishing (OIDC)
+  actions: write     # needed to dispatch mlsysim-publish-live.yml
+
+concurrency:
+  group: mlsysim-pypi-${{ github.ref }}
+  cancel-in-progress: false   # never cancel a publish in flight
+
+jobs:
+  # ===========================================================================
+  # Stage 1: Verify coherence before doing any irreversible work
+  # ===========================================================================
+  verify:
+    name: '🔍 Verify Version Coherence'
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.extract.outputs.version }}
+      tag: ${{ steps.extract.outputs.tag }}
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0   # need full history to verify tag reachability from dev
+
+      - name: 🏷️  Extract version from tag
+        id: extract
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          if [[ ! "$TAG" =~ ^mlsysim-v[0-9]+\.[0-9]+\.[0-9]+(.*)?$ ]]; then
+            echo "::error::Tag '$TAG' does not match expected pattern 'mlsysim-vX.Y.Z'"
+            exit 1
+          fi
+          VERSION="${TAG#mlsysim-v}"
+          echo "tag=$TAG"       | tee -a "$GITHUB_OUTPUT"
+          echo "version=$VERSION" | tee -a "$GITHUB_OUTPUT"
+
+      - name: 🔢 Verify pyproject.toml version matches tag
+        run: |
+          PKG_VERSION=$(grep -E '^version = ' mlsysim/pyproject.toml | head -1 | cut -d'"' -f2)
+          EXPECTED="${{ steps.extract.outputs.version }}"
+          if [ "$PKG_VERSION" != "$EXPECTED" ]; then
+            echo "::error::pyproject.toml version '$PKG_VERSION' does not match tag version '$EXPECTED'"
+            exit 1
+          fi
+          echo "✅ pyproject.toml version ($PKG_VERSION) matches tag"
+
+      - name: 🔢 Verify __init__.py version matches tag
+        run: |
+          PKG_VERSION=$(grep -E '^__version__ = ' mlsysim/mlsysim/__init__.py | head -1 | cut -d'"' -f2)
+          EXPECTED="${{ steps.extract.outputs.version }}"
+          if [ "$PKG_VERSION" != "$EXPECTED" ]; then
+            echo "::error::mlsysim/__init__.py __version__ ('$PKG_VERSION') does not match tag ('$EXPECTED')"
+            exit 1
+          fi
+          echo "✅ __init__.py version ($PKG_VERSION) matches tag"
+
+      - name: 🔢 Verify CITATION.cff version matches tag
+        run: |
+          CFF_VERSION=$(grep -E '^version:' mlsysim/CITATION.cff | head -1 | sed 's/.*"\([^"]*\)".*/\1/')
+          EXPECTED="${{ steps.extract.outputs.version }}"
+          if [ "$CFF_VERSION" != "$EXPECTED" ]; then
+            echo "::error::CITATION.cff version ('$CFF_VERSION') does not match tag ('$EXPECTED')"
+            exit 1
+          fi
+          echo "✅ CITATION.cff version ($CFF_VERSION) matches tag"
+
+      - name: 📝 Verify CHANGELOG has entry for this version
+        run: |
+          EXPECTED="${{ steps.extract.outputs.version }}"
+          if ! grep -qE "^## v${EXPECTED}[[:space:]]" mlsysim/CHANGELOG.md; then
+            echo "::error::CHANGELOG.md is missing an entry for v${EXPECTED}"
+            echo "Expected a heading like: '## v${EXPECTED} (YYYY-MM-DD)'"
+            exit 1
+          fi
+          echo "✅ CHANGELOG entry present for v${EXPECTED}"
+
+      - name: 🌿 Verify tag is reachable from dev
+        run: |
+          # Published packages should come from code that has been merged to dev.
+          # This prevents accidentally tagging a stale branch or feature branch.
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" "origin/dev" 2>/dev/null; then
+            echo "::warning::Tagged commit is not an ancestor of origin/dev."
+            echo "This is allowed but unusual. Continuing anyway (publish discipline rests on reviewer)."
+          else
+            echo "✅ Tagged commit is reachable from origin/dev"
+          fi
+
+  # ===========================================================================
+  # Stage 2: Full test suite in a clean environment
+  # ===========================================================================
+  test:
+    name: '🧪 Test Suite'
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v6
+
+      - name: 🐍 Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: 📦 Install package with dev extras
+        working-directory: mlsysim
+        run: pip install ".[dev]"
+
+      - name: 🧪 Run tests
+        working-directory: mlsysim
+        run: pytest tests/ -v --tb=short
+
+  # ===========================================================================
+  # Stage 3: Build wheel + sdist (reproducible, clean)
+  # ===========================================================================
+  build:
+    name: '🔨 Build Distribution'
+    needs: [verify, test]
+    runs-on: ubuntu-latest
+    outputs:
+      wheel_name: ${{ steps.names.outputs.wheel }}
+      sdist_name: ${{ steps.names.outputs.sdist }}
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v6
+
+      - name: 🐍 Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: 📦 Install build tools
+        run: pip install build twine
+
+      - name: 🔨 Build wheel + sdist
+        working-directory: mlsysim
+        run: python -m build
+
+      - name: 🔍 twine check
+        working-directory: mlsysim
+        run: twine check dist/*
+
+      - name: 📛 Capture artifact names
+        id: names
+        working-directory: mlsysim
+        run: |
+          echo "wheel=$(ls dist/*.whl)" >> "$GITHUB_OUTPUT"
+          echo "sdist=$(ls dist/*.tar.gz)" >> "$GITHUB_OUTPUT"
+
+      - name: 📤 Upload distributions as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mlsysim-dist-${{ needs.verify.outputs.version }}
+          path: mlsysim/dist/
+          if-no-files-found: error
+          retention-days: 90
+
+  # ===========================================================================
+  # Stage 4: Publish to PyPI via Trusted Publishing (OIDC)
+  # ===========================================================================
+  # No API token is used. The pypa/gh-action-pypi-publish action requests an
+  # OIDC token from GitHub, which PyPI then validates against the trusted
+  # publisher configuration. If this step fails with an OIDC error, it means
+  # Trusted Publishing has not been set up on pypi.org for this project/workflow.
+  # ===========================================================================
+  publish-pypi:
+    name: '📦 Publish to PyPI'
+    needs: [verify, test, build]
+    if: ${{ !inputs.skip_pypi }}
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi-mlsysim
+      url: https://pypi.org/project/mlsysim/${{ needs.verify.outputs.version }}/
+    steps:
+      - name: 📥 Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: mlsysim-dist-${{ needs.verify.outputs.version }}
+          path: dist/
+
+      - name: 📦 Upload to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          # Default repository URL is https://upload.pypi.org/legacy/ — correct
+          # for production PyPI. Trusted Publishing is configured per-project
+          # at https://pypi.org/manage/account/publishing/.
+          verbose: true
+
+  # ===========================================================================
+  # Stage 5: Create GitHub Release with artifacts attached
+  # ===========================================================================
+  github-release:
+    name: '🏷️ GitHub Release'
+    needs: [verify, build, publish-pypi]
+    if: always() && needs.build.result == 'success' && (needs.publish-pypi.result == 'success' || inputs.skip_pypi)
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v6
+
+      - name: 📥 Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: mlsysim-dist-${{ needs.verify.outputs.version }}
+          path: dist/
+
+      - name: 📝 Resolve release notes file
+        id: notes
+        run: |
+          VERSION="${{ needs.verify.outputs.version }}"
+          NOTES_FILE="mlsysim/RELEASE_NOTES_${VERSION}.md"
+          if [ -f "$NOTES_FILE" ]; then
+            echo "file=$NOTES_FILE" >> "$GITHUB_OUTPUT"
+            echo "✅ Using $NOTES_FILE"
+          else
+            # Fallback: extract CHANGELOG entry for this version
+            echo "file=" >> "$GITHUB_OUTPUT"
+            echo "ℹ️  $NOTES_FILE not found; GitHub Release will use auto-generated notes from CHANGELOG.md"
+          fi
+
+      - name: 🏷️ Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.verify.outputs.tag }}
+          name: 'MLSys·im ${{ needs.verify.outputs.version }}'
+          body_path: ${{ steps.notes.outputs.file }}
+          files: |
+            dist/*.whl
+            dist/*.tar.gz
+          generate_release_notes: ${{ steps.notes.outputs.file == '' }}
+          fail_on_unmatched_files: true
+
+  # ===========================================================================
+  # Stage 6: Trigger docs redeploy so mlsysbook.ai/mlsysim reflects new version
+  # ===========================================================================
+  docs-redeploy:
+    name: '📚 Trigger Docs Redeploy'
+    needs: [verify, publish-pypi]
+    if: ${{ needs.publish-pypi.result == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📚 Dispatch mlsysim-publish-live.yml on dev
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run mlsysim-publish-live.yml \
+            --repo ${{ github.repository }} \
+            --ref dev
+          echo "✅ Dispatched docs redeploy on dev"

--- a/mlsysim/CHANGELOG.md
+++ b/mlsysim/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.1.1 (2026-04-24)
+
+**Metadata-only patch release.** No code or API changes; safe drop-in
+replacement for 0.1.1.
+
+- Corrected paper title in citations: now reads "MLSys·im:
+  First-Principles Infrastructure Modeling for Machine Learning
+  Systems" (was "A Composable Analytical Framework for Machine Learning
+  Systems"). Updated in `CITATION.cff`, the BibTeX snippet in
+  `README.md`, and the reference in `mlsysim/core/walls.py`.
+
 ## v0.1.0 (2026-04-01)
 
 **Initial release** of MLSysim — the first-principles analytical modeling engine for ML systems.

--- a/mlsysim/CITATION.cff
+++ b/mlsysim/CITATION.cff
@@ -1,14 +1,14 @@
 cff-version: 1.2.0
 message: "If you use mlsysim in your research or teaching, please cite it as below."
-title: "MLSysim: A Composable Analytical Framework for Machine Learning Systems"
+title: "MLSys·im: First-Principles Infrastructure Modeling for Machine Learning Systems"
 type: software
 authors:
   - family-names: "Janapa Reddi"
     given-names: "Vijay"
     orcid: "https://orcid.org/0000-0002-5005-2564"
     affiliation: "Harvard University"
-version: "0.1.0"
-date-released: "2026-04-01"
+version: "0.1.1"
+date-released: "2026-04-24"
 license: "Apache-2.0"
 url: "https://mlsysbook.ai/mlsysim"
 repository-code: "https://github.com/harvard-edge/cs249r_book"

--- a/mlsysim/README.md
+++ b/mlsysim/README.md
@@ -157,10 +157,10 @@ If you use mlsysim in your research or teaching, please cite:
 ```bibtex
 @software{mlsysim2026,
   author       = {Janapa Reddi, Vijay},
-  title        = {{MLSysim}: A Composable Analytical Framework for Machine Learning Systems},
+  title        = {{MLSys$\cdot$im}: First-Principles Infrastructure Modeling for Machine Learning Systems},
   year         = {2026},
   url          = {https://mlsysbook.ai/mlsysim},
-  version      = {0.1.0},
+  version      = {0.1.1},
   institution  = {Harvard University}
 }
 ```

--- a/mlsysim/RELEASE.md
+++ b/mlsysim/RELEASE.md
@@ -1,126 +1,149 @@
 # MLSys·im Release Runbook
 
-This is the operational runbook for cutting an MLSys·im release. Use it verbatim — every step is intended to be copy-paste-able.
+Releases are **automated** via the `mlsysim-pypi-publish.yml` GitHub Actions
+workflow. Publishing happens when a tag matching `mlsysim-v*` is pushed to
+origin. The workflow authenticates to PyPI via **Trusted Publishing (OIDC)** —
+no PyPI API token is stored in the repo or in GitHub Secrets.
 
-The current version under `mlsysim/pyproject.toml` is the source of truth; bump it before tagging.
+## Happy path — the 3-step release
 
-## 0. Pre-flight checklist
-
-Run from the **`dev`** branch after the release-prep PR has merged.
-
-- [ ] Tests green: `cd mlsysim && pytest tests/ -q` reports the expected pass count (367 as of 0.1.0) and `0 failed`.
-- [ ] Versions aligned: `grep -E '^(version|__version__|date-released)' mlsysim/pyproject.toml mlsysim/CITATION.cff mlsysim/__init__.py` and `head -3 mlsysim/CHANGELOG.md` all read the same `X.Y.Z` and date.
-- [ ] Changelog updated: top entry of `mlsysim/CHANGELOG.md` is the version about to ship.
-- [ ] Release notes written: `mlsysim/RELEASE_NOTES_<version>.md` exists.
-- [ ] Docs build cleanly: `cd mlsysim/docs && quarto render` produces no `Unable to resolve link target` warnings.
-- [ ] CLI smoke: `mlsysim eval Llama3_8B H100 --batch-size 32` returns a scorecard.
-
-If any of these fail, **stop and fix on a PR** before continuing.
-
-## 1. Tag the release
-
-Tags follow the pattern `mlsysim-vX.Y.Z` (the `mlsysim-` prefix avoids collision with TinyTorch and slide tags in the same monorepo).
+Prerequisite: your changes must already be merged to `dev`, with the version
+bumped in `pyproject.toml`, `mlsysim/__init__.py`, `CITATION.cff`, and an entry
+added to `CHANGELOG.md`.
 
 ```bash
+# 1. Move to merged dev
 git checkout dev
 git pull --ff-only origin dev
-git tag -a mlsysim-v0.1.0 -m "MLSys·im 0.1.0 — initial release"
-git push origin mlsysim-v0.1.0
+
+# 2. Tag the release (annotated, prefixed)
+git tag -a mlsysim-v0.1.2 -m "MLSys·im 0.1.2"
+
+# 3. Push the tag → the workflow fires automatically
+git push origin mlsysim-v0.1.2
 ```
 
-## 2. Build the distribution
+From there, the workflow does everything:
 
-```bash
-cd mlsysim
-make clean
-make build           # → dist/mlsysim-X.Y.Z-py3-none-any.whl + dist/mlsysim-X.Y.Z.tar.gz
-```
+1. **Verify** — tag format, version coherence across `pyproject.toml` /
+   `__init__.py` / `CITATION.cff`, CHANGELOG entry present, tag reachable
+   from dev.
+2. **Test** — full pytest suite in a clean Python 3.11 container.
+3. **Build** — `python -m build` → wheel + sdist; `twine check` on both.
+4. **Publish to PyPI** — via `pypa/gh-action-pypi-publish` + OIDC.
+5. **GitHub Release** — creates the release, attaches wheel + sdist, uses
+   `RELEASE_NOTES_<version>.md` as the body if present.
+6. **Docs redeploy** — dispatches `mlsysim-publish-live.yml` on `dev` so the
+   docs site reflects the new version.
 
-Sanity-check the wheel before publishing:
+Monitor the run: <https://github.com/harvard-edge/cs249r_book/actions/workflows/mlsysim-pypi-publish.yml>
 
-```bash
-python -m venv /tmp/wheel-test && source /tmp/wheel-test/bin/activate
-pip install dist/mlsysim-*.whl
-python -c "import mlsysim; print(mlsysim.__version__)"
-mlsysim eval Llama3_8B H100 --batch-size 32
-deactivate && rm -rf /tmp/wheel-test
-```
+## Pre-release checklist (before tagging)
 
-## 3. Publish to PyPI
+Run this locally to catch the easy failures before the workflow does:
 
-```bash
-cd mlsysim
-pip install --upgrade twine
-twine check dist/*
-twine upload dist/*           # uses ~/.pypirc credentials
-```
+- [ ] `cd mlsysim && pytest tests/ -q` → 0 failures
+- [ ] Versions aligned: all four places read the same `X.Y.Z`
+  ```bash
+  grep -E '^version = ' mlsysim/pyproject.toml
+  grep -E '^__version__ = ' mlsysim/mlsysim/__init__.py
+  grep -E '^version:' mlsysim/CITATION.cff
+  head -3 mlsysim/CHANGELOG.md
+  ```
+- [ ] CHANGELOG top entry is the version about to ship
+- [ ] Optional: `mlsysim/RELEASE_NOTES_<version>.md` written for the GH Release body
+- [ ] CLI smoke: `mlsysim eval Llama3_8B H100 --batch-size 32` returns a scorecard
+- [ ] Docs render cleanly: `cd mlsysim/docs && quarto render` — no
+  `Unable to resolve link target` warnings
 
-For a dry-run upload to TestPyPI:
+If anything fails, fix on a PR to dev and merge before tagging. The workflow
+will re-run these checks, but catching them locally saves 5 minutes per
+attempt.
 
-```bash
-twine upload --repository testpypi dist/*
-pip install --index-url https://test.pypi.org/simple/ mlsysim==X.Y.Z
-```
+## Trusted Publishing — one-time setup
 
-## 4. Deploy the docs site
+If the workflow fails with an OIDC error, Trusted Publishing has not been
+configured on pypi.org. Do this once:
 
-The docs workflow is `workflow_dispatch` only — trigger it manually after the tag is in place.
+1. Sign in to <https://pypi.org/> as a maintainer of the `mlsysim` project.
+2. Go to <https://pypi.org/manage/account/publishing/>.
+3. Click **Add a new pending publisher** (or **Manage** for existing ones).
+4. Fill in:
 
-```bash
-gh workflow run mlsysim-publish-live.yml -R harvard-edge/cs249r_book --ref dev
-gh run watch -R harvard-edge/cs249r_book
-```
+   | Field       | Value                      |
+   |-------------|----------------------------|
+   | PyPI Project name | `mlsysim`            |
+   | Owner       | `harvard-edge`             |
+   | Repository name  | `cs249r_book`         |
+   | Workflow name    | `mlsysim-pypi-publish.yml` |
+   | Environment name | `pypi-mlsysim`        |
 
-When the run completes, visit <https://mlsysbook.ai/mlsysim/> and confirm:
+5. Save. No token is ever generated; GitHub's OIDC provider attests the
+   workflow identity at publish time and PyPI trusts that attestation.
 
-- Hero example output matches the engine (no stale numbers).
-- Navbar shows `MLSys·im` (mixed case, not `MLSys·IM`).
-- API Reference loads.
+This setup is per-project and per-workflow. It stays in place across workflow
+runs indefinitely; only re-do it if the workflow filename or environment name
+changes.
 
-## 5. Cut the GitHub Release
+## Post-release verification
 
-```bash
-gh release create mlsysim-v0.1.0 \
-  --repo harvard-edge/cs249r_book \
-  --title "MLSys·im 0.1.0" \
-  --notes-file mlsysim/RELEASE_NOTES_0.1.0.md \
-  mlsysim/dist/mlsysim-0.1.0-py3-none-any.whl \
-  mlsysim/dist/mlsysim-0.1.0.tar.gz
-```
-
-## 6. Final verification
-
-From a clean machine (or a fresh container):
+From a clean venv (CI already ran this, but a human spot-check catches UX bugs):
 
 ```bash
 python -m venv /tmp/release-verify && source /tmp/release-verify/bin/activate
-pip install mlsysim==0.1.0
+pip install mlsysim==<just-released-version>
 python -c "import mlsysim; print('OK', mlsysim.__version__)"
 mlsysim eval Llama3_8B H100 --batch-size 32
+deactivate
 ```
 
-Open <https://mlsysbook.ai/mlsysim/> in an incognito window and click through:
+Open <https://mlsysbook.ai/mlsysim/> in an incognito window; confirm:
 
-- Getting Started
-- Tutorials → Hello, Roofline
-- API Reference → Solvers
-- Footer links resolve
+- Version number on the site matches
+- Navbar shows `MLSys·im` (mixed case, not `MLSys·IM`)
+- Footer shows `Code: Apache-2.0 · Docs: CC-BY-NC-SA 4.0`
+- Getting Started and Tutorials still load
 
-## 7. Announce (optional)
+## Announce (optional)
 
-- Bump the announcement banner in `mlsysim/docs/config/announcement.yml` if you want to flag the new release on every page for a few weeks.
-- Cross-post a short note to the textbook newsletter / course channels.
-
----
+- Bump `mlsysim/docs/config/announcement.yml` banner if the release is
+  user-visible (major features, breaking changes).
+- Cross-post to the textbook newsletter / course channels.
 
 ## Rollback
 
-If a critical bug ships:
+You cannot re-upload a PyPI version, even after deleting it. If a release
+has a critical bug:
+
+1. **Yank** the bad version on pypi.org (Manage → Versions → Yank).
+   This hides it from `pip install mlsysim` but keeps existing pins working.
+2. Fix the bug on a PR to `dev`, bump to the next patch version
+   (`X.Y.Z+1`), merge.
+3. Tag `mlsysim-vX.Y.Z+1` and push — the workflow ships the fix.
+
+Never force-push or amend a tag that's been pushed. Tags on origin are
+immutable release markers.
+
+---
+
+## Manual fallback — only if the workflow is broken
+
+If the workflow itself has a bug that prevents automated release and you
+*must* ship, the legacy manual steps still work (your `~/.pypirc` with a
+PyPI token is the required credential path here). Fix the workflow in a
+follow-up PR; don't normalize the manual path.
 
 ```bash
-# Yank the bad version from PyPI (cannot be re-uploaded under the same number)
-twine upload --skip-existing dist/*    # never overwrite — bump and re-release
-pip install mlsysim==<previous>        # confirm the previous version still installs
+# From a clean checkout of the tagged commit:
+cd mlsysim
+make clean && make build
+twine check dist/*
+twine upload dist/*                  # requires ~/.pypirc with scoped token
+gh release create mlsysim-vX.Y.Z \
+  --repo harvard-edge/cs249r_book \
+  --title "MLSys·im X.Y.Z" \
+  --notes-file RELEASE_NOTES_X.Y.Z.md \
+  dist/mlsysim-X.Y.Z-py3-none-any.whl \
+  dist/mlsysim-X.Y.Z.tar.gz
+gh workflow run mlsysim-publish-live.yml -R harvard-edge/cs249r_book --ref dev
 ```
-
-Then publish `X.Y.(Z+1)` with the fix following the same runbook. Never amend a tag that has been pushed.

--- a/mlsysim/mlsysim/__init__.py
+++ b/mlsysim/mlsysim/__init__.py
@@ -3,7 +3,7 @@
 mlsysim: Machine Learning Systems Infrastructure and Modeling Platform
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 from . import core
 from . import hardware

--- a/mlsysim/mlsysim/core/walls.py
+++ b/mlsysim/mlsysim/core/walls.py
@@ -17,7 +17,7 @@ hardware resources to global fleet-scale operations:
 
 Reference
 ---------
-Janapa Reddi et al. (2025), "MLSYSIM: A Composable Analytical Framework
+Janapa Reddi (2026), "MLSys·im: First-Principles Infrastructure Modeling
 for Machine Learning Systems."  Table 1 and Section 4.
 """
 

--- a/mlsysim/pyproject.toml
+++ b/mlsysim/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mlsysim"
-version = "0.1.0"
+version = "0.1.1"
 description = "ML Systems Infrastructure Modeling Engine — first-principles analytical framework for ML workloads."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Ships two things intentionally bundled so the new release infrastructure is validated by its first actual use:

1. **mlsysim 0.1.1 content fix** — corrects the paper title cited in three places to match \`paper.tex\` (was \"A Composable Analytical Framework for Machine Learning Systems\", now \"MLSys·im: First-Principles Infrastructure Modeling for Machine Learning Systems\"). Metadata-only patch; no code or API changes.

2. **Automated PyPI publish workflow** (\`mlsysim-pypi-publish.yml\`) using **Trusted Publishing (OIDC)** — no PyPI token stored anywhere. Triggered by tag push matching \`mlsysim-v*\`. Future releases reduce to \`git tag && git push --tags\`.

## What changes in commit 1 (content fix)

- \`mlsysim/CITATION.cff\` — title + version 0.1.1 + date 2026-04-24
- \`mlsysim/README.md\` — BibTeX snippet title + version 0.1.1
- \`mlsysim/mlsysim/core/walls.py\` — reference docstring
- \`mlsysim/pyproject.toml\` — version 0.1.1
- \`mlsysim/mlsysim/__init__.py\` — \`__version__ = '0.1.1'\`
- \`mlsysim/CHANGELOG.md\` — 0.1.1 entry

## What changes in commit 2 (CI infrastructure)

- \`.github/workflows/mlsysim-pypi-publish.yml\` — new 6-stage pipeline:
  1. **Verify** — tag/version coherence across all version-of-truth files, CHANGELOG entry present, tag reachable from dev
  2. **Test** — full pytest suite on Python 3.11
  3. **Build** — \`python -m build\` → wheel + sdist; \`twine check\`
  4. **Publish** — \`pypa/gh-action-pypi-publish\` via OIDC (zero secrets)
  5. **GitHub Release** — creates release with artifacts attached
  6. **Docs redeploy** — dispatches \`mlsysim-publish-live.yml\` automatically
- \`mlsysim/RELEASE.md\` — rewritten with the 3-step automated happy path (tag + push), legacy manual twine steps kept as break-glass fallback only

## Before merging — one-time pypi.org setup required

Trusted Publishing must be registered on pypi.org once. Go to <https://pypi.org/manage/account/publishing/> and add:

| Field | Value |
|-------|-------|
| Project | \`mlsysim\` |
| Owner | \`harvard-edge\` |
| Repository | \`cs249r_book\` |
| Workflow | \`mlsysim-pypi-publish.yml\` |
| Environment | \`pypi-mlsysim\` |

No token. Just five form fields.

## Release process after merge

\`\`\`bash
git checkout dev
git pull --ff-only origin dev
git tag -a mlsysim-v0.1.1 -m \"MLSys·im 0.1.1\"
git push origin mlsysim-v0.1.1
# Workflow fires automatically; monitor at:
# https://github.com/harvard-edge/cs249r_book/actions/workflows/mlsysim-pypi-publish.yml
\`\`\`

## Test plan

- [ ] Workflow YAML syntax is valid (GitHub runs its own YAML validation on push)
- [ ] Trusted Publishing configured on pypi.org per the table above
- [ ] After merge, tag push triggers the workflow
- [ ] Workflow \`verify\` stage passes (version coherence check catches real issues)
- [ ] Workflow \`test\` stage green (same pytest run as validate-dev)
- [ ] Workflow \`build\` stage produces wheel + sdist
- [ ] Workflow \`publish-pypi\` stage uploads successfully via OIDC
- [ ] \`pip install mlsysim==0.1.1\` in a fresh venv works post-publish
- [ ] GitHub Release appears with wheel + sdist attached
- [ ] Docs redeploy auto-dispatches and updates mlsysbook.ai/mlsysim