### PR TITLE
mlsysim: align identity copy with paper title + CHANGELOG-driven release notes

### DIFF
--- a/.github/workflows/mlsysim-pypi-publish.yml
+++ b/.github/workflows/mlsysim-pypi-publish.yml
@@ -329,8 +329,10 @@ jobs:
     if: always() && needs.build.result == 'success' && (needs.publish-pypi.result == 'success' || inputs.skip_pypi)
     runs-on: ubuntu-latest
     steps:
-      - name: 📥 Checkout
+      - name: 📥 Checkout (full history for tag resolution)
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0       # needed for `git describe --tags` to find PREV_TAG
 
       - name: 📥 Download build artifacts
         uses: actions/download-artifact@v4
@@ -338,30 +340,107 @@ jobs:
           name: mlsysim-dist-${{ needs.verify.outputs.version }}
           path: dist/
 
-      - name: 📝 Resolve release notes file
+      - name: 📝 Compose release notes
         id: notes
         run: |
           VERSION="${{ needs.verify.outputs.version }}"
           NOTES_FILE="mlsysim/RELEASE_NOTES_${VERSION}.md"
+          OUT="$RUNNER_TEMP/release-body.md"
+
           if [ -f "$NOTES_FILE" ]; then
-            echo "file=$NOTES_FILE" >> "$GITHUB_OUTPUT"
-            echo "✅ Using $NOTES_FILE"
+            # Hand-written release notes (for milestone releases). Use as-is —
+            # the file is assumed to already be well-formed.
+            echo "::notice::Using hand-written $NOTES_FILE"
+            cp "$NOTES_FILE" "$OUT"
           else
-            # Fallback: extract CHANGELOG entry for this version
-            echo "file=" >> "$GITHUB_OUTPUT"
-            echo "ℹ️  $NOTES_FILE not found; GitHub Release will use auto-generated notes from CHANGELOG.md"
+            # Default path: extract the `## vX.Y.Z` section from CHANGELOG.md
+            # and wrap with title, install, links, and the About footer.
+            echo "::notice::Extracting v${VERSION} section from CHANGELOG.md"
+            CHANGELOG="mlsysim/CHANGELOG.md"
+
+            # Optional theme: everything after " — " on the heading line.
+            THEME=$(awk -v ver="v${VERSION}" '
+              $0 ~ "^## " ver " " {
+                if (match($0, / — /)) print substr($0, RSTART + RLENGTH)
+                exit
+              }
+            ' "$CHANGELOG")
+
+            # Body: lines between the heading and the next `## v…` heading.
+            BODY=$(awk -v ver="v${VERSION}" '
+              $0 ~ "^## " ver " " {flag=1; next}
+              flag && /^## v[0-9]/ {exit}
+              flag {print}
+            ' "$CHANGELOG")
+
+            if [ -z "$BODY" ]; then
+              echo "::error::CHANGELOG.md has no section for v${VERSION}"
+              exit 1
+            fi
+
+            # Previous tag for the diff link (best-effort; empty on first release).
+            PREV_TAG=$(git describe --tags --abbrev=0 --match='mlsysim-v*' --exclude="mlsysim-v${VERSION}" 2>/dev/null || echo '')
+
+            {
+              if [ -n "$THEME" ]; then
+                echo "# MLSys·im ${VERSION} — ${THEME}"
+              else
+                echo "# MLSys·im ${VERSION}"
+              fi
+              echo "*First-principles infrastructure modeling for the [Machine Learning Systems](https://mlsysbook.ai) textbook.*"
+              echo ""
+              printf '%s\n' "$BODY"
+              echo ""
+              echo "---"
+              echo ""
+              echo "## Install"
+              echo ""
+              echo '    pip install --upgrade mlsysim=='"${VERSION}"
+              echo ""
+              echo "---"
+              echo ""
+              echo "## Links"
+              echo ""
+              echo "- [PyPI · mlsysim ${VERSION}](https://pypi.org/project/mlsysim/${VERSION}/)"
+              echo "- [Documentation](https://mlsysbook.ai/mlsysim/)"
+              echo "- [Full CHANGELOG](https://github.com/${{ github.repository }}/blob/dev/mlsysim/CHANGELOG.md)"
+              if [ -n "$PREV_TAG" ]; then
+                echo "- [Diff ${PREV_TAG} → mlsysim-v${VERSION}](https://github.com/${{ github.repository }}/compare/${PREV_TAG}...mlsysim-v${VERSION})"
+              fi
+              echo ""
+              echo "---"
+              echo ""
+              echo "## About MLSys·im"
+              echo ""
+              echo "MLSys·im is the first-principles infrastructure modeling engine that"
+              echo "produces every quantitative result in the [*Machine Learning Systems*](https://mlsysbook.ai)"
+              echo "textbook — memory bandwidth calculations, roofline analyses, TCO projections,"
+              echo "sustainability estimates, and every other number a reader encounters. Each"
+              echo "figure and equation in the textbook is **computed, not hand-typed**; mlsysim"
+              echo "is the computation."
+              echo ""
+              echo "The framework codifies **22 systems walls** — the physical and logical"
+              echo "constraints that bound ML system performance — into composable solvers,"
+              echo "with SI units enforced at runtime. Designed for three audiences: **students**"
+              echo "building quantitative intuition, **instructors** running live classroom"
+              echo "demonstrations, and **researchers** doing rapid what-if analysis."
+            } > "$OUT"
           fi
+
+          echo "body_file=$OUT" >> "$GITHUB_OUTPUT"
+          echo "::group::composed release body (first 80 lines)"
+          head -80 "$OUT"
+          echo "::endgroup::"
 
       - name: 🏷️ Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.verify.outputs.tag }}
           name: 'MLSys·im ${{ needs.verify.outputs.version }}'
