### PR TITLE
fix(book): break entirely-bold paragraphs that Pandoc promotes to <h4>

### DIFF
--- a/book/quarto/contents/vol1/benchmarking/benchmarking.qmd
+++ b/book/quarto/contents/vol1/benchmarking/benchmarking.qmd
@@ -660,31 +660,27 @@ class BertRoofline:
 
 **Problem**: BERT-Base must be deployed for inference on an A100 GPU. Management expects high GPU utilization. What performance should we predict, and how can we improve it?
 
-**Step 1: Hardware limits.**
-
+**Step 1**: Hardware limits.
 - Peak compute: `{python} BertRoofline.a100_tflops_fp16_str` TFLOPS (FP16 Tensor Core)
 - Memory bandwidth: `{python} BertRoofline.a100_bw_tbs_str` TB/s
 - Ridge point: `{python} BertRoofline.a100_tflops_fp16_str` ÷ `{python} BertRoofline.a100_bw_tbs_str` = `{python} BertRoofline.a100_ridge_str` FLOPs/byte
 
 Any workload with arithmetic intensity below `{python} BertRoofline.a100_ridge_str` FLOPs/byte is memory bound; above is compute bound.
 
-**Step 2: BERT-base characteristics.**
-
+**Step 2**: BERT-base characteristics.
 - Parameters: `{python} BertRoofline.bert_params_m_str` M = `{python} BertRoofline.bert_weight_mb_str` MB (FP32)
 - FLOPs per inference: ~`{python} BertRoofline.bert_flops_b_str` billion (forward pass with sequence length $S=128$)
 - Data movement: ~`{python} BertRoofline.bert_weight_mb_str` MB (must load all weights from memory)
 - Arithmetic intensity: `{python} BertRoofline.bert_ai_eq_str` = `{python} BertRoofline.bert_ai_b1_str` FLOPs/byte (weights-only model; see note in main text)
 
-**Step 3: Performance prediction.**
-
+**Step 3**: Performance prediction.
 Since `{python} BertRoofline.bert_ai_b1_str` < `{python} BertRoofline.a100_ridge_str`, BERT at batch=1 is **memory-bound**:
 
 Achievable perf = `{python} BertRoofline.bert_ai_b1_str` FLOPs/byte$\times$ `{python} BertRoofline.a100_bw_tbs_str` TB/s = **`{python} BertRoofline.bert_perf_b1_str` TFLOPS**
 
 GPU utilization = `{python} BertRoofline.bert_perf_b1_str` ÷ `{python} BertRoofline.a100_tflops_fp16_str` = **`{python} BertRoofline.bert_util_b1_str` percent**
 
-**Step 4: Optimization via batching.**
-
+**Step 4**: Optimization via batching.
 Increase batch size to `{python} BertRoofline.batch32_str`:
 
 - Same `{python} BertRoofline.bert_weight_mb_str` MB of weights, but `{python} BertRoofline.batch32_str`$\times$ more compute
@@ -2037,20 +2033,17 @@ class ScalingEfficiencyCalc:
 
 **Problem**: A team trains ResNet-50 on ImageNet. Single-GPU training takes `{python} ScalingEfficiencyCalc.t1_hours_str` hours. With `{python} ScalingEfficiencyCalc.n_gpus_str` GPUs, training takes `{python} ScalingEfficiencyCalc.tn_hours_str` hours. Is this good scaling? Where did the efficiency go?
 
