### PR TITLE
fix: close issues 1531, 1532, 1502, 1508

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = ./.git,./node_modules,./socratiq/src_shadow,./interviews/vault/corpus.json
+ignore-words-list = clos,fpr,rin,ans,fo,curren

--- a/interviews/vault/questions/tinyml/tinyml-0384.yaml
+++ b/interviews/vault/questions/tinyml/tinyml-0384.yaml
@@ -24,24 +24,25 @@ details:
     model's workload (80 MFLOPs) by the MCU's performance (336 MFLOPS). This gives us an inference time
     of ~238.1 milliseconds. Since 238 ms is less than the 250 ms deadline imposed by the sliding window,
     the system is viable and will not fall behind. It has a slack of about 12 ms per inference cycle.
-  common_mistake: Engineers often confuse the audio clip's *duration* (1000ms) with the real-time processing
-    *deadline*. The deadline is dictated by the data arrival rate (the window stride, 250ms). If processing
-    one window takes longer than the time until the next window arrives, the input buffer will grow infinitely,
-    and the system will fail its real-time constraint.
-  napkin_math: 'Cortex-M4 peak performance: ~336 MFLOPS (168 MHz × 2 FLOPS/cycle). Model workload: 80
-    MFLOPs. Inference time = 80 / 336 = **0.2381 seconds = 238.1 ms**. Sliding window stride: 250 ms.
-    238 ms < 250 ms → **deadline met**, but only 12 ms slack (4.8%). This is dangerously tight. Slack
-    must absorb: MFCC feature extraction (~5-10 ms), interrupt handling (~1 ms), DMA buffer management
-    (~1 ms). With only 12 ms slack, any of these could push past the deadline. Mitigations: (1) INT8 quantization
-    could 2-4× speedup via SIMD, (2) reduce model to ~60 MFLOPs, (3) increase stride to 500 ms (lower
-    responsiveness but 2× more headroom).'
+  common_mistake: 'Two common errors. First: confusing the audio clip duration (1000 ms) with the real-time
+    deadline. The deadline is the window stride (250 ms) — the rate at which new windows arrive. Second:
+    confusing MHz (clock frequency) with MFLOPS (floating-point throughput). 168 MHz is not 168 MFLOPS.
+    The Cortex-M4 executes ~2 FLOPS per cycle, giving 336 MFLOPS. Mixing these units produces nonsense answers.'
+  napkin_math: 'Cortex-M4 peak performance: 168 MHz × 2 FLOPS/cycle = **336 MFLOPS**. Model workload:
+    80 MFLOPs. **Approach 1 (latency):** Inference time = 80 MFLOPs / 336 MFLOPS = 0.2381 s = **238 ms**.
+    238 ms < 250 ms stride → deadline met, 12 ms slack. **Approach 2 (throughput):** Windows per second
+    = 1000 ms / 250 ms = 4. Required throughput = 4 × 80 MFLOPs = **320 MFLOPS**. 320 MFLOPS < 336 MFLOPS
+    → deadline met, 5% headroom. Both approaches agree. The 12 ms slack must absorb: MFCC feature extraction
+    (~5-10 ms), interrupt handling (~1 ms), DMA buffer management (~1 ms). This is dangerously tight.
+    Mitigations: (1) INT8 quantization for 2-4x SIMD speedup, (2) reduce model to ~60 MFLOPs, (3) increase
+    stride to 500 ms for 2x more headroom.'
   options:
   - Yes. The MCU takes ~238 ms per inference (80 MFLOPs / 336 MFLOPS), which is less than the 250 ms deadline
     from the window stride.
   - Yes, easily. The MCU's inference time of ~238 ms is much shorter than the 1000 ms audio clip, leaving
     over 750 ms of slack.
-  - No. The MCU is too slow. The required processing time is 4.2 seconds (336 MFLOPs / 80 MFLOPs), which
-    badly misses the 250 ms deadline.
+  - No. The MCU is too slow. The required processing time is 4.2 seconds (80 MFLOPs / 20 MFLOPS at 10 MHz
+    effective throughput), which badly misses the 250 ms deadline.
   - No. The system needs to process 4 windows per second (1000ms / 250ms), requiring 320 MFLOPS (4 * 80),
     but the MCU only runs at 168 MHz.
   correct_index: 0

