### PR TITLE
fix(tinytorch/ux): h3, pre code, and who-card paragraph text visibility

### DIFF
--- a/tinytorch/quarto/_quarto.yml
+++ b/tinytorch/quarto/_quarto.yml
@@ -258,7 +258,9 @@ format:
     number-sections: false
     code-copy: true
     code-overflow: wrap
-    highlight-style: github
+    highlight-style:
+      light: github
+      dark: github-dark
     link-external-icon: false
     link-external-newwindow: true
     anchor-sections: true

--- a/tinytorch/quarto/assets/styles/dark-mode.scss
+++ b/tinytorch/quarto/assets/styles/dark-mode.scss
@@ -75,6 +75,7 @@ a {
 
 .who-card {
   background: #2d2d2d;
+  p { color: #e6e6e6; }
 }
 
 .action-card {

--- a/tinytorch/quarto/assets/styles/style.scss
+++ b/tinytorch/quarto/assets/styles/style.scss
@@ -589,6 +589,9 @@ $callout-secondary-bg: rgba($callout-secondary, 0.08);
   &.btn-blue { background: #3b82f6; }
 }
 
+#quarto-content h3 { color: #d0d0d0 !important; }
+pre code { color: #e6e6e6; }
+
 @media (max-width: 768px) {
   .action-cards {
     grid-template-columns: 1fr;
@@ -642,6 +645,7 @@ pre.mermaid svg {
   p {
     margin: 0.5rem 0 0 0;
     font-size: 0.95rem;
+    color: #475569;
   }
 }
 


### PR DESCRIPTION
## Background

Three small follow-ups on top of the dark-mode UX fixes already merged on `dev` (the inline-style refactor in `tito/milestones.qmd`, sidebar coverage, and `div.sourceCode` dark surface). Found while QA'ing those pages in both modes plus the hybrid state where `data-bs-theme="dark"` is set on `<html>` but the light stylesheet is the active bundle.

## Changes

- **`_quarto.yml`** — split `highlight-style: github` into `light: github` / `dark: github-dark`, so dark-mode code blocks render with the github-dark token palette instead of the light theme's red/blue tokens on a dark surface.

- **`style.scss`**
  - `#quarto-content h3 { color: #d0d0d0 !important }` — keeps subheadings readable on the dark body. `!important` is needed because Quarto re-loads the light bundle as `quarto-color-scheme-extra` after the dark bundle, so equal-specificity rules from `_headers.scss` would otherwise win the cascade.
  - `pre code { color: #e6e6e6 }` — base text color for code blocks. No `!important`, so syntax-highlighted spans (`code span.kw`, `.ex`, `.st`, …) keep their token colors via higher specificity; github-light/-dark theming still works.
  - `.who-card p { color: #475569 }` — pins card paragraph text to slate-500 so it stays readable on the `#fafafa` card surface in **all** states. Previously, when the page was in the hybrid `data-bs-theme="dark"` + light-stylesheet state (Bootstrap sets `--bs-body-color: #dee2e6` under that selector), `.who-card p` inherited a near-white body color and became invisible against the still-light card surface.

- **`dark-mode.scss`** — pair the `.who-card p` fix: when the card flips to `#2d2d2d` in true dark mode, paragraphs go to `#e6e6e6`.

## Test plan

- [ ] `cd tinytorch/quarto && quarto render --to html` succeeds for all pages
- [ ] `_build/tito/milestones.html` in dark mode — H3s like `### Discover/Learn/Run/Track Milestones` readable, code blocks have github-dark tokens on a dark slab, `.who-card` paragraphs readable
- [ ] Same page in light mode — H3s back to dark slate (no light-grey ghost), code blocks on light surface with github-light tokens, `.who-card` paragraphs slate-500
- [ ] Same page in hybrid state (toggle dark via in-page button, then emulate `prefers-color-scheme: light` in DevTools) — `.who-card` paragraphs stay readable
- [ ] Light mode visually unchanged on landing/preface/big-picture pages