### PR TITLE
fix(tinytorch/ux): readable code-block surface in dark mode

### DIFF
--- a/tinytorch/quarto/assets/styles/dark-mode.scss
+++ b/tinytorch/quarto/assets/styles/dark-mode.scss
@@ -177,6 +177,25 @@ a {
   border: 1px solid $border-color-dark;
 }
 
+// --- Code block surface in dark mode ---
+// Quarto's default styles `div.sourceCode { background: rgba(233, 236, 239, 0.65) }`
+// — a LIGHT fill at 65% opacity. Over the #1a1a1a body that blends to a
+// washed-out medium grey (~#a0a0a0) which fights the syntax-highlighted
+// foreground. Replace with an explicit dark surface that's slightly
+// lighter than the body so blocks read as distinct rectangles.
+div.sourceCode {
+  background-color: #22262c !important;
+  border: 1px solid $border-color-dark;
+}
+
+// Inline code (e.g. `tinytorch/` in prose) has the same washed-grey
+// problem. A translucent slate fill keeps it visually distinct from
+// surrounding prose without competing with full code blocks.
+:not(pre) > code:not(.sourceCode) {
+  background-color: rgba(110, 118, 129, 0.35) !important;
+  color: #e6edf3 !important;
+}
+
 // --- Dark-mode safety net for inline-styled light-fill panels ---
 // Several .qmd pages still use inline `style="background: #X..."` for
 // callout-style panels (the same failure mode #1529 fixed for preface).


### PR DESCRIPTION
Follow-up to #1537. The shipped dark-mode coverage was correct for panels/sidebar/cards, but Quarto's default code-block style is

\`\`\`css
div.sourceCode { background: rgba(233, 236, 239, 0.65); }
\`\`\`

— a LIGHT fill at 65% opacity. Over the dark body (\`#1a1a1a\`) that blends to a washed-out medium grey (~\`#a0a0a0\`) which fights the syntax-highlighted foreground. User reported this on the live site after #1537 deployed.

## Fix

Override in \`dark-mode.scss\`:
- \`div.sourceCode\` → explicit \`#22262c\` surface (slightly lighter than body for delineation) + 1px border using \`\$border-color-dark\`.
- Inline \`code\` (e.g. \`tinytorch/\` in prose) → translucent slate \`rgba(110, 118, 129, 0.35)\` + light text \`#e6edf3\`.

## Verification

Local Playwright on getting-started.html (most code-heavy page): code block bg \`rgb(34, 38, 44)\` = \`#22262c\`, border \`#454d55\`, body bg unchanged \`#1a1a1a\`. Visually distinct rectangles, syntax highlighting now reads cleanly.

## Deploy

Same path as #1537: merge → re-trigger \`tinytorch-publish-live\` with \`site_only: true\`.