### PR TITLE
polish(tinytorch/ux): hero hierarchy + milestone roster + honest star CTA

### DIFF
--- a/tinytorch/quarto/assets/styles/style.scss
+++ b/tinytorch/quarto/assets/styles/style.scss
@@ -256,6 +256,65 @@ $callout-secondary-bg: rgba($callout-secondary, 0.08);
   max-width: 1100px;
 }
 
+// Milestone grid — 6-card roster on the Historical Milestones hub so a
+// first-time reader sees the 1958-2018 arc before any prose. Cards inherit
+// the preface/audience-card flat-with-colored-left-border aesthetic; the
+// per-era color maps to the tier that produces the milestone's modules
+// (foundation blue, architecture purple, optimization orange).
+.milestone-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  margin: 1rem 0 2rem 0;
+  max-width: 1100px;
+}
+.milestone-card {
+  display: block;
+  background: #fafafa;
+  padding: 1rem 1.1rem;
+  border-radius: 0.5rem;
+  border-left: 4px solid #9ca3af; // overridden by [data-era]
+  text-decoration: none !important;
+  color: inherit;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+
+  &:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.06);
+    text-decoration: none;
+  }
+
+  .milestone-year {
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    color: #6b7280;
+    text-transform: uppercase;
+  }
+  .milestone-name {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #1e293b;
+    margin: 0.1rem 0 0.35rem 0;
+  }
+  .milestone-desc {
+    font-size: 0.85rem;
+    color: #475569;
+    line-height: 1.4;
+  }
+
+  &[data-era="foundation"]   { border-left-color: #1976d2; }
+  &[data-era="architecture"] { border-left-color: #7b1fa2; }
+  &[data-era="optimization"] { border-left-color: #f57c00; }
+}
+
+@media (max-width: 768px) {
+  .milestone-grid { grid-template-columns: 1fr 1fr; }
+}
+@media (max-width: 480px) {
+  .milestone-grid { grid-template-columns: 1fr; }
+}
+
 // Audience grid (3-col)
 .audience-grid {
   display: grid;

--- a/tinytorch/quarto/index.qmd
+++ b/tinytorch/quarto/index.qmd
@@ -2,22 +2,28 @@
 pagetitle: "TinyTorch — Don't import torch. Build it."
 ---
 
+<!--
+  Hero hierarchy:
+    h1   = "Don't import it. Build it."   (visual hero, quotable, matches pagetitle)
+    h2/p = "Build your own ML framework."  (subtitle — describes what h1 means)
+  The earlier version had the subtitle rendered bigger than the slogan, which
+  inverted the semantic hierarchy: screen readers and search engines saw the
+  subtitle as the page's most important content. Fixing that here.
+-->
 ```{=html}
-<p style="text-align: center; font-size: 2.5rem; margin: 1rem 0 0.5rem 0; font-weight: 700;">
-Build Your Own ML Framework
+<h1 class="hero-gradient-text">Don't import it. Build it.</h1>
+
+<p style="text-align: center; font-size: 1.25rem; margin: 0.25rem 0 0.5rem 0; font-weight: 500; color: #475569;">
+Build your own ML framework — from tensors to systems.
 
 </p>
+
 <p style="text-align: center; margin: 0 0 1rem 0;">
-<span class="preview-badge">Preview · Classroom ready 2026</span>
+<span class="preview-badge">Preview · Classroom ready Fall 2026</span>
 </p>
 
-<h2 class="hero-gradient-text">
-Don't import it. Build it.
-
-</h2>
-
-<p style="text-align: center; font-size: 1.15rem; margin: 0 auto 1.5rem auto; max-width: 750px; color: #374151;">
-From tensors to systems. An educational framework for building and optimizing ML—understand how PyTorch, TensorFlow, and JAX really work.
+<p style="text-align: center; font-size: 1.1rem; margin: 0 auto 1.5rem auto; max-width: 750px; color: #374151;">
+An educational framework for building and optimizing ML — understand how PyTorch, TensorFlow, and JAX really work.
 
 </p>
 
@@ -29,7 +35,7 @@ From tensors to systems. An educational framework for building and optimizing ML
 <span>⭐</span>
 
 <span id="star-count-hero" style="font-weight: 600;">...</span>
-<span>learners · every ⭐ helps support free ML education</span>
+<span>stars on GitHub — <strong>add yours</strong> and support free ML education</span>
 </a>
 
 </div>

--- a/tinytorch/quarto/milestones/index.qmd
+++ b/tinytorch/quarto/milestones/index.qmd
@@ -7,6 +7,48 @@
 Milestones are runnable recreations of historical ML breakthroughs that use **YOUR** TinyTorch implementations. Each one validates that the components you built across the modules can reproduce results that once made headlines.
 :::
 
+```{=html}
+<!--
+  Six-milestone roster — appears right after the About-This-Part callout so a
+  first-time reader sees the concrete 1958 -> 2018 arc before any prose. The
+  cards mirror the preface audience-card aesthetic (neutral fill, colored
+  left border) so they feel native to the TinyTorch design system. Detailed
+  journey table with required-modules stays further down the page.
+-->
+<div class="milestone-grid">
+<a href="01_perceptron.html" class="milestone-card" data-era="foundation">
+  <div class="milestone-year">1958</div>
+  <div class="milestone-name">Perceptron</div>
+  <div class="milestone-desc">First neural network — forward pass + training</div>
+</a>
+<a href="02_xor.html" class="milestone-card" data-era="foundation">
+  <div class="milestone-year">1969</div>
+  <div class="milestone-name">XOR Crisis</div>
+  <div class="milestone-desc">The proof that stalled AI for a decade</div>
+</a>
+<a href="03_mlp.html" class="milestone-card" data-era="foundation">
+  <div class="milestone-year">1986</div>
+  <div class="milestone-name">MLP Revival</div>
+  <div class="milestone-desc">Backprop solves XOR — revival begins</div>
+</a>
+<a href="04_cnn.html" class="milestone-card" data-era="architecture">
+  <div class="milestone-year">1998</div>
+  <div class="milestone-name">CNN Revolution</div>
+  <div class="milestone-desc">Convolutions clear 70%+ on CIFAR-10</div>
+</a>
+<a href="05_transformer.html" class="milestone-card" data-era="architecture">
+  <div class="milestone-year">2017</div>
+  <div class="milestone-name">Transformers</div>
+  <div class="milestone-desc">Multi-head attention on a structured task</div>
+</a>
+<a href="06_mlperf.html" class="milestone-card" data-era="optimization">
+  <div class="milestone-year">2018</div>
+  <div class="milestone-name">MLPerf</div>
+  <div class="milestone-desc">Production optimization pipeline</div>
+</a>
+</div>
+```
+
 ## Overview
 
 You've spent the modules building a working ML framework — tensors, autograd, layers, optimizers, attention. The milestones answer the only question that matters: does it actually run the experiments that defined the field?


### PR DESCRIPTION
## Summary

Round-2 UX polish pass after a Playwright walkthrough. Three surgical fixes:

| # | Fix | File | Why |
|---|---|---|---|
| 1 | Hero headline hierarchy swap | \`index.qmd\` | Tagline was bigger than the memorable slogan; H1/H2 now match visual weight |
| 2 | Preview badge: \"2026\" -> \"Fall 2026\" | \`index.qmd\` | We're in 2026 already — old copy was ambiguous |
| 3 | Star-count CTA is honest about what the number is | \`index.qmd\` | \"learners\" was conflated with GitHub stars — now says \"stars on GitHub\" with a concrete action |
| 4 | Six-card milestone roster above \"Overview\" | \`milestones/index.qmd\` + \`style.scss\` | First-time reader sees 1958-2018 arc at a glance |

## Before → After copy

- **H1**: \"Build Your Own ML Framework\" (rendered as a big <p>) → **\"Don't import it. Build it.\"** (real h1, matches pagetitle)
- **Subtitle**: *(none)* → \"Build your own ML framework — from tensors to systems.\"
- **Badge**: \"Preview · Classroom ready 2026\" → \"Preview · Classroom ready Fall 2026\"
- **Star link**: \"⭐ {N} learners · every ⭐ helps support free ML education\" → \"⭐ {N} stars on GitHub — **add yours** and support free ML education\"

## Milestone hub — new 6-card roster

The hub previously opened with two prose paragraphs before any concrete listing of the milestones. Now the About-This-Part callout is followed immediately by a 6-card grid: **1958 Perceptron → 1969 XOR Crisis → 1986 MLP Revival → 1998 CNN Revolution → 2017 Transformers → 2018 MLPerf**. Color coding mirrors the producing tier (Foundation blue / Architecture purple / Optimization orange) for visual continuity with the rest of the site. Journey table with per-milestone module dependencies stays in place further down.

## Deferred (intentionally)

From the same walkthrough, these were flagged as valid but out of scope for this PR:

- **Swap action cards above Module Info on module pages** — touches ~20 QMD files; wants a template-level intervention, not ad-hoc rewrites
- **Sticky per-module progress indicator** — wants JS + scroll listener
- **Announcement-bar collapse on narrow viewport** — JS + cross-site change
- **Olympics \"Coming Soon\" → dated promise** — per user direction, the Olympics launch content is landing in a separate PR in the next few days, so leaving the placeholder as-is

## Verification (Playwright)

```
Home h1          : \"Don't import it. Build it.\" at 42.5px  ✓
Preview badge    : \"Preview · Classroom ready Fall 2026\"   ✓
Star link        : \"⭐ 23,767 stars on GitHub — add yours
                    and support free ML education\"          ✓
Milestone grid   : 6 cards rendered with correct data-era colors
                   foundation  rgb(25, 118, 210)
                   architecture rgb(123, 31, 162)
                   optimization rgb(245, 124, 0)              ✓
```

## Test plan

- [x] Local \`quarto preview\` renders home + milestones cleanly
- [x] Computed styles verified via Playwright
- [x] Pre-commit passes
- [ ] Post-merge: eye the deployed tinytorch preview + verify mobile rendering of the 6-card grid