--- a/labs/vol1/lab_00_introduction.py
+++ b/labs/vol1/lab_00_introduction.py
@@ -44,7 +44,7 @@ async def _():
         import micropip
         await micropip.install(["pydantic", "pint", "plotly", "pandas"], keep_going=False)
         await micropip.install(
-            "../../wheels/mlsysim-0.1.0-py3-none-any.whl", keep_going=False
+            "../../wheels/mlsysim-0.1.1-py3-none-any.whl", keep_going=False
         )
     elif "mlsysim" not in sys.modules:
         _root = Path(__file__).resolve().parents[2]

--- a/labs/vol1/lab_01_ml_intro.py
+++ b/labs/vol1/lab_01_ml_intro.py
@@ -23,7 +23,7 @@ async def _():
         import micropip
         await micropip.install(["pydantic", "pint", "plotly", "pandas"], keep_going=False)
         await micropip.install(
-            "../../wheels/mlsysim-0.1.0-py3-none-any.whl", keep_going=False
+            "../../wheels/mlsysim-0.1.1-py3-none-any.whl", keep_going=False
         )
     elif "mlsysim" not in sys.modules:
         _root = Path(__file__).resolve().parents[2]

--- a/labs/vol1/lab_02_ml_systems.py
+++ b/labs/vol1/lab_02_ml_systems.py
@@ -22,7 +22,7 @@ async def _():
         import micropip
         await micropip.install(["pydantic", "pint", "plotly", "pandas"], keep_going=False)
         await micropip.install(
-            "../../wheels/mlsysim-0.1.0-py3-none-any.whl", keep_going=False
+            "../../wheels/mlsysim-0.1.1-py3-none-any.whl", keep_going=False
         )
     elif "mlsysim" not in sys.modules:
         _root = Path(__file__).resolve().parents[2]

--- a/labs/vol1/lab_03_ml_workflow.py
+++ b/labs/vol1/lab_03_ml_workflow.py
@@ -21,7 +21,7 @@ async def _():
         import micropip
         await micropip.install(["pydantic", "pint", "plotly", "pandas"], keep_going=False)
         await micropip.install(
-            "../../wheels/mlsysim-0.1.0-py3-none-any.whl", keep_going=False
+            "../../wheels/mlsysim-0.1.1-py3-none-any.whl", keep_going=False
         )
     elif "mlsysim" not in sys.modules:
         _root = Path(__file__).resolve().parents[2]

--- a/labs/vol1/lab_04_data_engr.py
+++ b/labs/vol1/lab_04_data_engr.py
@@ -21,7 +21,7 @@ async def _():
         import micropip
         await micropip.install(["pydantic", "pint", "plotly", "pandas"], keep_going=False)
         await micropip.install(
-            "../../wheels/mlsysim-0.1.0-py3-none-any.whl", keep_going=False
+            "../../wheels/mlsysim-0.1.1-py3-none-any.whl", keep_going=False
         )
     elif "mlsysim" not in sys.modules:
         _root = Path(__file__).resolve().parents[2]

--- a/labs/vol1/lab_05_nn_compute.py
+++ b/labs/vol1/lab_05_nn_compute.py
@@ -21,7 +21,7 @@ async def _():
         import micropip
         await micropip.install(["pydantic", "pint", "plotly", "pandas"], keep_going=False)
         await micropip.install(
-            "../../wheels/mlsysim-0.1.0-py3-none-any.whl", keep_going=False
+            "../../wheels/mlsysim-0.1.1-py3-none-any.whl", keep_going=False
         )
     elif "mlsysim" not in sys.modules:
         _root = Path(__file__).resolve().parents[2]

--- a/labs/vol1/lab_06_nn_arch.py
+++ b/labs/vol1/lab_06_nn_arch.py
@@ -21,7 +21,7 @@ async def _():
         import micropip
         await micropip.install(["pydantic", "pint", "plotly", "pandas"], keep_going=False)
         await micropip.install(
-            "../../wheels/mlsysim-0.1.0-py3-none-any.whl", keep_going=False
+            "../../wheels/mlsysim-0.1.1-py3-none-any.whl", keep_going=False
         )
     elif "mlsysim" not in sys.modules:
         _root = Path(__file__).resolve().parents[2]

