### PR TITLE
fix(games): use 'all-time' in display strings to satisfy codespell

### DIFF
--- a/site/assets/games/_archive/roofline.js
+++ b/site/assets/games/_archive/roofline.js
@@ -262,7 +262,7 @@ MLSP.games.roofline = function(canvas, opts) {
     ctx.fillStyle = secs <= 5 ? "#c44" : "#333"; ctx.font = "bold 13px 'Helvetica Neue', Arial, sans-serif";
     ctx.fillText("⏱ " + secs + "s", W/2 + 30, H - 26);
     ctx.fillStyle = "#333"; ctx.font = "11px 'Helvetica Neue', Arial, sans-serif"; ctx.textAlign = "right";
-    ctx.fillText("alltime best " + alltimeBest, W - 20, H - 26);
+    ctx.fillText("all-time best " + alltimeBest, W - 20, H - 26);
     ctx.font = "9px 'Helvetica Neue', Arial, sans-serif"; ctx.fillStyle = "#999"; ctx.textAlign = "left";
     ctx.fillText("daily " + today + " · day " + MLSP.dayNumber() + " · mouse / arrows · R retry", 20, H - 10);
   }

--- a/site/assets/games/oom.js
+++ b/site/assets/games/oom.js
@@ -340,7 +340,7 @@ MLSP.games.oom = function(canvas, opts) {
     ctx.textAlign = "center"; ctx.fillStyle = secs <= 10 ? "#c44" : "#333";
     ctx.font = "bold 13px 'Helvetica Neue', Arial, sans-serif"; ctx.fillText("⏱ " + secs + "s", W/2, H - 26);
     ctx.fillStyle = "#333"; ctx.font = "11px 'Helvetica Neue', Arial, sans-serif"; ctx.textAlign = "right";
-    ctx.fillText("alltime best " + alltimeBest, W - 20, H - 26);
+    ctx.fillText("all-time best " + alltimeBest, W - 20, H - 26);
     ctx.font = "9px 'Helvetica Neue', Arial, sans-serif"; ctx.fillStyle = "#999"; ctx.textAlign = "left";
     ctx.fillText("daily " + today + " · day " + MLSP.dayNumber() + " · space = hard drop · R = retry", 20, H - 10);
 

--- a/site/assets/games/prune.js
+++ b/site/assets/games/prune.js
@@ -324,7 +324,7 @@ MLSP.games.prune = function(canvas, opts) {
 
     ctx.font = "9px 'Helvetica Neue', Arial, sans-serif"; ctx.fillStyle = "#999";
     ctx.textAlign = "left";
-    ctx.fillText("daily " + today + " · day " + MLSP.dayNumber() + " · alltime best " + alltimeBest + "% · R retry", barX, accY + accH + 12);
+    ctx.fillText("daily " + today + " · day " + MLSP.dayNumber() + " · all-time best " + alltimeBest + "% · R retry", barX, accY + accH + 12);
   }
 
   function drawGameOver() {

--- a/site/assets/games/quantization.js
+++ b/site/assets/games/quantization.js
@@ -366,7 +366,7 @@ MLSP.games.quantization = function(canvas, opts) {
     ctx.textAlign = "center";
     ctx.fillText("hits: " + state.hits + " / " + WIN_HITS + " to ship", TARGET_AREA.x + TARGET_AREA.w / 2, H - 28);
     ctx.textAlign = "right";
-    ctx.fillText("alltime best " + alltimeBest, TARGET_AREA.x + TARGET_AREA.w, H - 28);
+    ctx.fillText("all-time best " + alltimeBest, TARGET_AREA.x + TARGET_AREA.w, H - 28);
     ctx.font = "9px 'Helvetica Neue', Arial, sans-serif"; ctx.fillStyle = "#999"; ctx.textAlign = "left";
     ctx.fillText("daily " + today + " · day " + MLSP.dayNumber() + " · arrows / mouse aim · 1-6 cycles a layer · R retry", TARGET_AREA.x, H - 10);
 


### PR DESCRIPTION
## Summary

- Codespell has been red on `dev` since the games-polish loop landed — the legacy `.js` game files (`oom.js`, `prune.js`, `quantization.js`, `_archive/roofline.js`) display the literal string `"alltime best"` in their HUD text, which Codespell flags as a misspelling of `"all-time"`.
- The newer `.mjs` rewrites of the same games (`prune.mjs:514`, `oom.mjs:602`, etc.) already use `"all-time best"`. This change brings the older files in line with that convention.
- Variable names (`alltimeBest`) and `onGameOver` / `onScoreChange` payload keys (`{ alltimeBest: ... }`) are unchanged — they're camelCase and already ignored by the regex in `pyproject.toml`. Only display-string literals were touched, so no consumer breaks.

## Test plan

- [x] `codespell --toml pyproject.toml` against the full tracked tree returns 0 hits (verified locally)
- [x] No callers reference `"alltime"` as a string key — only `alltimeBest` (variable/key) survives, which is camelCase-safe
- [x] `.mjs` versions already render `"all-time best"`, so this is a behavior alignment, not a UX regression