### PR TITLE
polish(tinytorch): sidebar + headers + flat tier cards + PDF milestone transitions

### DIFF
--- a/shared/styles/partials/_sidebar.scss
+++ b/shared/styles/partials/_sidebar.scss
@@ -15,6 +15,17 @@
 // Site-specific accent colors come from `$accent` defined in each site's
 // theme SCSS before this partial is imported.
 
+// When the sidebar has its own scroll container (Quarto sets this up once
+// the content exceeds the viewport), confine wheel-scroll inside it so
+// reaching the sidebar's top or bottom does NOT chain-scroll the body.
+// Without this, hovering-and-scrolling over the sidebar feels like you
+// were scrolling the page the whole time — which is exactly what the
+// reader is trying to avoid by engaging the sidebar in the first place.
+#quarto-sidebar,
+.sidebar-navigation {
+  overscroll-behavior: contain;
+}
+
 .sidebar-navigation .sidebar-item a {
   color: #495057; // Readable but not competing with main content
   font-weight: 400; // Normal weight — supportive not dominant

--- a/tinytorch/quarto/_quarto.yml
+++ b/tinytorch/quarto/_quarto.yml
@@ -80,7 +80,7 @@ website:
           - text: "Historical Milestones"
             href: milestones/index.qmd
           - text: "---"
-          - text: "TITO CLI Reference"
+          - text: "TITO CLI"
             href: tito/overview.qmd
           - text: "Datasets Guide"
             href: datasets.qmd
@@ -137,19 +137,17 @@ website:
             - href: modules/08_training.qmd
               text: "08. Training"
 
-        # Milestone chapters live alongside the tier whose modules unlock
-        # them. They are runnable historical recreations powered by YOUR
-        # implementations from the prior tier.
-        - section: "🕰️ Foundation Milestones"
-          contents:
-            - href: milestones/index.qmd
-              text: "📖 Milestone Overview"
-            - href: milestones/01_perceptron.qmd
-              text: "1958 · Perceptron"
-            - href: milestones/02_xor.qmd
-              text: "1969 · XOR Crisis"
-            - href: milestones/03_mlp.qmd
-              text: "1986 · MLP Revival"
+        # Milestones are intentionally OMITTED from the HTML sidebar — they
+        # interleaved between tiers and broke the Foundation -> Architecture
+        # -> Optimization -> Capstone reading flow that the sidebar is meant
+        # to communicate. They remain fully accessible via:
+        #   1. The top navbar's "Historical Milestones" entry (line 80 above)
+        #      which routes to milestones/index.qmd (the hub page).
+        #   2. The PDF build (tinytorch/quarto/pdf/_quarto.yml), which
+        #      interleaves them as separate `part:` blocks — that's the
+        #      intended reading experience in print.
+        # Do not restore milestone sections to the HTML sidebar without
+        # rethinking that tier-flow design.
 
         - section: "🏛️ Architecture Tier"
           contents:
@@ -165,13 +163,6 @@ website:
               text: "12. Attention"
             - href: modules/13_transformers.qmd
               text: "13. Transformers"
-
-        - section: "🕰️ Architecture Milestones"
-          contents:
-            - href: milestones/04_cnn.qmd
-              text: "1998 · CNN Revolution"
-            - href: milestones/05_transformer.qmd
-              text: "2017 · Transformers"
 
         - section: "⏱️ Optimization Tier"
           contents:
@@ -190,12 +181,7 @@ website:
             - href: modules/19_benchmarking.qmd
               text: "19. Benchmarking"
 
-        - section: "🕰️ Optimization Milestones"
-          contents:
-            - href: milestones/06_mlperf.qmd
-              text: "2018 · MLPerf"
-
-        - section: "🏅 Capstone Competition"
+        - section: "🏅 Capstone"
           contents:
             - href: tiers/olympics.qmd
               text: "📖 Competition Overview"
@@ -207,7 +193,7 @@ website:
             - href: conclusion.qmd
               text: "You Built Something Real"
 
-        - section: "🛠️ TITO CLI Reference"
+        - section: "🛠️ TITO CLI"
           contents:
             - href: tito/overview.qmd
               text: "Command Overview"

--- a/tinytorch/quarto/assets/styles/style.scss
+++ b/tinytorch/quarto/assets/styles/style.scss
@@ -46,6 +46,25 @@ $callout-secondary-bg: rgba($callout-secondary, 0.08);
 // TINYTORCH-SPECIFIC STYLES
 // =============================================================================
 
+// Header decoration overrides — shared/styles/partials/_headers.scss decorates
+// H2–H6 with a thick accent left-border + thin bottom line (the "L-shape"
+// that reads well in a long-form textbook). TinyTorch is framework
+// documentation, not a book — the L-shape feels heavy against code blocks,
+// comparison grids, and card-based page layouts. Strip the decoration site-
+// wide so headings read as plain, weight-differentiated section breaks.
+// Don't remove the decoration from the shared partial itself (book/kits/
+// labs/mlsysim all keep it).
+.content h2, main h2, article h2, #quarto-content h2,
+.content h3, main h3, article h3, #quarto-content h3,
+.content h4, main h4, article h4, #quarto-content h4,
+.content h5, main h5, article h5, #quarto-content h5,
+.content h6, main h6, article h6, #quarto-content h6 {
+  border-left: 0 !important;
+  border-bottom: 0 !important;
+  padding-left: 0 !important;
+  padding-bottom: 0 !important;
+}
+
 // Hero section gradient text
 .hero-gradient-text {
   background: linear-gradient(135deg, #E74C3C 0%, #E67E22 50%, #F39C12 100%);
@@ -159,33 +178,15 @@ $callout-secondary-bg: rgba($callout-secondary, 0.08);
   }
 }
 