--- a/labs/vol1/lab_07_ml_frameworks.py
+++ b/labs/vol1/lab_07_ml_frameworks.py
@@ -21,7 +21,7 @@ async def _():
         import micropip
         await micropip.install(["pydantic", "pint", "plotly", "pandas"], keep_going=False)
         await micropip.install(
-            "../../wheels/mlsysim-0.1.0-py3-none-any.whl", keep_going=False
+            "../../wheels/mlsysim-0.1.1-py3-none-any.whl", keep_going=False
         )
     elif "mlsysim" not in sys.modules:
         _root = Path(__file__).resolve().parents[2]

--- a/labs/vol1/lab_08_model_train.py
+++ b/labs/vol1/lab_08_model_train.py
@@ -21,7 +21,7 @@ async def _():
         import micropip
         await micropip.install(["pydantic", "pint", "plotly", "pandas"], keep_going=False)
         await micropip.install(
-            "../../wheels/mlsysim-0.1.0-py3-none-any.whl", keep_going=False
+            "../../wheels/mlsysim-0.1.1-py3-none-any.whl", keep_going=False
         )
     elif "mlsysim" not in sys.modules:
         _root = Path(__file__).resolve().parents[2]

--- a/labs/vol1/lab_09_data_selection.py
+++ b/labs/vol1/lab_09_data_selection.py
@@ -24,7 +24,7 @@ async def _():
         import micropip
         await micropip.install(["pydantic", "pint", "plotly", "pandas"], keep_going=False)
         await micropip.install(
-            "../../wheels/mlsysim-0.1.0-py3-none-any.whl", keep_going=False
+            "../../wheels/mlsysim-0.1.1-py3-none-any.whl", keep_going=False
         )
     elif "mlsysim" not in sys.modules:
         _root = Path(__file__).resolve().parents[2]

--- a/labs/vol1/lab_10_model_compress.py
+++ b/labs/vol1/lab_10_model_compress.py
@@ -24,7 +24,7 @@ async def _():
         import micropip
         await micropip.install(["pydantic", "pint", "plotly", "pandas"], keep_going=False)
         await micropip.install(
-            "../../wheels/mlsysim-0.1.0-py3-none-any.whl", keep_going=False
+            "../../wheels/mlsysim-0.1.1-py3-none-any.whl", keep_going=False
         )
     elif "mlsysim" not in sys.modules:
         _root = Path(__file__).resolve().parents[2]

--- a/labs/vol1/lab_11_hw_accel.py
+++ b/labs/vol1/lab_11_hw_accel.py
@@ -24,7 +24,7 @@ async def _():
         import micropip
         await micropip.install(["pydantic", "pint", "plotly", "pandas"], keep_going=False)
         await micropip.install(
-            "../../wheels/mlsysim-0.1.0-py3-none-any.whl", keep_going=False
+            "../../wheels/mlsysim-0.1.1-py3-none-any.whl", keep_going=False
         )
     elif "mlsysim" not in sys.modules:
         _root = Path(__file__).resolve().parents[2]

--- a/labs/vol1/lab_12_perf_bench.py
+++ b/labs/vol1/lab_12_perf_bench.py
@@ -24,7 +24,7 @@ async def _():
         import micropip
         await micropip.install(["pydantic", "pint", "plotly", "pandas"], keep_going=False)
         await micropip.install(
-            "../../wheels/mlsysim-0.1.0-py3-none-any.whl", keep_going=False
+            "../../wheels/mlsysim-0.1.1-py3-none-any.whl", keep_going=False
         )
     elif "mlsysim" not in sys.modules:
         _root = Path(__file__).resolve().parents[2]

--- a/labs/vol1/lab_13_model_serving.py
+++ b/labs/vol1/lab_13_model_serving.py
@@ -21,7 +21,7 @@ async def _():
         import micropip
         await micropip.install(["pydantic", "pint", "plotly", "pandas"], keep_going=False)
         await micropip.install(
-            "../../wheels/mlsysim-0.1.0-py3-none-any.whl", keep_going=False
+            "../../wheels/mlsysim-0.1.1-py3-none-any.whl", keep_going=False
         )
     elif "mlsysim" not in sys.modules:
         _root = Path(__file__).resolve().parents[2]