-**Step 1: Define scaling efficiency.**
-
+**Step 1**: Define scaling efficiency.
 For **strong scaling** (fixed problem size, more processors), let $T(1)$ be the training time on a single GPU, $T(N)$ the training time on $N$ GPUs, and $N$ the GPU count. @eq-scaling-efficiency defines efficiency:
 
 $$\text{Scaling Efficiency}(N) = \frac{T(1)}{N \times T(N)} \times 100\%$$ {#eq-scaling-efficiency}
 
-**Step 2: Calculate efficiency.**
-
+**Step 2**: Calculate efficiency.
 `{python} ScalingEfficiencyCalc.scaling_eq_str` = `{python} ScalingEfficiencyCalc.t1_hours_str`/`{python} ScalingEfficiencyCalc.eff_denom_str` = **`{python} ScalingEfficiencyCalc.eff_str` percent**
 
 With perfect scaling, `{python} ScalingEfficiencyCalc.n_gpus_str` GPUs would complete in `{python} ScalingEfficiencyCalc.ideal_str` hours (`{python} ScalingEfficiencyCalc.t1_hours_str`/`{python} ScalingEfficiencyCalc.n_gpus_str`). The actual `{python} ScalingEfficiencyCalc.tn_hours_str` hours represents `{python} ScalingEfficiencyCalc.eff_str` percent efficiency.
 
-**Step 3: Account for the efficiency loss.**
-
+**Step 3**: Account for the efficiency loss.
 The "missing" `{python} ScalingEfficiencyCalc.loss_str` percent decomposes into measurable overhead:
 
 | **Source**                   | **Typical Contribution** | **Measurement**                     |
@@ -2060,8 +2053,7 @@ The "missing" `{python} ScalingEfficiencyCalc.loss_str` percent decomposes into 
 | **Load imbalance**           |              2-5 percent | Per-GPU step time variance          |
 | **Batch size effects**       |              2-5 percent | Larger batches converge differently |
 
-**Step 4: The systems insight.**
-
+**Step 4**: The systems insight.
 Scaling efficiency decreases as $N$ grows because communication overhead scales with GPU count while per-GPU compute shrinks. At eight GPUs, 75 percent efficiency is typical. At 64 GPUs, efficiency often drops to 50–60 percent. At 1000+ GPUs, even 30–40 percent efficiency requires sophisticated optimization.
 
 MLPerf reports both raw performance and scaling efficiency for this reason: a system achieving 2$\times$ throughput at 50 percent efficiency may be worse than 1.5$\times$ throughput at 90 percent efficiency, depending on cost constraints.

--- a/book/quarto/contents/vol1/data_engineering/data_engineering.qmd
+++ b/book/quarto/contents/vol1/data_engineering/data_engineering.qmd
@@ -1093,14 +1093,14 @@ class BudgetAllocation:
 - **Memory**: `{python} DataEngineeringSetup.kws_memory_limit_design_kb_str` KB model size limit (always-on island)
 - **Timeline**: `{python} DataEngineeringSetup.kws_timeline_months_str` months to production
 
-**Step 1: Apply constraints to eliminate options.**
+**Step 1**: Apply constraints to eliminate options.
 
 From @tbl-kws-design-space, the 64 KB memory limit eliminates:
 
 - 40 MFCC coefficients (3$\times$ memory) → Must use 13 MFCCs
 - Cloud inference (requires network stack) → Must use local inference
 
-**Step 2: Calculate budget allocation.**
+**Step 2**: Calculate budget allocation.
 
 Allocating our \$150K budget across three cost categories (refer to the earlier Key Data Engineering Numbers):
 
@@ -1112,7 +1112,7 @@ At USD `{python} BudgetAllocation.cost_per_label_str`/label with `{python} Budge
 
 This falls between 1M and 10M in our design space, closer to 1M, suggesting +5–6 percent accuracy contribution from data volume.
 
-**Step 3: Maximize remaining accuracy.**
+**Step 3**: Maximize remaining accuracy.
 
 Current accuracy budget:
 
@@ -1126,7 +1126,7 @@ Options from design space:
 - Noisy training data: +10–15 percent real-world accuracy, 3$\times$ collection cost
 - Synthetic augmentation: +3–5 percent robustness, 10$\times$ cheaper than real data ✓
 
-**Step 4: Final configuration.**
+**Step 4**: Final configuration.
 
 | **Choice**            | **Selection**            | **Rationale**                                      |
 |:----------------------|:-------------------------|:---------------------------------------------------|

--- a/book/quarto/contents/vol1/model_serving/model_serving.qmd
+++ b/book/quarto/contents/vol1/model_serving/model_serving.qmd
@@ -2071,28 +2071,23 @@ Consider designing a ResNet-50 serving system with these requirements:
 - **Peak expected traffic**: `{python} CapacityPlanningCalc.cp_peak_qps_str` requests per second
 - **Service time** (TensorRT FP16): 5 ms
 
-**Step 1: Find safe utilization.**
-
+**Step 1**: Find safe utilization.
 From @eq-p99-latency, $W_{p99}$ ≈ `{python} CapacityPlanningCalc.mm1_p99_factor_str`$\times$ service time / (1 − $\rho$). Setting $W_{p99}$ ≤ 50 ms with 5 ms service time gives $\rho$ ≤ one − (`{python} CapacityPlanningCalc.mm1_p99_factor_str`$\times$ 5)/50 = 0.54. However, the M/M/1 model is conservative for ML inference, which has near-deterministic service times (closer to M/D/1). For M/D/1 queues, average wait is roughly half of M/M/1 at the same utilization, allowing a higher safe operating point. Using the M/D/1-adjusted threshold yields $\rho$ ≤ `{python} CapacityPlanningCalc.cp_rho_safe_str` (`{python} CapacityPlanningCalc.cp_rho_safe_pct_str` percent maximum utilization).
 
-**Step 2: Calculate required service rate.**
-
+**Step 2**: Calculate required service rate.
 mu_required = `{python} CapacityPlanningCalc.cp_peak_qps_str` / `{python} CapacityPlanningCalc.cp_rho_safe_str` = `{python} CapacityPlanningCalc.cp_mu_required_str` requests/second
 
-**Step 3: Determine GPU count.**
-
+**Step 3**: Determine GPU count.
 Single V100 throughput at batch=16: `{python} CapacityPlanningCalc.cp_v100_throughput_str` images/second
 
 GPUs needed = `{python} CapacityPlanningCalc.cp_mu_required_str` / `{python} CapacityPlanningCalc.cp_v100_throughput_str` = `{python} CapacityPlanningCalc.cp_gpus_raw_str` → `{python} CapacityPlanningCalc.cp_gpus_ceil_str` GPUs
 
-**Step 4: Add headroom for variance.**
-
+**Step 4**: Add headroom for variance.
 Production systems add 30 percent headroom for traffic spikes and variance:
 
 Final count = `{python} CapacityPlanningCalc.cp_gpus_ceil_str`$\times$ 1.3 = `{python} CapacityPlanningCalc.cp_final_raw_str` → `{python} CapacityPlanningCalc.cp_final_ceil_str` GPUs
 
-**Step 5: Verify fault tolerance.**
-
+**Step 5**: Verify fault tolerance.
 The 30 percent headroom addresses traffic variance, but production systems also need fault tolerance. With `{python} CapacityPlanningCalc.cp_final_ceil_str` GPUs, losing one leaves `{python} CapacityPlanningCalc.cp_gpus_after_fail_str` GPUs handling `{python} CapacityPlanningCalc.cp_peak_qps_str` QPS:
 
 Utilization after failure = (`{python} CapacityPlanningCalc.cp_peak_qps_str` / `{python} CapacityPlanningCalc.cp_v100_throughput_str`) / `{python} CapacityPlanningCalc.cp_gpus_after_fail_str` = `{python} CapacityPlanningCalc.cp_util_after_fail_str` percent

--- a/book/quarto/contents/vol1/nn_architectures/nn_architectures.qmd
+++ b/book/quarto/contents/vol1/nn_architectures/nn_architectures.qmd
@@ -4594,8 +4594,7 @@ With the throughput ceiling established, we can now apply the complete decision 
 
 **Problem Statement:** Design an ML system to identify wildlife species from camera trap images in a national park. The system must process images locally (no cloud connectivity), operate on battery power for six months, and achieve 90 percent+ accuracy on 50 target species.
 
-**Step 1: Data characterization.**
-
+**Step 1**: Data characterization.
 The input is spatial data (images from camera traps, typically $1920 \times 1080$ resolution, downsampled to $224 \times 224$ for processing). The task requires recognizing visual patterns (fur textures, body shapes, distinctive markings) that are:
 
 - **Spatially local**: Species identification relies on local features (ear shape, stripe patterns)
@@ -4604,8 +4603,7 @@ The input is spatial data (images from camera traps, typically $1920 \times 1080
 
 **Initial Architecture Candidate:** CNN (matches spatial locality and translation invariance)
 
-**Step 2: Constraint analysis.**
-
+**Step 2**: Constraint analysis.
 | **Constraint**   |                **Requirement** | **Implication**                                    |
 |:-----------------|-------------------------------:|:---------------------------------------------------|
 | **Connectivity** |                 None (offline) | All inference must run on-device                   |
@@ -4614,8 +4612,7 @@ The input is spatial data (images from camera traps, typically $1920 \times 1080
 | **Memory**       |       512 MB RAM, 2 GB storage | Model must fit in ~100 MB after quantization       |
 | **Accuracy**     |      90 percent+ on 50 species | Requires sufficient model capacity                 |
 
-**Step 3: Architecture evaluation using lighthouse benchmarks.**
-
+**Step 3**: Architecture evaluation using lighthouse benchmarks.
 Compare candidates against our Lighthouse models:
 
 - **ResNet-50** (`{python} LighthouseSpecs.resnet_params_m_str` M params, `{python} LighthouseSpecs.resnet_gflops_str` GFLOPs): Too large. At ~`{python} LighthouseSpecs.resnet_fp32_mb_str` MB FP32, leaves no room for OS and buffers. Power consumption would exceed budget.
@@ -4628,8 +4625,7 @@ Compare candidates against our Lighthouse models:
 - **FLOPs:** ~`{python} WildlifeModelSizing.mnv2_flops_str` MFLOPs at $224 \times 224$
 - **Rationale:** Sufficient capacity for 50-class problem; fits memory budget with margin; depthwise separable convolutions are power-efficient
 
-**Step 4: Systems validation.**
-
+**Step 4**: Systems validation.
 *Memory Check:*
 $$
 \underbrace{\text{2.2 MB}}_{\text{Model}} + \underbrace{224 \times 224 \times 64 \times 4 \approx \text{12 MB}}_{\text{Activations}} + \underbrace{\text{50 MB}}_{\text{OS/Buffers}} = \text{65 MB} \ll \text{512 MB}~\checkmark
@@ -4643,8 +4639,7 @@ $$\frac{150 \text{ MOPs}}{2 \text{ GOPS}} = 75 \text{ ms latency} \ll 500 \text{
 Estimated inference power: ~200 mW for 75 ms = `{python} WildlifeModelSizing.energy_mj_str` mJ per inference
 At 100 inferences/day: `{python} WildlifeModelSizing.energy_j_str` J/day → negligible vs. sleep power budget $\checkmark$
 
-**Step 5: Risk assessment.**
-
+**Step 5**: Risk assessment.
 | **Risk**                              | **Mitigation**                                                                   |
 |:--------------------------------------|:---------------------------------------------------------------------------------|
 | **90 percent accuracy not achieved**  | Train on augmented dataset; consider EfficientNet-Lite if MobileNet insufficient |

--- a/book/quarto/contents/vol1/nn_computation/nn_computation.qmd
+++ b/book/quarto/contents/vol1/nn_computation/nn_computation.qmd
@@ -811,12 +811,12 @@ The basic unit of neural computation, the artificial neuron\index{Artificial Neu
 
 The mapping in @fig-bio_nn2ai_nn traces a signal through four stages, each translating a biological structure into a mathematical operation. @tbl-neuron_structure formalizes these correspondences.
 
-| **Biological Structure**           | **Artificial Component**    | **Mathematical Operation**       | **Engineering Role**                          |
+| **Biological Structure**           | **Artificial Component**    |    **Mathematical Operation**    | **Engineering Role**                          |
 |:-----------------------------------|:----------------------------|:--------------------------------:|:----------------------------------------------|
 | **Dendrites** (receive signals)    | **Input Vector**            | $\mathbf{x} = [x_1, \dots, x_n]$ | Data ingestion from sensors or prior layers   |
 | **Synapses** (modulate strength)   | **Weight Vector**           | $\mathbf{w} = [w_1, \dots, w_n]$ | Learnable parameters encoding importance      |
-| **Cell Body** (integrates signals) | **Linear Function** $z$     | $z = \sum (x_i \cdot w_i) + b$   | Linear integration of feature signals         |
-| **Axon** (fires output)            | **Activation Function** $f$ | $a = f(z)$                       | Nonlinear thresholding and signal propagation |
+| **Cell Body** (integrates signals) | **Linear Function** $z$     |  $z = \sum (x_i \cdot w_i) + b$  | Linear integration of feature signals         |
+| **Axon** (fires output)            | **Activation Function** $f$ |            $a = f(z)$            | Nonlinear thresholding and signal propagation |
 
 : **Neuron Structure and Function**: Each biological structure maps to a computational operation in the artificial neuron. Dendrites become input vectors, synaptic strengths become learnable weights, the cell body becomes a linear aggregation function $z$, and the axon's firing behavior becomes the nonlinear activation function $f$ that produces the output $y$. {#tbl-neuron_structure tbl-colwidths="[29,21,20,30]"}
 
@@ -1141,14 +1141,14 @@ class HistoricalScale:
 
 @tbl-historical-performance grounds these trends in concrete systems, showing how parameters, compute, and hardware co-evolved across four decades of neural network development.
 
-| **Year** | **System** |                                                 **Params** |     **Train FLOPs** |              **Hardware** | **Train Time** | **Error/Task**          |
+| **Year** | **System** |                         **Params**                         |   **Train FLOPs**   |              **Hardware** | **Train Time** | **Error/Task**          |
 |:---------|:-----------|:----------------------------------------------------------:|:-------------------:|--------------------------:|:--------------:|:------------------------|
-| 1989     | LeNet-1    |                                                      ~9.8K | $10^{11}$–$10^{12}$ |     Sun-4/260 workstation | 3 days         | 1.0 percent (USPS)      |
-| 1998     | LeNet-5    |                                                    60K ±1K |    $10^{14}$ ±1 OoM | SGI Origin 2000 (200 MHz) | 2–3 days       | 0.95 percent (MNIST)    |
-| 2012     | AlexNet    |                                                       ~60M |  $5 \times 10^{17}$ |    2$\times$ GTX 580 GPUs | 5–6 days       | 15.3 percent (ImageNet) |
-| 2015     | ResNet-152 |                                                       ~60M |  $10^{19}$ ±0.5 OoM |  8$\times$ Tesla K80 GPUs | ~3 weeks       | 3.6 percent (ImageNet)  |
-| 2020     | GPT-3      |      `{python} HistoricalScale.gpt3_params_b_str`B (exact) |  $3 \times 10^{23}$ |            ~10K V100 GPUs | weeks          | N/A (language)          |
-| 2023     | GPT-4      | ~`{python} HistoricalScale.gpt4_params_t_str`T (MoE, est.) | $10^{24}$–$10^{25}$ |       10-25K A100s (est.) | months         | N/A (language)          |
+| 1989     | LeNet-1    |                           ~9.8K                            | $10^{11}$–$10^{12}$ |     Sun-4/260 workstation |     3 days     | 1.0 percent (USPS)      |
+| 1998     | LeNet-5    |                          60K ±1K                           |   $10^{14}$ ±1 OoM  | SGI Origin 2000 (200 MHz) |    2–3 days    | 0.95 percent (MNIST)    |
+| 2012     | AlexNet    |                            ~60M                            |  $5 \times 10^{17}$ |    2$\times$ GTX 580 GPUs |    5–6 days    | 15.3 percent (ImageNet) |
+| 2015     | ResNet-152 |                            ~60M                            |  $10^{19}$ ±0.5 OoM |  8$\times$ Tesla K80 GPUs |    ~3 weeks    | 3.6 percent (ImageNet)  |
+| 2020     | GPT-3      |   `{python} HistoricalScale.gpt3_params_b_str`B (exact)    |  $3 \times 10^{23}$ |            ~10K V100 GPUs |     weeks      | N/A (language)          |
+| 2023     | GPT-4      | ~`{python} HistoricalScale.gpt4_params_t_str`T (MoE, est.) | $10^{24}$–$10^{25}$ |       10-25K A100s (est.) |     months     | N/A (language)          |
 
 : **Historical Performance**: Four decades of neural network evolution showing the co-scaling of model parameters, training compute, and hardware infrastructure. Training FLOPs increased by approximately $10^{13}\times$ from LeNet-1 to GPT-4, while parameters grew by $10^{8}\times$. **Uncertainty notes**: Earlier systems (LeNet, AlexNet) have well-documented specifications; recent closed models (GPT-4) have only external estimates (OpenAI has not officially confirmed GPT-4's architecture or parameter count; the ~1.8T MoE estimate is based on public reporting and analysis). "OoM" = order of magnitude uncertainty. {#tbl-historical-performance tbl-colwidths="[6,11,17,16,19,12,19]"}
 
@@ -1795,7 +1795,6 @@ ReLU is not without drawbacks. The **dying ReLU problem**\index{ReLU!dying ReLU 
 \index{Softmax!etymology}
 Unlike the previous activation functions that operate *element-wise* (independently on each value), softmax\index{Activation Function!softmax}\index{Softmax!probability distribution}[^fn-softmax-etymology] is a *vector-level* function: it considers all values simultaneously to produce a probability distribution. This distinction means softmax is used exclusively in output layers for classification, not as a hidden-layer activation. The softmax function is defined in @eq-softmax:
 $$ \text{softmax}(z_i) = \frac{e^{z_i}}{\sum_{j=1}^K e^{z_j}} $$ {#eq-softmax}
-
 
 [^fn-softmax-etymology]: **Softmax**: The name reflects its role as a "soft" or differentiable version of `argmax`, a function that must evaluate an entire vector to find its maximum value. This vector-wise operation makes it unsuitable for hidden layers. Critically, its use of exponentiation creates a numerical stability hazard: inputs greater than ~88 will overflow standard 32-bit floats, a common source of silent `NaN` failures in production. \index{Softmax!numerical stability}
 
@@ -2795,37 +2794,34 @@ class MnistTrainingMemoryCalc:
 
 **Solution**:
 
-**Step 1: Model parameters.**
-
+**Step 1**: Model parameters.
 ::: {tbl-colwidths="[25,25,25,25]"}
 
-| **Layer**           |                                    **Weights** |                    **Biases** |                        **Total Parameters** |
+| **Layer**           |                  **Weights**                   |           **Biases**          |             **Total Parameters**            |
 |:--------------------|:----------------------------------------------:|:-----------------------------:|:-------------------------------------------:|
-| **Input→Hidden1**   | $784\times128$ = `{python} MNISTMemory.w1_str` | `{python} MNISTMemory.b1_str` |               `{python} MNISTMemory.p1_str` |
-| **Hidden1→Hidden2** |  $128\times64$ = `{python} MNISTMemory.w2_str` | `{python} MNISTMemory.b2_str` |               `{python} MNISTMemory.p2_str` |
-| **Hidden2→Output**  |   $64\times10$ = `{python} MNISTMemory.w3_str` | `{python} MNISTMemory.b3_str` |               `{python} MNISTMemory.p3_str` |
+| **Input→Hidden1**   | $784\times128$ = `{python} MNISTMemory.w1_str` | `{python} MNISTMemory.b1_str` |        `{python} MNISTMemory.p1_str`        |
+| **Hidden1→Hidden2** | $128\times64$ = `{python} MNISTMemory.w2_str`  | `{python} MNISTMemory.b2_str` |        `{python} MNISTMemory.p2_str`        |
+| **Hidden2→Output**  |  $64\times10$ = `{python} MNISTMemory.w3_str`  | `{python} MNISTMemory.b3_str` |        `{python} MNISTMemory.p3_str`        |
 | **Total**           |                                                |                               | **`{python} MNISTMemory.total_params_str`** |
 
 :::
 
 **Parameter memory**: `{python} MNISTMemory.total_params_str`$\times$ 4 bytes = **`{python} MnistTrainingMemoryCalc.param_kib_str` KB**
 
-**Step 2: Activations.**
-
+**Step 2**: Activations.
 ::: {tbl-colwidths="[25,25,25,25]"}
 
-| **Layer**   | **Activation Shape** |                                             **Values** |                                                  **Memory** |
+| **Layer**   | **Activation Shape** |                       **Values**                       |                          **Memory**                         |
 |:------------|:--------------------:|:------------------------------------------------------:|:-----------------------------------------------------------:|
-| **Input**   |        $32\times784$ |    `{python} MnistTrainingMemoryCalc.act_in_count_str` |        `{python} MnistTrainingMemoryCalc.act_in_kib_str` KB |
-| **Hidden1** |        $32\times128$ |    `{python} MnistTrainingMemoryCalc.act_h1_count_str` |        `{python} MnistTrainingMemoryCalc.act_h1_kib_str` KB |
-| **Hidden2** |         $32\times64$ |    `{python} MnistTrainingMemoryCalc.act_h2_count_str` |        `{python} MnistTrainingMemoryCalc.act_h2_kib_str` KB |
-| **Output**  |         $32\times10$ |   `{python} MnistTrainingMemoryCalc.act_out_count_str` |       `{python} MnistTrainingMemoryCalc.act_out_kib_str` KB |
+| **Input**   |    $32\times784$     |  `{python} MnistTrainingMemoryCalc.act_in_count_str`   |     `{python} MnistTrainingMemoryCalc.act_in_kib_str` KB    |
+| **Hidden1** |    $32\times128$     |  `{python} MnistTrainingMemoryCalc.act_h1_count_str`   |     `{python} MnistTrainingMemoryCalc.act_h1_kib_str` KB    |
+| **Hidden2** |     $32\times64$     |  `{python} MnistTrainingMemoryCalc.act_h2_count_str`   |     `{python} MnistTrainingMemoryCalc.act_h2_kib_str` KB    |
+| **Output**  |     $32\times10$     |  `{python} MnistTrainingMemoryCalc.act_out_count_str`  |    `{python} MnistTrainingMemoryCalc.act_out_kib_str` KB    |
 | **Total**   |                      | `{python} MnistTrainingMemoryCalc.total_act_count_str` | **`{python} MnistTrainingMemoryCalc.total_act_kib_str` KB** |
 
 :::
 
-**Step 3: Training-only memory.**
-
+**Step 3**: Training-only memory.
 - **Gradients** (same size as parameters): `{python} MnistTrainingMemoryCalc.grad_kib_str` KB
 - **Optimizer state** (Adam stores momentum + velocity, 2$\times$ parameters): `{python} MnistTrainingMemoryCalc.opt_kib_str` KB
 
@@ -2833,12 +2829,12 @@ class MnistTrainingMemoryCalc:
 
 ::: {tbl-colwidths="[33,34,33]"}
 
-| **Component**       | **Training**                                                   | **Inference**                                                  |
+| **Component**       |                          **Training**                          |                         **Inference**                          |
 |:--------------------|:--------------------------------------------------------------:|:--------------------------------------------------------------:|
-| **Parameters**      | `{python} MnistTrainingMemoryCalc.param_kib_str` KB            | `{python} MnistTrainingMemoryCalc.param_kib_str` KB            |
-| **Activations**     | `{python} MnistTrainingMemoryCalc.total_act_kib_str` KB        | `{python} MnistTrainingMemoryCalc.total_act_kib_str` KB        |
-| **Gradients**       | `{python} MnistTrainingMemoryCalc.grad_kib_str` KB             | —                                                              |
-| **Optimizer state** | `{python} MnistTrainingMemoryCalc.opt_kib_str` KB              | —                                                              |
+| **Parameters**      |      `{python} MnistTrainingMemoryCalc.param_kib_str` KB       |      `{python} MnistTrainingMemoryCalc.param_kib_str` KB       |
+| **Activations**     |    `{python} MnistTrainingMemoryCalc.total_act_kib_str` KB     |    `{python} MnistTrainingMemoryCalc.total_act_kib_str` KB     |
+| **Gradients**       |       `{python} MnistTrainingMemoryCalc.grad_kib_str` KB       |                               —                                |
+| **Optimizer state** |       `{python} MnistTrainingMemoryCalc.opt_kib_str` KB        |                               —                                |
 | **Total**           | **~`{python} MnistTrainingMemoryCalc.total_train_mib_str` MB** | **~`{python} MnistTrainingMemoryCalc.total_infer_kib_str` KB** |
 
 :::
@@ -2997,10 +2993,10 @@ Detailed calculations are essential for design documents, but experienced engine
 
 **Quick Sanity Checks**
 
-| **Question**                                 |                                       **Quick Estimate** |
+| **Question**                                 | **Quick Estimate**                                       |
 |:---------------------------------------------|:---------------------------------------------------------|
-| **"Will this model fit in GPU memory?"**     |   Parameters$\times$ 4 bytes$\times$ 4 (training) < VRAM |
-| **"How long per epoch on MNIST?"**           |              60K images$\times$ FLOPs/image ÷ GPU TFLOPS |
+| **"Will this model fit in GPU memory?"**     | Parameters$\times$ 4 bytes$\times$ 4 (training) < VRAM   |
+| **"How long per epoch on MNIST?"**           | 60K images$\times$ FLOPs/image ÷ GPU TFLOPS              |
 | **"Is this compute bound or memory bound?"** | If batch$\times$ layer_width < 1000, likely memory bound |
 
 **Example**: *"Can I train a `{python} MentalMathCalc.mm_params_m_str`M parameter model on a `{python} MentalMathCalc.mm_gpu_gb_str`GB GPU?"*
@@ -3199,8 +3195,8 @@ This composition reveals that forward propagation is, at its core, a chain of ma
 
 | **Operation**                 | **Complexity (Ops)** | **Data Movement (IO)** | **Intensity (FLOPs/byte)** | **Hardware Fit** |
 |:------------------------------|:--------------------:|:----------------------:|:--------------------------:|:----------------:|
-| **Matrix Mul ($N \times N$)** |               $2N^3$ |                 $3N^2$ |      $\approx 2N/3$ (High) | **GPU/TPU**      |
-| **Element-wise (ReLU)**       |                $N^2$ |                 $2N^2$ |                $0.5$ (Low) | **CPU/Vector**   |
+| **Matrix Mul ($N \times N$)** |        $2N^3$        |         $3N^2$         |   $\approx 2N/3$ (High)    |   **GPU/TPU**    |
+| **Element-wise (ReLU)**       |        $N^2$         |         $2N^2$         |        $0.5$ (Low)         |  **CPU/Vector**  |
 
 :::
 
@@ -3350,15 +3346,15 @@ class MnistFlopsCalc:
 
 ::: {tbl-colwidths="[14,20,28,40]"}
 
-| **Layer**   | **Operation**  |                           **Dimensions** |                                                                   **Ops** |
+| **Layer**   | **Operation**  |              **Dimensions**              |                                  **Ops**                                  |
 |:------------|:---------------|:----------------------------------------:|:-------------------------------------------------------------------------:|
 | **Layer 1** | MatMul         | ($32\times784$)$\times$ ($784\times128$) | 2$\times$ 32$\times$ $784\times128$ = `{python} MnistFlopsCalc.l1_mm_str` |
-| **Layer 1** | Bias + ReLU    |                            $32\times128$ |                    $2\times4,096$ = `{python} MnistFlopsCalc.l1_bias_str` |
-| **Layer 2** | MatMul         |  ($32\times128$)$\times$ ($128\times64$) |  2$\times$ 32$\times$ $128\times64$ = `{python} MnistFlopsCalc.l2_mm_str` |
-| **Layer 2** | Bias + ReLU    |                             $32\times64$ |                    $2\times2,048$ = `{python} MnistFlopsCalc.l2_bias_str` |
-| **Layer 3** | MatMul         |    ($32\times64$)$\times$ ($64\times10$) |   2$\times$ 32$\times$ $64\times10$ = `{python} MnistFlopsCalc.l3_mm_str` |
-| **Layer 3** | Bias + Softmax |                             $32\times10$ |                       ~`{python} MnistFlopsCalc.l3_bias_str` (simplified) |
-| **Total**   |                |                                          |                           **~`{python} MNISTMemory.total_mops_str` MOps** |
+| **Layer 1** | Bias + ReLU    |              $32\times128$               |           $2\times4,096$ = `{python} MnistFlopsCalc.l1_bias_str`          |
+| **Layer 2** | MatMul         | ($32\times128$)$\times$ ($128\times64$)  |  2$\times$ 32$\times$ $128\times64$ = `{python} MnistFlopsCalc.l2_mm_str` |
+| **Layer 2** | Bias + ReLU    |               $32\times64$               |           $2\times2,048$ = `{python} MnistFlopsCalc.l2_bias_str`          |
+| **Layer 3** | MatMul         |  ($32\times64$)$\times$ ($64\times10$)   |  2$\times$ 32$\times$ $64\times10$ = `{python} MnistFlopsCalc.l3_mm_str`  |
+| **Layer 3** | Bias + Softmax |               $32\times10$               |            ~`{python} MnistFlopsCalc.l3_bias_str` (simplified)            |
+| **Total**   |                |                                          |              **~`{python} MNISTMemory.total_mops_str` MOps**              |
 
 :::
 
@@ -4629,15 +4625,15 @@ The success of this early large-scale neural network deployment helped establish
 
 The same neural network computation that required industrial-scale infrastructure in 1990 runs on pocket-sized devices today. @tbl-then-vs-now quantifies four decades of progress:
 
-| **Aspect**            |                            **1990s USPS System** |                                          **2025 Equivalent** |        **Improvement** |
+| **Aspect**            |              **1990s USPS System**               |                     **2025 Equivalent**                      |    **Improvement**     |
 |:----------------------|:------------------------------------------------:|:------------------------------------------------------------:|:----------------------:|
-| **Hardware cost**     |                    ~\$50,000 (Sun-4 workstation) |                                       ~\$50 (Raspberry Pi 5) |          1,000$\times$ |
-| **Inference latency** |                                    ~100 ms/digit |                                                ~0.1 ms/digit |          1,000$\times$ |
-| **Power consumption** |                                         50–100 W |                                                          5 W |         10--20$\times$ |
-| **Training time**     |                                           3 days |                                                  ~30 seconds |          8,640$\times$ |
+| **Hardware cost**     |          ~\$50,000 (Sun-4 workstation)           |                    ~\$50 (Raspberry Pi 5)                    |     1,000$\times$      |
+| **Inference latency** |                  ~100 ms/digit                   |                        ~0.1 ms/digit                         |     1,000$\times$      |
+| **Power consumption** |                     50–100 W                     |                             5 W                              |     10--20$\times$     |
+| **Training time**     |                      3 days                      |                         ~30 seconds                          |     8,640$\times$      |
 | **Model storage**     | ~`{python} UspsLenetSpecs.lenet_1_mem_kb_str` KB | ~`{python} UspsLenetSpecs.lenet_1_mem_kb_str` KB (unchanged) | 1$\times$ (same model) |
-| **Energy/inference**  |                                            ~10 J |                                                      ~0.5 mJ |         20,000$\times$ |
-| **\$/inference**      |                                         ~\$0.001 |                                                  ~\$0.000001 |          1,000$\times$ |
+| **Energy/inference**  |                      ~10 J                       |                           ~0.5 mJ                            |     20,000$\times$     |
+| **\$/inference**      |                     ~\$0.001                     |                         ~\$0.000001                          |     1,000$\times$      |
 
 : **Hardware Progress for Neural Network Computation**: The same LeNet computation that required a \$50,000 workstation in 1990 runs on a \$50 Raspberry Pi today—1,000$\times$ cheaper, 1,000$\times$ faster, and 20,000$\times$ more energy-efficient. Crucially, the algorithm is unchanged; all improvement came from hardware. This validates the systems principle that algorithm-hardware co-design multiplies gains across both dimensions. {#tbl-then-vs-now tbl-colwidths="[25,30,25,20]"}
 

--- a/book/quarto/contents/vol1/training/training.qmd
+++ b/book/quarto/contents/vol1/training/training.qmd
@@ -4876,8 +4876,7 @@ The memory analysis from @sec-model-training-mixedprecision-training-9218 applie
 
 With memory solved, the next step is determining whether throughput is acceptable.
 
-**Step 4: Profile for throughput bottlenecks.**
-
+**Step 4**: Profile for throughput bottlenecks.
 With memory solved, profile shows:
 
 - accelerator utilization: 45 percent
@@ -4887,8 +4886,7 @@ With memory solved, profile shows:
 
 Bottleneck identified: data-bound---a *Data* constraint in D·A·M terms. GPU starving for data.
 
-**Step 5: Apply prefetching and data pipeline optimization.**
-
+**Step 5**: Apply prefetching and data pipeline optimization.
 Configure DataLoader with eight workers, pin_memory=True, prefetch_factor=2:
 
 ```{.text}
@@ -4900,8 +4898,7 @@ After optimization:
 - Memory transfers: 20% of iteration time
 ```
 
-**Step 6: Final profile and results.**
-
+**Step 6**: Final profile and results.
 | **Metric**                  | **Naive** |    **Optimized** | **Improvement**       |
 |:----------------------------|:----------|-----------------:|:----------------------|
 | **Memory**                  | 89 GB     |            32 GB | 2.8$\times$ reduction |

--- a/book/quarto/contents/vol2/backmatter/appendix_reliability.qmd
+++ b/book/quarto/contents/vol2/backmatter/appendix_reliability.qmd
@@ -508,12 +508,10 @@ class WorkedExampleYoungDaly:
 
 **Setup.** You are training a 175B-parameter model on a 10,000-GPU cluster. The cluster MTBF is `{python} WorkedExampleYoungDaly.yd_mtbf_h_str` hours (@tbl-mtbf-cluster). The checkpoint size is `{python} WorkedExampleYoungDaly.ckpt_175b_gb` GB, and your parallel storage system writes at `{python} WorkedExampleYoungDaly.ckpt_write_bw` GB/s.
 
-**Step 1: Checkpoint write time ($\delta$).**
-
+**Step 1**: Checkpoint write time ($\delta$).
 `{python} WorkedExampleYoungDaly.delta_eq_math`
 
-**Step 2: Apply the Young-Daly formula.**
-
+**Step 2**: Apply the Young-Daly formula.
 `{python} WorkedExampleYoungDaly.tau_opt_eq_math`
 
 **Interpretation.** The optimal checkpoint interval is approximately `{python} WorkedExampleYoungDaly.yd_tau_min_str` minutes. The overhead from checkpointing alone is $\delta / \tau_\text{opt} \approx$ `{python} WorkedExampleYoungDaly.yd_overhead_str` percent of training time.

--- a/book/quarto/contents/vol2/collective_communication/collective_communication.qmd
+++ b/book/quarto/contents/vol2/collective_communication/collective_communication.qmd
@@ -156,24 +156,20 @@ class AllReduceCost:
 
 **Problem**\index{Problem}: A 70 billion parameter model trains with data parallelism across `{python} AllReduceCost.n_gpus_napkin_str` GPUs connected by InfiniBand NDR (50 GB/s per port). Each GPU computes gradients in FP32 (4 bytes per parameter). How long does one AllReduce take?
 
-**Step 1: Size the gradient payload.**
-
+**Step 1**: Size the gradient payload.
 Each GPU produces a full gradient tensor: $70 \times 10^9 \times 4\ \text{bytes} =$ `{python} AllReduceCost.gradient_size_gb_str` GB.
 
-**Step 2: Apply the Ring AllReduce bandwidth formula.**
-
+**Step 2**: Apply the Ring AllReduce bandwidth formula.
 $$T_{\text{bandwidth}} = 2 \cdot \frac{N-1}{N} \cdot \frac{M}{\beta}$$
 
 Substituting: $T_{\text{bandwidth}}$ = `{python} AllReduceCost.ring_bw_factor_str`$\times$ 280 GB/50 GB/s $\approx$ `{python} AllReduceCost.ring_bw_time_ms_str` ms.
 
-**Step 3: Add the latency term.**
-
+**Step 3**: Add the latency term.
 $$T_{\text{latency}} = 2(N-1) \cdot \alpha$$
 
 Substituting: $T_{\text{latency}}$ = 2$\times$ $63 \times 3$ $\mu$s = `{python} AllReduceCost.ring_lat_time_ms_str` ms.
 
-**Step 4: Total communication time.**
-
+**Step 4**: Total communication time.
 Total: $T_{\text{AllReduce}} \approx$ `{python} AllReduceCost.ring_bw_time_ms_str` + `{python} AllReduceCost.ring_lat_time_ms_str` $\approx$ `{python} AllReduceCost.ring_total_ms_str` ms.
 
 **The Systems Insight**: The gradient AllReduce alone takes over 11 seconds. This is pure communication overhead added to every training step. At this scale, communication dominates the step time unless overlapped with backward pass computation. This is why production systems pipeline AllReduce with the backward pass, launching communication for early layers while later layers are still computing.

--- a/book/quarto/contents/vol2/compute_infrastructure/compute_infrastructure.qmd
+++ b/book/quarto/contents/vol2/compute_infrastructure/compute_infrastructure.qmd
@@ -1908,23 +1908,19 @@ To solidify the memory planning concepts, consider a concrete sizing exercise fo
 - Host: 2 TB DDR5
 - Parallelism: 8-way tensor parallelism within the node
 
-**Step 1: Weight Distribution**
-
+**Step 1**: Weight Distribution
 With 8-way TP, each GPU holds 1/8 of every weight tensor.
 Per-GPU weight memory: 350 GB/8 = 43.75 GB (FP16).
 
-**Step 2: Optimizer State with ZeRO Stage 1**
-
+**Step 2**: Optimizer State with ZeRO Stage 1
 ZeRO Stage 1 shards the optimizer states across data-parallel workers. Within a single node using only TP (no data parallelism), the optimizer is *not* sharded. Each GPU stores the full optimizer state for its TP shard: 43.75 GB$\times$ 4 (FP32 $m$ and $v$) = 175 GB.
 
 The total exceeds the 80 GB HBM capacity. **Solution**\index{Solution}: offload optimizer states to host DDR5. The 2 TB of DDR5 can hold the full 1,400 GB of optimizer state with room to spare.
 
-**Step 3: Activations**
-
+**Step 3**: Activations
 With activation checkpointing (recomputing every other layer), the activation memory for a microbatch of 4 sequences at 2,048 token length is approximately 15--25 GB per GPU. Without checkpointing, it would be 100--200 GB per GPU, which is impossible.
 
-**Step 4: Gradient Accumulation**
-
+**Step 4**: Gradient Accumulation
 Gradients match the weight size: 43.75 GB per GPU in FP16.
 
 **Total per-GPU HBM usage**\index{Total Per-GPU HBM Usage}:

--- a/book/quarto/contents/vol2/inference/inference.qmd
+++ b/book/quarto/contents/vol2/inference/inference.qmd
@@ -2138,16 +2138,13 @@ $$ \text{Total Memory} = M_{weights} + (\text{Batch} \times \text{Context} \time
 *   $s_{\text{elem}} = 2$ bytes (FP16).
 *   Context $= 131,072$ tokens.
 
-**Step 1: Calculate memory per token.**
-
+**Step 1**: Calculate memory per token.
 $$ M_{KV} = 2 \times 80 \times 64 \times 128 \times 2 = 2,621,440 \text{ bytes} \approx \mathbf{2.6 \text{ MB/token}} $$
 
-**Step 2: Calculate cache per request.**
-
+**Step 2**: Calculate cache per request.
 $$ 131,072 \text{ tokens} \times 2.6 \text{ MB/token} \approx \mathbf{340 \text{ GB/request}} $$
 
-**Step 3: Determine max batch size.**
-
+**Step 3**: Determine max batch size.
 Available Memory for KV = $640 \text{ GB (Total)} - 140 \text{ GB (Weights)} - 20 \text{ GB (System)} = 480 \text{ GB}$.
 $$ \text{Max Batch} = \lfloor \frac{480}{340} \rfloor = \mathbf{1} $$
 

--- a/book/quarto/contents/vol2/network_fabrics/network_fabrics.qmd
+++ b/book/quarto/contents/vol2/network_fabrics/network_fabrics.qmd
@@ -779,20 +779,17 @@ class AllReduceBottleneck:
 
 **Setup**\index{Setup}: A cluster of 1,024 H100 GPUs training a model with 1 billion parameters (4 GB of FP32 gradients). Each GPU computes at `{python} NetworkFabricsContextScenario.h100_tflops` TFLOPS. The network uses NDR InfiniBand (`{python} AllReduceBottleneck.alpha_math` and `{python} AllReduceBottleneck.beta_math` per link).
 
-**Step 1: Compute time per iteration.**
-
+**Step 1**: Compute time per iteration.
 Assume each GPU processes a microbatch requiring $2 \times 10^{18}$ FLOPs (a rough estimate for a forward plus backward pass on a large batch). At `{python} NetworkFabricsContextScenario.h100_tflops` TFLOPS with 50 percent utilization:
 
 `{python} AllReduceBottleneck.t_comp_display_math`
 
-**Step 2: Communication time (Ring AllReduce).**
-
+**Step 2**: Communication time (Ring AllReduce).
 With $p = 1{,}024$ and $m = 4 \times 10^9$ bytes:
 
 - Total Communication: `{python} AllReduceBottleneck.t_ring_1b_math`
 
-**Step 3: Communication fraction.**
-
+**Step 3**: Communication fraction.
 `{python} AllReduceBottleneck.comm_frac_display_math`
 
 With overlap between communication and computation (possible because the backward pass produces gradients layer by layer), the effective overhead can be reduced further. The network is not the bottleneck for this configuration.

--- a/book/quarto/contents/vol2/security_privacy/security_privacy.qmd
+++ b/book/quarto/contents/vol2/security_privacy/security_privacy.qmd
@@ -3198,16 +3198,14 @@ This framework treats DP as one tool in a privacy-preserving toolkit rather than
 
 **Scenario**: Train a sentiment classifier on 100,000 customer reviews with target privacy $(\epsilon, \delta) = (8, 10^{-6})$.
 
-**Step 1: Configure DP-SGD parameters.**
-
+**Step 1**: Configure DP-SGD parameters.
 - Dataset size: $N = 100,000$
 - Batch size: $B = 2,000$ (sampling rate $q = B/N = 0.02$)
 - Gradient clipping norm: $C = 1.0$
 - Training epochs: $T = 10$ (total steps $k = T \times N/B = 500$)
 - Target: $\epsilon = 8$, $\delta = 10^{-6}$
 
-**Step 2: Calculate required noise multiplier.**
-
+**Step 2**: Calculate required noise multiplier.
 Using the Gaussian mechanism formula and RDP accounting, we need noise multiplier $\sigma$ such that after $k = 500$ iterations with sampling rate $q = 0.02$, the total privacy loss is $\epsilon \leq 8$.
 
 The per-step RDP guarantee for Gaussian mechanism with subsampling is approximately:
@@ -3218,8 +3216,7 @@ $$\varepsilon_{\text{step}}(\alpha) = \frac{(0.02)^2 \alpha}{2(0.8)^2} = \frac{0
 
 After 500 steps: $\varepsilon_{\text{total}}(\alpha) = 500 \times 0.000312\alpha = 0.156\alpha$
 
-**Step 3: Convert RDP to DP.**
-
+**Step 3**: Convert RDP to DP.
 Converting to $(\epsilon, \delta)$-DP by optimizing over $\alpha$:
 $$\epsilon = \varepsilon_{\text{total}}(\alpha) + \frac{\ln(1/\delta)}{\alpha - 1} = 0.156\alpha + \frac{\ln(10^6)}{\alpha - 1}$$
 
@@ -3231,12 +3228,10 @@ Evaluating at different $\alpha$ values:
 
 Optimal $\alpha \approx 48$ yields $\epsilon \approx 7.8$, which satisfies our target of $\epsilon \leq 8$.
 
-**Step 4: Expected accuracy impact.**
-
+**Step 4**: Expected accuracy impact.
 With $\sigma = 0.8$ and $\epsilon \approx 8$, expect 3-5 percent accuracy degradation compared to non-private training. For a sentiment classifier achieving 92 percent accuracy without DP, the private version should achieve 87–89 percent accuracy.
 
-**Step 5: Implementation verification.**
-
+**Step 5**: Implementation verification.
 ```{.python}
 # Using Opacus library for PyTorch
 from opacus import PrivacyEngine

--- a/book/quarto/contents/vol2/sustainable_ai/sustainable_ai.qmd
+++ b/book/quarto/contents/vol2/sustainable_ai/sustainable_ai.qmd
@@ -1052,14 +1052,12 @@ To make this framework concrete, we can apply it to the most common operation in
 
 Consider matrix multiplication $C = A \times B$ for $N \times N$ matrices in FP32 precision on a GPU with the energy characteristics above.
 
-**Step 1: Calculate FLOPs and bytes.**
-
+**Step 1**: Calculate FLOPs and bytes.
 - FLOPs: $2N^3$ (one multiply-add for each of $N^2$ output elements, accumulating over $N$ elements)
 - Bytes: $3N^2 \times 4$ bytes (read matrices $A$ and $B$, write matrix $C$, each FP32 = 4 bytes)
 - Arithmetic intensity: $AI = \frac{2N^3}{12N^2} = \frac{N}{6}$ FLOPs/byte
 
-**Step 2: Determine energy-limiting factor.**
-
+**Step 2**: Determine energy-limiting factor.
 For small matrices ($N = 60$):
 
 - $AI = 60/6 = 10$ FLOPs/byte (at crossover)
@@ -1351,19 +1349,16 @@ class A100PowerScenario:
 
 Consider training a 7 billion parameter model on 64 A100 GPUs for 14 days:
 
-**Step 1: Compute energy.**
-
+**Step 1**: Compute energy.
 - GPU power: `{python} A100PowerScenario.a100_tdp_w`W per A100 at typical training utilization
 - Training time: 14 days times 24 hours = `{python} TrainingEmissions.training_hours_str` hours
 - GPU energy: 64 GPUs times `{python} A100PowerScenario.a100_tdp_w`W times `{python} TrainingEmissions.training_hours_str`h = `{python} TrainingEmissions.gpu_energy_wh_str` Wh = `{python} TrainingEmissions.gpu_energy_kwh_str` kWh
 
-**Step 2: Apply PUE.**
-
+**Step 2**: Apply PUE.
 - Facility PUE: 1.2 (efficient hyperscale datacenter)
 - Total facility energy: `{python} TrainingEmissions.gpu_energy_kwh_str` kWh times 1.2 = `{python} TrainingEmissions.facility_energy_kwh_str` kWh
 
-**Step 3: Calculate emissions.**
-
+**Step 3**: Calculate emissions.
 - Grid carbon intensity: 429 gCO2/kWh (US average)
 - Operational emissions: `{python} TrainingEmissions.facility_energy_kwh_str` kWh times 429 g/kWh = `{python} TrainingEmissions.emissions_kg_str` kg CO2 = `{python} TrainingEmissions.emissions_tons_str` metric tons
 
@@ -2099,14 +2094,12 @@ Consider deploying an anomaly detection model on a factory sensor node:
 - Sleep power: 5 microamps at 3.3V (16.5 microwatts)
 - Battery: 2x AA (3000 mAh at 3.0V)
 
-**Step 1: Calculate duty cycle and average power.**
-
+**Step 1**: Calculate duty cycle and average power.
 $$D = \frac{5 \text{ ms}}{100 \text{ ms}} = 0.05 \text{ (5\% duty cycle)}$$
 
 $$P_{avg} = 12 \text{ mW} \times 0.05 + 0.0165 \text{ mW} \times 0.95 = 0.60 + 0.016 = 0.616 \text{ mW}$$
 
-**Step 2: Calculate battery life.**
-
+**Step 2**: Calculate battery life.
 $$E_{battery} = 3000 \text{ mAh} \times 3.0 \text{ V} = 9000 \text{ mWh}$$
 
 $$t_{life} = \frac{9000 \text{ mWh}}{0.616 \text{ mW}} = 14,610 \text{ hours} \approx 1.7 \text{ years}$$


### PR DESCRIPTION
Closes #1503.

## Summary

User report (#1503): in the rendered Vol1 Data Engineering chapter, body text after the "Optimizing the KWS Design Space" worked-example callout escaped the article column and rendered at full viewport width, overlapping the right-side TOC.

## Root cause

Pandoc/Quarto promotes paragraphs whose **entire content** is a single bold span (e.g. `**Step 1: Apply constraints to eliminate options.**`) into `<h4>` headings with auto-generated anchor IDs. With Quarto's `section-divs` enabled, each promotion creates a `<section class="level4">`. Inside a foldbox callout near a chapter boundary, the resulting cascade of `</section>` closes overshoots and prematurely emits `</main>`. Every paragraph after the callout then renders outside `<main>` — outside the article column — outside the layout.

The pattern that triggers promotion is specifically: a paragraph whose *entire* text is wrapped in `**...**`. Mixed-content bold (`**Scenario**: You are building...`) is unaffected.

## Fix

Move the colon outside the bold span: `**Step 1**: Apply constraints to eliminate options.` — the paragraph now has mixed `Strong + Str` content, so Pandoc treats it as prose, not as a heading. Same visual rendering. Matches the canonical `**Scenario**:` form already used in the same callouts.

## Scope

Swept all 52 entirely-bold "Step N:" paragraph triggers across 12 chapters:

- **Vol1**: benchmarking, data_engineering, model_serving, nn_architectures, nn_computation, training
- **Vol2**: appendix_reliability, collective_communication, compute_infrastructure, inference, network_fabrics, security_privacy, sustainable_ai

Even where the cascade didn't catastrophically break the layout, removing the spurious `<h4>` sections cleans up the rendered chapter TOC (each step was leaking in as a fake sub-subsection).

## Test plan

- [x] Pattern eliminated: `grep -rn -E '^\*\*Step [0-9]+: [^*]+\*\*\$' book/quarto/contents/vol{1,2}` returns 0
- [x] Pre-commit hooks all green (table prettifier ran on `nn_computation.qmd` post-edit; staged + recommitted)
- [ ] Spot-check rendered HTML for `vol1/data_engineering` after merge: layout should restore, no `<section id="step-N-...">` artifacts in the KWS callout