### PR TITLE
fix(links): suppress link-rot tracker noise + remove gitignored .claude link

### DIFF
--- a/shared/config/.lycheeignore
+++ b/shared/config/.lycheeignore
@@ -33,3 +33,18 @@
 # Lychee treats anything after # as a fragment to verify, but for these
 # single-page-apps the # is part of the URL semantics. Skip fragment check.
 ^https://star-history\.com/#
+
+# --- Unrendered JS template literals (false positives) ---
+# When Lychee parses a .qmd that contains JavaScript using template literals
+# like `https://github.com/${m.github}`, the template literal is URL-encoded
+# in the AST as `$%7B…%7D` and reported as a broken URL. The literal is
+# substituted at runtime with the actual value, so it is never a real URL.
+# Pattern matches any `${ANY.ANY}` template literal residue.
+^https?://[^/]+/[^?#\s]*\$%7B[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*%7D
+
+# --- GitHub avatar URLs (lychee unreliably HEADs them) ---
+# `https://github.com/<user>.png(?size=N)?` returns 200 in browsers but lychee
+# regularly returns 4xx/timeout against them due to GitHub's HEAD throttling
+# for unauthenticated avatar requests. Manually verified: every avatar URL
+# flagged by the link-rot tracker is reachable in a browser.
+^https://github\.com/[A-Za-z0-9][A-Za-z0-9-]*\.png(\?size=\d+)?$

--- a/slides/teaching.qmd
+++ b/slides/teaching.qmd
@@ -91,7 +91,7 @@ All diagrams are authored as **SVG files** in each chapter's `images/` directory
 To modify a diagram:
 
 1. Edit the `.svg` file in any vector editor (Inkscape, Illustrator, Figma)
-2. Follow the [SVG style guide](https://github.com/harvard-edge/cs249r_book/blob/main/.claude/rules/svg-style.md) for colors and typography
+2. Follow the SVG style guide (palette, typography, canvas conventions) used by the book figures
 3. Rebuild the deck; the Makefile handles SVG-to-PDF conversion
 
 ### Theme Customization


### PR DESCRIPTION
Two surgical fixes for the nightly link-rot tracker (#1424).

## 1. lycheeignore — suppress confirmed false positives

Add two patterns to `shared/config/.lycheeignore`:

### JS template-literal residue
When Lychee parses a `.qmd` containing JavaScript with template literals like `https://github.com/\${m.github}`, the literal is URL-encoded as `\$%7B…%7D` and reported as broken — but it is never a real URL (it is substituted at runtime). Pattern: `^https?://[^/]+/[^?#\s]*\$%7B[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*%7D`

### GitHub avatar URLs
`https://github.com/<user>.png?size=N` returns 200 in a browser but Lychee regularly returns transient 4xx/timeout against these (avatar HEAD throttling). I manually verified `profvjreddi.png?size=96`, `Mjrovai.png?size=96`, etc. all return 200. Pattern: `^https://github\.com/[A-Za-z0-9][A-Za-z0-9-]*\.png(\?size=\d+)?\$`

Together these cover the 8 remaining "broken" Unified Site URLs reported by #1424 that aren't actual failures.

## 2. slides/teaching.qmd — remove gitignored `.claude` link

Line 94 had:

\`\`\`markdown
2. Follow the [SVG style guide](https://github.com/harvard-edge/cs249r_book/blob/main/.claude/rules/svg-style.md) for colors and typography
\`\`\`

The `.claude/` directory is gitignored in this repo, so the URL 404s. Replaced with plain prose mentioning the SVG style guide.

## Out of scope

The 329 `tinyMLx/courseware/raw/master/edX/...` links in `slides/` that 404 against real-but-different file numbers in the upstream repo. That's a content question (upload missing PDFs / switch repos / remove links) requiring strategic input.

## Test plan

- [x] Manually verified each avatar URL and the discuss.tinymlx.org link return 200 in a browser
- [x] Confirmed `${m.github}` is JS source code in `site/about/people.qmd`, not authored URL
- [x] Confirmed AIConfigs is not a public repo (no obvious replacement target for the .claude link)
- [ ] Next nightly link-rot run should report Unified Site as clean and Slides count down by 1