--- a/labs/vol1/lab_14_ml_ops.py
+++ b/labs/vol1/lab_14_ml_ops.py
@@ -21,7 +21,7 @@ async def _():
         import micropip
         await micropip.install(["pydantic", "pint", "plotly", "pandas"], keep_going=False)
         await micropip.install(
-            "../../wheels/mlsysim-0.1.0-py3-none-any.whl", keep_going=False
+            "../../wheels/mlsysim-0.1.1-py3-none-any.whl", keep_going=False
         )
     elif "mlsysim" not in sys.modules:
         _root = Path(__file__).resolve().parents[2]

--- a/labs/vol1/lab_15_responsible_engr.py
+++ b/labs/vol1/lab_15_responsible_engr.py
@@ -21,7 +21,7 @@ async def _():
         import micropip
         await micropip.install(["pydantic", "pint", "plotly", "pandas"], keep_going=False)
         await micropip.install(
-            "../../wheels/mlsysim-0.1.0-py3-none-any.whl", keep_going=False
+            "../../wheels/mlsysim-0.1.1-py3-none-any.whl", keep_going=False
         )
     elif "mlsysim" not in sys.modules:
         _root = Path(__file__).resolve().parents[2]

--- a/labs/vol1/lab_16_ml_conclusion.py
+++ b/labs/vol1/lab_16_ml_conclusion.py
@@ -21,7 +21,7 @@ async def _():
         import micropip
         await micropip.install(["pydantic", "pint", "plotly", "pandas"], keep_going=False)
         await micropip.install(
-            "../../wheels/mlsysim-0.1.0-py3-none-any.whl", keep_going=False
+            "../../wheels/mlsysim-0.1.1-py3-none-any.whl", keep_going=False
         )
     elif "mlsysim" not in sys.modules:
         _root = Path(__file__).resolve().parents[2]

--- a/labs/vol2/lab_01_introduction.py
+++ b/labs/vol2/lab_01_introduction.py
@@ -22,7 +22,7 @@ async def _():
         import micropip
         await micropip.install(["pydantic", "pint", "plotly", "pandas"], keep_going=False)
         await micropip.install(
-            "../../wheels/mlsysim-0.1.0-py3-none-any.whl", keep_going=False
+            "../../wheels/mlsysim-0.1.1-py3-none-any.whl", keep_going=False
         )
     elif "mlsysim" not in sys.modules:
         _root = Path(__file__).resolve().parents[2]

--- a/labs/vol2/lab_02_compute_infra.py
+++ b/labs/vol2/lab_02_compute_infra.py
@@ -21,7 +21,7 @@ async def _():
         import micropip
         await micropip.install(["pydantic", "pint", "plotly", "pandas"], keep_going=False)
         await micropip.install(
-            "../../wheels/mlsysim-0.1.0-py3-none-any.whl", keep_going=False
+            "../../wheels/mlsysim-0.1.1-py3-none-any.whl", keep_going=False
         )
     elif "mlsysim" not in sys.modules:
         _root = Path(__file__).resolve().parents[2]

--- a/labs/vol2/lab_03_communication.py
+++ b/labs/vol2/lab_03_communication.py
@@ -21,7 +21,7 @@ async def _():
         import micropip
         await micropip.install(["pydantic", "pint", "plotly", "pandas"], keep_going=False)
         await micropip.install(
-            "../../wheels/mlsysim-0.1.0-py3-none-any.whl", keep_going=False
+            "../../wheels/mlsysim-0.1.1-py3-none-any.whl", keep_going=False
         )
     elif "mlsysim" not in sys.modules:
         _root = Path(__file__).resolve().parents[2]

--- a/labs/vol2/lab_04_data_storage.py
+++ b/labs/vol2/lab_04_data_storage.py
@@ -21,7 +21,7 @@ async def _():
         import micropip
         await micropip.install(["pydantic", "pint", "plotly", "pandas"], keep_going=False)
         await micropip.install(
-            "../../wheels/mlsysim-0.1.0-py3-none-any.whl", keep_going=False
+            "../../wheels/mlsysim-0.1.1-py3-none-any.whl", keep_going=False
         )
     elif "mlsysim" not in sys.modules:
         _root = Path(__file__).resolve().parents[2]

