### PR TITLE
fix(book): swap inverted MobileNet quantization values + align caption with figure

### DIFF
--- a/book/quarto/contents/vol1/optimizations/model_compression.qmd
+++ b/book/quarto/contents/vol1/optimizations/model_compression.qmd
@@ -3129,9 +3129,9 @@ Reducing numerical precision thus improves efficiency on two fronts: faster comp
 
 #### Performance gains {#sec-model-compression-performance-gains-0656}
 
-The practical payoff of quantization becomes concrete in @fig-quantization_impact. Compare the left bars (inference time) and right bars (model size) in each category to see the gains when moving from FP32 to INT8. Quantized models achieve up to 4$\times$ faster inference while reducing storage requirements by the same factor, making them well suited for deployment in resource-constrained environments.
+The practical payoff of quantization becomes concrete in @fig-quantization_impact. Compare the orange (FP32) and blue (INT8) segments in each stacked bar to see the gains when moving from FP32 to INT8. The magnitude of the gain varies by model: Inception_v3 and ResNet_v2 see a 1.5--4$\times$ reduction in both inference time and model size, while MobileNet_v1, designed for mobile-class INT8 hardware, sees an order-of-magnitude reduction. The pattern across architectures makes quantized models well suited for deployment in resource-constrained environments.
 
-::: {#fig-quantization_impact fig-env="figure" fig-pos="htb" fig-cap="**Quantization Impact**: Moving from FP32 to INT8 reduces inference time by up to 4 times while decreasing model size by a factor of 4, making models more efficient for resource-constrained environments." fig-alt="Two stacked bar charts comparing FP32 and INT8. Left chart shows inference time in milliseconds for Inception, MobileNet, and ResNet. Right chart shows model size in megabytes. INT8 consistently smaller and faster."}
+::: {#fig-quantization_impact fig-env="figure" fig-pos="htb" fig-cap="**Quantization Impact**: Moving from FP32 to INT8 reduces both inference time and model size, with the magnitude of reduction depending on the model's architecture and the target hardware's INT8 acceleration. Inception_v3 and ResNet_v2 see modest gains; MobileNet_v1, designed for mobile-class INT8 paths, sees an order-of-magnitude reduction." fig-alt="Two stacked bar charts comparing FP32 and INT8. Left chart shows inference time in milliseconds for Inception_v3, MobileNet_v1, and ResNet_v2; right chart shows model size in megabytes. Orange segments mark FP32 values, blue segments mark INT8 values; INT8 is smaller and faster across all models."}
 
 ```{.tikz}
 \begin{tikzpicture}[font=\small\usefont{T1}{phv}{m}{n}]
@@ -3181,11 +3181,11 @@ The practical payoff of quantization becomes concrete in @fig-quantization_impac
     ]
     \addplot [fill=WeightGradient!80,draw=none] coordinates {
         ({Inception\_v3},800)
-        ({MobileNet\_v1},30)
+        ({MobileNet\_v1},700)
         ({ResNet\_v2},300)};
     \addplot [fill=Activation!90,draw=none] coordinates {
         ({Inception\_v3},500)
-        ({MobileNet\_v1},700)
+        ({MobileNet\_v1},30)
         ({ResNet\_v2},70)};
 \end{axis}
  \end{scope}
@@ -3197,11 +3197,11 @@ The practical payoff of quantization becomes concrete in @fig-quantization_impac
     ]
     \addplot [fill=WeightGradient!80,draw=none] coordinates {
         ({Inception\_v3},135)
-        ({MobileNet\_v1},4)
+        ({MobileNet\_v1},45)
         ({ResNet\_v2},24)};
     \addplot [fill=Activation!90,draw=none] coordinates {
         ({Inception\_v3},71)
-        ({MobileNet\_v1},45)
+        ({MobileNet\_v1},4)
         ({ResNet\_v2},13)};
 
 \legend{FP32,INT8}


### PR DESCRIPTION
Closes #1318.

## Summary

Reporter observed that the "Quantization Impact" figure in the Model Compression chapter (@fig-quantization_impact) doesn't match its caption. Inspection revealed two compounding issues.

## Issue 1: Inverted MobileNet data

In the original TikZ source, MobileNet_v1's FP32 and INT8 values were swapped in **both** panels:

| Panel | Was (broken) | Now (fixed) |
|---|---|---|
| Inference Time | FP32=30 ms / INT8=700 ms | FP32=700 ms / INT8=30 ms |
| Model Size | FP32=4 MB / INT8=45 MB | FP32=45 MB / INT8=4 MB |

The original direction was physically impossible — quantization cannot produce a *slower*, *larger* model. The other two models (Inception_v3, ResNet_v2) had the correct direction.

## Issue 2: Caption claim ≠ figure data

Even after the swap, the gains vary substantially by architecture (Inception ~1.5–2×, ResNet ~1.85–4.3×, MobileNet ~10–23×), so the original "up to 4 times" claim under-described the figure and contradicted what readers actually see.

Caption rewritten to acknowledge per-architecture variability and the role of mobile-class INT8 hardware in MobileNet's outlier behavior. Body prose updated for consistency.

## Test plan

- [x] Pre-commit hooks all green
- [ ] Spot-check rendered TikZ figure post-merge: all three models should now show FP32 > INT8 (orange segment larger than blue)