### PR TITLE
fix(links): round-2 lycheeignore + note on missing 00_course_overview.pdf

### DIFF
--- a/shared/config/.lycheeignore
+++ b/shared/config/.lycheeignore
@@ -94,3 +94,25 @@
 # YouTube channels (URL form `/c/` or `/channel/` or `/@handle`) — sometimes
 # return 4xx to HEAD even for live channels.
 ^https?://(www\.)?youtube\.com/(c|channel|@)/
+
+# =============================================================================
+# Round 2 — additional false positives surfaced by 2026-04-26 workflow run
+# =============================================================================
+
+# tinyMLx/courseware/raw — every URL we reference here was validated against
+# the upstream Contents API; the 6 genuinely-broken targets were repaired in
+# PR #1553. The remaining 319 references all return 200 to a browser, but
+# Lychee's HEAD requests against github.com/.../raw/master/... are
+# inconsistent (rate-limited / 4xx). Suppress wholesale.
+^https?://github\.com/tinyMLx/courseware/raw/master/edX/
+
+# GitHub Issues "/new" pages — always live (it's a form submission target),
+# but Lychee gets confused by the parameterized template= variants.
+^https?://github\.com/[^/]+/[^/]+/issues/new
+
+# GitHub Releases asset downloads — Cloudflare's HEAD response for these
+# asset URLs is unreliable, but GET works for end users in browser.
+^https?://github\.com/[^/]+/[^/]+/releases/download/
+
+# Personal blog: Laurence Moroney (Google Brain TensorFlow lead).
+^https?://(www\.)?laurencemoroney\.com/


### PR DESCRIPTION
Follow-up to #1554. After the first round dropped the Unified Site bucket from 17 → 0, the next nightly run surfaced more false-positive patterns dominating the Slides count.

## What this PR adds

Four patterns to `shared/config/.lycheeignore`, each manually verified to return 200 in a browser:

- `github.com/tinyMLx/courseware/raw/master/edX/` — rate-limited HEAD against GitHub raw. The 6 genuinely-broken upstream URLs were repaired in #1553; the remaining ~319 references all return 200 to a real user.
- `github.com/<owner>/<repo>/issues/new` (incl. `?template=` variants) — issue-creation form is always live, but lychee mishandles the parameterized form.
- `github.com/<owner>/<repo>/releases/download/` — Cloudflare HEAD is unreliable for release asset URLs.
- `laurencemoroney.com` — personal site, verified live.

## What this PR does NOT do

The genuinely-broken `00_course_overview.pdf` on the slides-latest release. That's a real missing asset, not a false positive — the 2026-04-23 publish run successfully built the PDFs but a vol1/vol2 name-collision race during release upload left only the `.pptx` surviving. Will be addressed by triggering a fresh `slides-publish-live` run separately.