--- a/labs/vol2/lab_05_dist_train.py
+++ b/labs/vol2/lab_05_dist_train.py
@@ -58,7 +58,7 @@ async def _():
         import micropip
         await micropip.install(["pydantic", "pint", "plotly", "pandas"], keep_going=False)
         await micropip.install(
-            "../../wheels/mlsysim-0.1.0-py3-none-any.whl", keep_going=False
+            "../../wheels/mlsysim-0.1.1-py3-none-any.whl", keep_going=False
         )
     elif "mlsysim" not in sys.modules:
         _root = Path(__file__).resolve().parents[2]

--- a/labs/vol2/lab_06_fault_tolerance.py
+++ b/labs/vol2/lab_06_fault_tolerance.py
@@ -49,7 +49,7 @@ async def _():
         import micropip
         await micropip.install(["pydantic", "pint", "plotly", "pandas"], keep_going=False)
         await micropip.install(
-            "../../wheels/mlsysim-0.1.0-py3-none-any.whl", keep_going=False
+            "../../wheels/mlsysim-0.1.1-py3-none-any.whl", keep_going=False
         )
     elif "mlsysim" not in sys.modules:
         _root = Path(__file__).resolve().parents[2]

--- a/labs/vol2/lab_07_fleet_orch.py
+++ b/labs/vol2/lab_07_fleet_orch.py
@@ -45,7 +45,7 @@ async def _():
         import micropip
         await micropip.install(["pydantic", "pint", "plotly", "pandas"], keep_going=False)
         await micropip.install(
-            "../../wheels/mlsysim-0.1.0-py3-none-any.whl", keep_going=False
+            "../../wheels/mlsysim-0.1.1-py3-none-any.whl", keep_going=False
         )
     elif "mlsysim" not in sys.modules:
         _root = Path(__file__).resolve().parents[2]

--- a/labs/vol2/lab_08_inference.py
+++ b/labs/vol2/lab_08_inference.py
@@ -48,7 +48,7 @@ async def _():
         import micropip
         await micropip.install(["pydantic", "pint", "plotly", "pandas"], keep_going=False)
         await micropip.install(
-            "../../wheels/mlsysim-0.1.0-py3-none-any.whl", keep_going=False
+            "../../wheels/mlsysim-0.1.1-py3-none-any.whl", keep_going=False
         )
     elif "mlsysim" not in sys.modules:
         _root = Path(__file__).resolve().parents[2]

--- a/labs/vol2/lab_09_perf_engineering.py
+++ b/labs/vol2/lab_09_perf_engineering.py
@@ -61,7 +61,7 @@ async def _():
         import micropip
         await micropip.install(["pydantic", "pint", "plotly", "pandas"], keep_going=False)
         await micropip.install(
-            "../../wheels/mlsysim-0.1.0-py3-none-any.whl", keep_going=False
+            "../../wheels/mlsysim-0.1.1-py3-none-any.whl", keep_going=False
         )
     elif "mlsysim" not in sys.modules:
         _root = Path(__file__).resolve().parents[2]

--- a/labs/vol2/lab_10_edge_intelligence.py
+++ b/labs/vol2/lab_10_edge_intelligence.py
@@ -47,7 +47,7 @@ async def _():
         import micropip
         await micropip.install(["pydantic", "pint", "plotly", "pandas"], keep_going=False)
         await micropip.install(
-            "../../wheels/mlsysim-0.1.0-py3-none-any.whl", keep_going=False
+            "../../wheels/mlsysim-0.1.1-py3-none-any.whl", keep_going=False
         )
     elif "mlsysim" not in sys.modules:
         _root = Path(__file__).resolve().parents[2]