-          body_path: ${{ steps.notes.outputs.file }}
+          body_path: ${{ steps.notes.outputs.body_file }}
           files: |
             dist/*.whl
             dist/*.tar.gz
-          generate_release_notes: ${{ steps.notes.outputs.file == '' }}
           fail_on_unmatched_files: true
 
   # ===========================================================================

--- a/mlsysim/CHANGELOG.md
+++ b/mlsysim/CHANGELOG.md
@@ -1,15 +1,60 @@
 # Changelog
 
-## v0.1.1 (2026-04-24)
+<!--
+Format note
+===========
+Each release entry follows the structure below. The mlsysim-pypi-publish
+workflow extracts the `## vX.Y.Z (YYYY-MM-DD)` section and wraps it with
+install, links, and an "About MLSys·im" footer to produce the GitHub
+Release body. Omit any section that has no entries for a given release.
 
-**Metadata-only patch release.** No code or API changes; safe drop-in
-replacement for 0.1.1.
+    ## vX.Y.Z (YYYY-MM-DD) — Optional Short Theme
 
-- Corrected paper title in citations: now reads "MLSys·im:
-  First-Principles Infrastructure Modeling for Machine Learning
-  Systems" (was "A Composable Analytical Framework for Machine Learning
-  Systems"). Updated in `CITATION.cff`, the BibTeX snippet in
-  `README.md`, and the reference in `mlsysim/core/walls.py`.
+    [Narrative opening — 1–3 sentences describing the release.]
+
+    ### ✨ Highlights
+    [Optional; 2–4 bullets for feature+ releases.]
+
+    ### 🔬 Solvers, Models & Taxonomy
+    ### 🏭 Hardware Registry
+    ### 🧠 Workload & Model Registry
+    ### 🖥️ CLI
+    ### 🐍 Python API
+    ### 📚 Documentation
+    ### 🏗️ Packaging & Dependencies
+    ### 🐛 Bug Fixes
+    ### 🔧 Internal
+
+    ### ⚠️ Breaking Changes    (only if present)
+    ### 🔒 Security            (only if present)
+    ### Deprecations           (only if present)
+
+    ### Contributors
+    - @profvjreddi
+-->
+
+## v0.1.1 (2026-04-24) — Paper Title Correction
+
+Metadata-only patch release. No code or API changes; safe drop-in
+replacement for 0.1.0. Corrects the paper title cited in three places
+to match the actual title of the companion paper.
+
+### 📚 Documentation
+
+- **Paper title corrected** across `CITATION.cff`, the BibTeX snippet in
+  `README.md`, and the reference docstring in `mlsysim/core/walls.py`.
+  Was: *"A Composable Analytical Framework for Machine Learning Systems."*
+  Now: *"MLSys·im: First-Principles Infrastructure Modeling for Machine
+  Learning Systems."*
+
+### 🏗️ Packaging & Dependencies
+
+- Version bumped to `0.1.1` across `pyproject.toml`, `mlsysim/__init__.py`,
+  and `CITATION.cff`; `date-released` updated to `2026-04-24`.
+
+### Contributors
+
+- @profvjreddi
 
 ## v0.1.0 (2026-04-01)
 

--- a/mlsysim/docs/tutorials/index.qmd
+++ b/mlsysim/docs/tutorials/index.qmd
@@ -3,10 +3,10 @@ title: "Tutorials"
 subtitle: "Learn ML systems reasoning through the 22 Systems Walls."
 ---
 
-These tutorials teach you to reason quantitatively about ML infrastructure using the
-**MLSys·im** analytical framework. They are organized by the six domains of the
-[22 Systems Walls taxonomy](../architecture.qmd) — the same framework used in the
-*Machine Learning Systems* textbook.
+These tutorials teach you to reason quantitatively about ML infrastructure using
+**MLSys·im**, the first-principles infrastructure modeling engine behind the
+*Machine Learning Systems* textbook. They are organized by the six domains of the
+[22 Systems Walls taxonomy](../architecture.qmd).
 
 **Each tutorial answers one question.** Start at the beginning for a guided path, or
 jump to any domain that matches your interest.

--- a/mlsysim/mlsysim/cli/main.py
+++ b/mlsysim/mlsysim/cli/main.py
@@ -10,9 +10,11 @@ from mlsysim.cli.commands.audit import audit_main
 app = typer.Typer(
     name="mlsysim", 
     help="""
-    **The ML Systems Infrastructure Modeling Engine.**
-    
-    A first-principles analytical framework for predicting performance, cost, and carbon footprint of ML workloads.
+    **First-principles infrastructure modeling for machine learning systems.**
+
+    Predicts performance, cost, and carbon footprint from hardware and
+    workload specifications. The analytical engine behind the
+    *Machine Learning Systems* textbook.
     """,
     no_args_is_help=True,
     add_completion=True,

--- a/mlsysim/pyproject.toml
+++ b/mlsysim/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "mlsysim"
 version = "0.1.1"
-description = "ML Systems Infrastructure Modeling Engine — first-principles analytical framework for ML workloads."
+description = "First-principles infrastructure modeling for machine learning systems — predicts performance, cost, and carbon footprint from hardware and workload specifications."
 readme = "README.md"
 requires-python = ">=3.10"
 authors = [

--- a/mlsysim/tutorial/prerequisites.md
+++ b/mlsysim/tutorial/prerequisites.md
@@ -14,9 +14,9 @@ Everything you need to run the hands-on exercises.
 | Disk | 50 MB | 100 MB |
 | GPU | **Not required** | Not required |
 
-mlsysim is a pure analytical framework -- it models hardware performance
-from first principles without executing any GPU kernels. All exercises
-run on a laptop CPU in seconds.
+mlsysim is a first-principles infrastructure modeling tool -- it models
+hardware performance analytically without executing any GPU kernels.
+All exercises run on a laptop CPU in seconds.
 
 ---
 


### PR DESCRIPTION
## Summary

Three related fixes that together make mlsysim's public-facing identity consistent with the paper title, and give future releases professional, mlsysim-scoped GitHub Release bodies.

### Background

- The 0.1.1 release already corrected the paper *title* in `CITATION.cff`, `README.md`, and `walls.py` docstring
- BUT the package's *self-description* (pyproject description, CLI help, tutorial docs) still used earlier working-title framing (\"analytical framework\") that no longer matches the paper
- AND the 0.1.1 GitHub Release body auto-generated from all monorepo PRs since 0.1.0, pulling in staffml / tinytorch / lab04 work that has nothing to do with mlsysim

## What changes (3 commits)

### Commit 1 — `mlsysim: align package identity copy with paper title`

Four user-facing identity statements updated to echo the paper title (\"First-Principles Infrastructure Modeling for Machine Learning Systems\"):
- `mlsysim/pyproject.toml` — \`description\` field
- `mlsysim/mlsysim/cli/main.py` — \`mlsysim --help\` output
- `mlsysim/docs/tutorials/index.qmd` — tutorial landing blurb
- `mlsysim/tutorial/prerequisites.md` — prerequisites preamble

Descriptive uses of \"analytical framework\" inside the paper and related technical prose are *retained* — those are legitimate category terms situating mlsysim among Paleo, Calculon, Vidur. Only identity-claiming statements are changed.

### Commit 2 — `mlsysim(CHANGELOG): restructure 0.1.1 entry to match release-notes template`

Rewrites the 0.1.1 changelog entry to use a 9-category structure (Solvers, Hardware, Workloads, CLI, Python API, Documentation, Packaging, Bug Fixes, Internal — only sections with content shown). Adds an \"— Optional Theme\" extension to the heading. Adds a format-note comment block at the top of CHANGELOG.md so future authors write entries in the shape the workflow expects to extract.

### Commit 3 — `ci(mlsysim): extract release notes from CHANGELOG.md with template wrapper`

Replaces the auto-generate fallback in `mlsysim-pypi-publish.yml`. New logic:
1. If `RELEASE_NOTES_<version>.md` exists → use it as-is (milestone escape hatch)
2. Otherwise → extract `## vX.Y.Z` section from CHANGELOG.md, wrap with:
   - Title \`MLSys·im X.Y.Z — <Optional Theme>\`
   - Sub-title pointing at the textbook
   - CHANGELOG body (unchanged)
   - Install block
   - Links (PyPI, Docs, CHANGELOG, diff-from-previous)
   - Persistent \"About MLSys·im\" footer emphasizing the textbook-engine role

The About footer is the key positioning claim: every equation and quantitative result in the textbook is computed by mlsysim, not hand-typed.

## Post-hoc fix to 0.1.1 release

Outside this PR (already applied): the live 0.1.1 GitHub Release body has been replaced via \`gh release edit\` with a body generated locally by the same logic the new workflow uses. This fixes the visible noise on the public release page immediately, without waiting for merge.

View: <https://github.com/harvard-edge/cs249r_book/releases/tag/mlsysim-v0.1.1>

## Test plan

- [x] Identity copy audit: all remaining \"analytical framework\" uses classified (identity-claim → fixed; technical-category → left)
- [x] YAML syntax valid (\`python -c 'import yaml; yaml.safe_load(...)'\`)
- [x] Local extraction test against real CHANGELOG.md produces clean body
- [x] 0.1.1 release body post-hoc replacement verified
- [ ] Next real release exercises the full extract+wrap path (no action for this PR — next bump naturally tests it)

## Risk

Low. All changes are either copy/documentation or workflow-only. The workflow change fallsback safely: if CHANGELOG extraction fails (missing section), the job errors out BEFORE the release is created.