-.tier-foundation {
-  background: linear-gradient(135deg, #e3f2fd 0%, #bbdefb 100%);
-  border-left: 4px solid #1976d2;
-  h3 { color: #0d47a1; }
-  p { color: #1565c0; }
-}
-
-.tier-architecture {
-  background: linear-gradient(135deg, #f3e5f5 0%, #e1bee7 100%);
-  border-left: 4px solid #7b1fa2;
-  h3 { color: #4a148c; }
-  p { color: #6a1b9a; }
-}
-
-.tier-optimization {
-  background: linear-gradient(135deg, #fff3e0 0%, #ffe0b2 100%);
-  border-left: 4px solid #f57c00;
-  h3 { color: #e65100; }
-  p { color: #ef6c00; }
-}
-
-.tier-olympics {
-  background: linear-gradient(135deg, #fce4ec 0%, #f8bbd0 100%);
-  border-left: 4px solid #c2185b;
-  h3 { color: #880e4f; }
-  p { color: #ad1457; }
-}
+// Tier variants — flat single-color left-border over a neutral fill, matching
+// the audience cards in preface.qmd. Previous variant used heavy gradient
+// fills per tier which competed with the comparison grid on the same page
+// and felt marketing-heavy for framework docs. The left border still carries
+// the tier's identity color; the rest reads clean.
+.tier-foundation    { background: #fafafa; border-left: 4px solid #1976d2; h3, p { color: #1e293b; } }
+.tier-architecture  { background: #fafafa; border-left: 4px solid #7b1fa2; h3, p { color: #1e293b; } }
+.tier-optimization  { background: #fafafa; border-left: 4px solid #f57c00; h3, p { color: #1e293b; } }
+.tier-olympics      { background: #fafafa; border-left: 4px solid #c2185b; h3, p { color: #1e293b; } }
 
 // Audience cards
 .audience-card {

--- a/tinytorch/quarto/milestones/01_perceptron.qmd
+++ b/tinytorch/quarto/milestones/01_perceptron.qmd
@@ -14,6 +14,8 @@
 
 ## Overview
 
+You just finished the Foundation Tier. Your `Tensor` (Module 01), `Linear` layer (Module 03), `BCELoss` (Module 04), autograd (Module 06), `SGD` (Module 07), and `Trainer` (Module 08) are all working. This milestone runs the simplest possible model those pieces can drive — and the one that started the field.
+
 It's 1958. Computers fill entire rooms and can barely add numbers. Then Frank Rosenblatt makes an outrageous claim: he's built a machine that can LEARN. Not through programming — through experience, like a human child.
 
 The press goes wild. The Navy funds research expecting machines that will "walk, talk, see, write, reproduce itself and be conscious of its existence." The New York Times runs the headline: *"New Navy Device Learns by Doing."*

--- a/tinytorch/quarto/milestones/04_cnn.qmd
+++ b/tinytorch/quarto/milestones/04_cnn.qmd
@@ -14,6 +14,8 @@
 
 ## Overview
 
+This is the first **Architecture Milestone**. The Foundation Milestones proved your training loop learns; the next two prove your *architectures* do the work they were invented for. Here you pick up the `Conv2d` and `MaxPool2d` layers you just built in Module 09 and point them at natural images — the exact problem that made convolutions famous.
+
 1998. Yann LeCun deploys LeNet-5: a convolutional neural network that reads handwritten zip codes for the US Postal Service and dollar amounts on bank checks for NCR. It is not a research demo. It is production software, sorting mail and clearing checks at industrial scale — the first commercial success of deep learning.
 
 The breakthrough is structural. Images are not bags of pixels; nearby pixels matter more than distant ones, and the same edge detector works whether you put it in the corner or the center. Exploit those two facts — local connectivity and weight sharing — and a convolutional network matches a dense one's accuracy with two orders of magnitude fewer parameters.

--- a/tinytorch/quarto/milestones/06_mlperf.qmd
+++ b/tinytorch/quarto/milestones/06_mlperf.qmd
@@ -14,6 +14,8 @@
 
 ## Overview
 
+This is the **Optimization Milestone** — the third and final act of the historical arc. The Foundation Milestones proved your training loop learns. The Architecture Milestones proved your layers match real data. This one proves your *optimization stack* — the Profiler (Module 14), Quantization (15), Compression (16), Acceleration (17), and KV-Cache (18) you just finished — can turn a working model into a shippable one.
+
 2018. ML research is sprinting; deployment is crawling. BERT-Large lands at 340M parameters and won't fit on a phone. ResNet-152 inference blows past production latency budgets. Teams ship two-year-old models because the new ones are too slow, too big, too expensive — and every vendor's benchmark numbers use a different dataset, batch size, and accuracy floor, so you can't even tell whose hardware is faster.
 
 MLPerf changes that. One protocol, one accuracy floor, one set of reference models — apples-to-apples across CPUs, GPUs, TPUs, and accelerators that didn't exist last year. Optimization stops being an afterthought and becomes the discipline that decides who ships.

--- a/tinytorch/quarto/modules/08_training.qmd
+++ b/tinytorch/quarto/modules/08_training.qmd
@@ -993,9 +993,11 @@ For students who want to understand the academic foundations and advanced traini
 
 You just shipped the Foundation Tier. Tensors, autograd, optimizers, dataloader, and a `Trainer` that ties them together — these are the load-bearing pieces of every modern ML framework, and you wrote all of them. The next tier is about *what gets put inside the model*. The training loop you built does not change.
 
-:::{.callout-note title="Coming Up: Module 09 — Convolutions"}
+Before moving on, the next three chapters give those Foundation pieces their first real workout. The **Foundation Milestones** — Rosenblatt's 1958 Perceptron, the 1969 XOR Crisis, and the 1986 MLP Revival — are runnable recreations of the experiments that shaped early neural-network history, all driven by the Tensor, Linear layer, autograd, optimizer, and Trainer you just finished. You watch your own code fail in the same way Minsky proved it had to, then break through with the same fix Rumelhart shipped. Then, on the far side, Module 09 opens the Architecture Tier.
 
-Architecture Tier begins. You'll implement `Conv2d`, `MaxPool2d`, and `Flatten` — the layers that exploit spatial structure in images and make computer vision possible. Same `Trainer.train_epoch()` you wrote here will train the CNNs you build there, with no code changes. That's the payoff of separating orchestration from architecture.
+:::{.callout-note title="Coming Up: Foundation Milestones, then Module 09 — Convolutions"}
+
+First: three Foundation Milestones run your Trainer on Perceptron (1958), XOR (1969), and MLP digit recognition (1986) — proof that the framework you built reproduces the history of the field. Then Module 09 opens the Architecture Tier with `Conv2d`, `MaxPool2d`, and `Flatten`: the layers that exploit spatial structure in images and make computer vision possible. Same `Trainer.train_epoch()` you wrote here will train the CNNs you build there, with no code changes. That's the payoff of separating orchestration from architecture.
 :::
 
 **Preview — how the Trainer you just built gets reused:**

--- a/tinytorch/quarto/modules/13_transformers.qmd
+++ b/tinytorch/quarto/modules/13_transformers.qmd
@@ -927,9 +927,11 @@ The transition from a theoretical transformer diagram to a planet-scale language
 
 You finished the Architecture Tier. You have a transformer that trains, generates text, and matches the structural blueprint of GPT. Everything from here is about making it *fast, small, and deployable*.
 
-:::{.callout-note title="Coming Up: Module 14 — Profiling"}
+Before that, the next two chapters take the Architecture Tier on a historical test drive. The **Architecture Milestones** — LeNet-5 on CIFAR-10 (1998) and the 2017 Transformer attention test — run your `Conv2d`, `MaxPool2d`, multi-head attention, and `TransformerBlock` on the exact problems those architectures were invented to solve. Convolutional networks hit 70%+ on natural images; attention clears sequence-reversal tasks RNNs can't. Both are proof that the layers you just wrote behave the way the original papers claimed.
 
-The Optimization Tier opens with the only honest place to start: measurement. Before you optimize anything, you need to know *where the time goes*. In Module 14 you instrument your transformer's forward pass and answer concrete questions — how much of a step is spent in attention versus the MLP, how memory grows with sequence length on your machine, and which layer is the actual bottleneck. Every optimization in the chapters that follow (quantization, kernel fusion, KV caching) targets a number you measured in Module 14.
+:::{.callout-note title="Coming Up: Architecture Milestones, then Module 14 — Profiling"}
+
+First: two Architecture Milestones exercise your Conv/Pool layers (CIFAR-10) and your attention stack (sequence tasks) on their landmark problems. Then the Optimization Tier opens with the only honest place to start: measurement. Before you optimize anything, you need to know *where the time goes*. In Module 14 you instrument your transformer's forward pass and answer concrete questions — how much of a step is spent in attention versus the MLP, how memory grows with sequence length on your machine, and which layer is the actual bottleneck. Every optimization in the chapters that follow (quantization, kernel fusion, KV caching) targets a number you measured in Module 14.
 :::
 
 **Where your transformer goes from here:**
@@ -956,7 +958,3 @@ The Optimization Tier opens with the only honest place to start: measurement. Be
 
 Binder sessions are temporary. Download your completed notebook when done, or clone the repository for persistent local work.
 :::
- clone the repository for persistent local work.
-:::
-44B parameters |
-| **20: Capstone** | Complete production system | Deploy transformer for real-time inference |

--- a/tinytorch/quarto/modules/19_benchmarking.qmd
+++ b/tinytorch/quarto/modules/19_benchmarking.qmd
@@ -963,13 +963,15 @@ For students who want to understand the academic and industry foundations of ML 
 
 ## What's Next
 
-You now have a tool that separates real speedups from noise. Module 20 — the **Capstone: TorchPerf Olympics** — is where that tool earns its keep. You will combine the optimizations from Modules 14-18 (quantization, pruning, fusion, caching), submit results to a public leaderboard, and defend every number against the same statistical scrutiny you just built.
+You now have a tool that separates real speedups from noise. Before the Capstone, the next chapter puts the whole Optimization Tier through a historical end-to-end run. The **Optimization Milestone** — MLPerf (2018) — chains your Profiler (Module 14), Quantization (15), Compression (16), Acceleration (17), and KV-Cache (18) into a single measure → optimize → validate loop, the same discipline MLPerf forced onto an industry that previously measured whatever made its hardware look fastest. You compress a model 8× and speed up transformer generation 10×, on your own framework, with every speedup traceable to code you wrote.
+
+After that, Module 20 — the **Capstone: TorchPerf Olympics** — is where the benchmarking harness earns its keep. You will combine the optimizations from Modules 14-18 (quantization, pruning, fusion, caching), submit results to a public leaderboard, and defend every number against the same statistical scrutiny you just built.
 
 The capstone has no "easy" mode. Every entry is judged by the harness from this chapter — overlapping confidence intervals are not a win, and a faster mean without proper warmup is a disqualification. The discipline you practiced here is the price of admission.
 
-:::{.callout-note title="Coming Up: Module 20 — Capstone"}
+:::{.callout-note title="Coming Up: Optimization Milestone (MLPerf), then Module 20 — Capstone"}
 
-Combine everything from Modules 01-19 to compete in the TorchPerf Olympics: stack optimizations, benchmark them honestly, and chase the fastest, smallest, or most accurate model on the leaderboard.
+First: the MLPerf milestone runs your Profiler → Quantization → Pruning → KV-Cache pipeline on real models, the same measure-optimize-validate loop production teams use. Then Module 20 combines everything from Modules 01-19 to compete in the TorchPerf Olympics: stack optimizations, benchmark them honestly, and chase the fastest, smallest, or most accurate model on the leaderboard.
 :::
 
 **Preview — How Your Benchmarking Gets Used in the Capstone:**


### PR DESCRIPTION
## Summary

Six independent polish items in one PR — they all landed on the same mental walkthrough of the TinyTorch site.

| # | What | Where |
|---|---|---|
| 1 | Sidebar title renames (no more wrapping) | \`_quarto.yml\` |
| 2 | Milestones removed from HTML sidebar (PDF untouched) | \`_quarto.yml\` |
| 3 | Sidebar \`overscroll-behavior: contain\` (all ecosystem sites benefit) | shared \`_sidebar.scss\` |
| 4 | H2 L-shape decoration stripped on TinyTorch only | \`style.scss\` override |
| 5 | Tier cards flattened — neutral fill + colored left-border | \`style.scss\` |
| 6 | PDF milestone transitions (tier-ending modules + milestone openers) | 6 \`.qmd\` files |
| 7 | Pre-existing corrupted trailing content removed | \`13_transformers.qmd\` |

## Details

### 1 + 2. Sidebar structure (\`_quarto.yml\`)
\"Capstone Competition\" → \"Capstone\"; \"TITO CLI Reference\" → \"TITO CLI\" (also in the navbar). All three milestone sections removed from the HTML sidebar because they interleaved between tiers and broke the Foundation → Architecture → Optimization → Capstone reading flow. Milestones stay reachable via the navbar's \"Historical Milestones\" entry; the PDF build has its own config (\`pdf/_quarto.yml\`) and is untouched.

### 3. Sidebar scroll chaining (\`shared/styles/partials/_sidebar.scss\`)
\`overscroll-behavior: contain\` on \`#quarto-sidebar\` prevents scrolls that hit the sidebar's top/bottom from chain-scrolling the body. Every Quarto site in the ecosystem picks this up — not just TinyTorch.

### 4. H2 L-shape (\`tinytorch/quarto/assets/styles/style.scss\`)
The shared \`_headers.scss\` partial decorates H2-H6 with a thick accent left-border plus a thin accent bottom line — an \"L-shape\" that works in the textbook's long-form prose. TinyTorch is framework documentation (code blocks, comparison grids, card layouts) and the decoration felt heavy. Scoped override strips \`border-left\`/\`border-bottom\`/\`padding-left\`/\`padding-bottom\` from H2-H6 on TinyTorch **only** — book/kits/labs/mlsysim keep the decoration.

### 5. Tier cards (\`tinytorch/quarto/assets/styles/style.scss\`)
\`.tier-foundation\` / \`.tier-architecture\` / \`.tier-optimization\` / \`.tier-olympics\` previously used four heavy gradient fills that fought the comparison grid on the same page (and tier-optimization read as specifically orange-heavy). Flattened to the same \`#fafafa\` neutral fill used by \`.audience-card\` and preface.qmd's cards, with a 4px colored left-border per tier carrying the identity color.

### 6. PDF milestone transitions (6 \`.qmd\` files)
Milestones appeared suddenly in the PDF after each tier. Added short transitions:
- **\`modules/08_training.qmd\`**: forward-hook into Foundation Milestones, naming the components (Tensor/Linear/autograd/optimizer/Trainer) they exercise
- **\`modules/13_transformers.qmd\`**: forward-hook into Architecture Milestones (LeNet-5, 2017 Transformer)
- **\`modules/19_benchmarking.qmd\`**: forward-hook into Optimization Milestone (MLPerf 2018)
- **\`milestones/01_perceptron.qmd\`**: opening naming the Foundation Tier components used
- **\`milestones/04_cnn.qmd\`**: first-Architecture-Milestone framing + three-tier arc
- **\`milestones/06_mlperf.qmd\`**: sole-Optimization-Milestone + \"third act\" framing

Files left untouched because their transitions were already good: \`milestones/index.qmd\`, \`02_xor.qmd\`, \`03_mlp.qmd\`, \`05_transformer.qmd\`.

### 7. Drive-by: corruption cleanup (\`modules/13_transformers.qmd\`)
Pre-existing orphan content at the end of the file (duplicate sentence + two orphan table rows \`44B parameters |\` and a duplicate Capstone row). Removed since we were already editing the file.

## Verification (Playwright against local \`quarto preview\`)

| Check | Result |
|---|---|
| Sidebar section labels | \`[\"Getting Started\", \"Foundation Tier\", \"Architecture Tier\", \"Optimization Tier\", \"Capstone\", \"Conclusion\", \"TITO CLI\", \"Reference\", \"Community\"]\` — no wrapping, no milestones |
| \`#quarto-sidebar\` \`overscroll-behavior\` | \`contain\` |
| H2 \"Don't import it. Build it.\" | \`border-left-width: 0px\`, \`border-bottom-width: 0px\`, \`padding-left: 0px\` |
| \`.tier-card\` | all \`bg: rgb(250, 250, 250)\`, each with \`border-left: 4px solid {tier-color}\` |

## Test plan

- [x] Local \`quarto preview\` build renders cleanly
- [x] Playwright DOM/style checks pass
- [x] Pre-commit hooks pass
- [ ] Post-merge: preview deploy for visual confirmation on the deployed tinytorch site