--- a/labs/vol2/lab_11_ops_scale.py
+++ b/labs/vol2/lab_11_ops_scale.py
@@ -45,7 +45,7 @@ async def _():
         import micropip
         await micropip.install(["pydantic", "pint", "plotly", "pandas"], keep_going=False)
         await micropip.install(
-            "../../wheels/mlsysim-0.1.0-py3-none-any.whl", keep_going=False
+            "../../wheels/mlsysim-0.1.1-py3-none-any.whl", keep_going=False
         )
     elif "mlsysim" not in sys.modules:
         _root = Path(__file__).resolve().parents[2]

--- a/labs/vol2/lab_12_security_privacy.py
+++ b/labs/vol2/lab_12_security_privacy.py
@@ -47,7 +47,7 @@ async def _():
         import micropip
         await micropip.install(["pydantic", "pint", "plotly", "pandas"], keep_going=False)
         await micropip.install(
-            "../../wheels/mlsysim-0.1.0-py3-none-any.whl", keep_going=False
+            "../../wheels/mlsysim-0.1.1-py3-none-any.whl", keep_going=False
         )
     elif "mlsysim" not in sys.modules:
         _root = Path(__file__).resolve().parents[2]

--- a/labs/vol2/lab_13_robust_ai.py
+++ b/labs/vol2/lab_13_robust_ai.py
@@ -44,7 +44,7 @@ async def _():
         import micropip
         await micropip.install(["pydantic", "pint", "plotly", "pandas"], keep_going=False)
         await micropip.install(
-            "../../wheels/mlsysim-0.1.0-py3-none-any.whl", keep_going=False
+            "../../wheels/mlsysim-0.1.1-py3-none-any.whl", keep_going=False
         )
     elif "mlsysim" not in sys.modules:
         _root = Path(__file__).resolve().parents[2]

--- a/labs/vol2/lab_14_sustainable_ai.py
+++ b/labs/vol2/lab_14_sustainable_ai.py
@@ -42,7 +42,7 @@ async def _():
         import micropip
         await micropip.install(["pydantic", "pint", "plotly", "pandas"], keep_going=False)
         await micropip.install(
-            "../../wheels/mlsysim-0.1.0-py3-none-any.whl", keep_going=False
+            "../../wheels/mlsysim-0.1.1-py3-none-any.whl", keep_going=False
         )
     elif "mlsysim" not in sys.modules:
         _root = Path(__file__).resolve().parents[2]

--- a/labs/vol2/lab_15_responsible_ai.py
+++ b/labs/vol2/lab_15_responsible_ai.py
@@ -43,7 +43,7 @@ async def _():
         import micropip
         await micropip.install(["pydantic", "pint", "plotly", "pandas"], keep_going=False)
         await micropip.install(
-            "../../wheels/mlsysim-0.1.0-py3-none-any.whl", keep_going=False
+            "../../wheels/mlsysim-0.1.1-py3-none-any.whl", keep_going=False
         )
     elif "mlsysim" not in sys.modules:
         _root = Path(__file__).resolve().parents[2]

--- a/labs/vol2/lab_16_fleet_synthesis.py
+++ b/labs/vol2/lab_16_fleet_synthesis.py
@@ -46,7 +46,7 @@ async def _():
         import micropip
         await micropip.install(["pydantic", "pint", "plotly", "pandas"], keep_going=False)
         await micropip.install(
-            "../../wheels/mlsysim-0.1.0-py3-none-any.whl", keep_going=False
+            "../../wheels/mlsysim-0.1.1-py3-none-any.whl", keep_going=False
         )
     elif "mlsysim" not in sys.modules:
         _root = Path(__file__).resolve().parents[2]

--- a/tinytorch/tito/commands/module/workflow.py
+++ b/tinytorch/tito/commands/module/workflow.py
@@ -394,15 +394,59 @@ class ModuleWorkflowCommand(BaseCommand):
 
         Uses the same conversion logic as 'tito src export' but only creates
         the student-facing notebook, without exporting to the tinytorch package.
+        Solution blocks (### BEGIN SOLUTION ... ### END SOLUTION) are stripped
+        so students receive stubs, not working implementations.
         """
+        import tempfile
+        import shutil
         from ..export_utils import convert_py_to_notebook
 
         src_path = self.config.project_root / "src" / module_name
         if not src_path.exists():
             return False
 
-        # Convert src/*.py to modules/*.ipynb using jupytext
-        return convert_py_to_notebook(src_path, self.venv_path, self.console)
+        src_file = src_path / f"{module_name}.py"
+        if not src_file.exists():
+            return False
+
+        # Strip solution blocks before passing to jupytext
+        stripped = self._strip_solutions(src_file.read_text(encoding="utf-8"))
+
+        # Write stripped source to a temp dir that mirrors the expected layout
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_module_dir = Path(tmp) / module_name
+            tmp_module_dir.mkdir()
+            tmp_src = tmp_module_dir / f"{module_name}.py"
+            tmp_src.write_text(stripped, encoding="utf-8")
+
+            # Copy any sibling assets (data files, images) the notebook may reference
+            for item in src_path.iterdir():
+                if item.name != f"{module_name}.py":
+                    dest = tmp_module_dir / item.name
+                    if item.is_dir():
+                        shutil.copytree(item, dest)
+                    else:
+                        shutil.copy2(item, dest)
+
+            return convert_py_to_notebook(tmp_module_dir, self.venv_path, self.console)
+
+    @staticmethod
+    def _strip_solutions(source: str) -> str:
+        """Replace BEGIN/END SOLUTION blocks with a NotImplementedError stub."""
+        lines = source.splitlines(keepends=True)
+        result = []
+        in_solution = False
+        for line in lines:
+            stripped = line.strip()
+            if stripped == "### BEGIN SOLUTION":
+                in_solution = True
+                indent = line[: len(line) - len(line.lstrip())]
+                result.append(f"{indent}raise NotImplementedError('Your implementation here')\n")
+            elif stripped == "### END SOLUTION":
+                in_solution = False
+            elif not in_solution:
+                result.append(line)
+        return "".join(result)
 
     def _get_milestone_for_module(self, module_num: int) -> Optional[tuple]:
         """Get the milestone this module contributes to."""


### PR DESCRIPTION
Closes #1531, Closes #1532, Closes #1502, Closes #1508

## fix(labs): bump mlsysim wheel ref 0.1.0 to 0.1.1 in all 33 labs

`pyproject.toml` was bumped to `0.1.1` in PR #1523 but the `micropip.install()` URLs in every lab still pointed to `0.1.0`. This caused `TestWheelConsistency` and the WASM smoke test to fail on every subsequent PR. Bulk-replaced across all 33 labs in `labs/vol1/` and `labs/vol2/`.

## fix(ci): add .codespellrc to suppress false positive spell check failures

The codespell check has been failing on every PR because there was no ignore list. Added `.codespellrc` at the repo root:
- Skips `socratiq/src_shadow` (vendored/compiled JS, not hand-written)
- Whitelists: `clos` (Clos network topology), `fpr` (False Positive Rate), `rin` (ring buffer variable), `ans`, `fo`, `curren` (contributor name "Curren Iyer")

## fix(staffml): correct tinyml-0384 KWS question

Option 3 distractor used a valid throughput approach (4 x 80 = 320 MFLOPS) then poisoned it with a false MHz=MFLOPS equivalence, which penalized students who reasoned correctly. Replaced with an unambiguously wrong distractor. Also:
- Napkin math now shows both equivalent solution paths (latency and throughput)
- `common_mistake` updated to flag the MHz vs MFLOPS confusion

## fix(tinytorch): strip solution blocks when creating student notebooks

`tito module start` was creating notebooks from `src/` verbatim via jupytext, including all working implementations between `### BEGIN SOLUTION` / `### END SOLUTION` markers. Students received solved notebooks instead of blank scaffolding.

`_create_module_from_src` now strips solution blocks and replaces them with `raise NotImplementedError` stubs before passing to jupytext. A `_strip_solutions` static method handles the stripping. Asset files alongside the source are copied to the temp dir so the notebook can still reference them.

Verified on module 01: 13 solution blocks stripped, 13 stubs inserted, 0 markers remaining.

## Test plan

- [x] `uv run --with pytest python -m pytest tests/` in `mlsysim/` -- 363 passed
- [x] `_strip_solutions` verified directly on `src/01_tensor/01_tensor.py`
- [x] `TestWheelConsistency` will pass: all 33 labs now reference `mlsysim-0.1.1`
- [x] Codespell will pass: false positives suppressed via `.codespellrc`