### PR TITLE
fix(tinytorch/ux): coverage for accent text + light-gradient panels

### DIFF
--- a/tinytorch/quarto/assets/styles/dark-mode.scss
+++ b/tinytorch/quarto/assets/styles/dark-mode.scss
@@ -241,3 +241,23 @@ div.sourceCode {
 [style*="color: #546e7a"] {  // (2)
   color: #cbd5e1 !important;
 }
+
+// Saturated accent text colors used inline on h4 section headers across
+// tito/data.qmd, tito/modules.qmd, tito/overview.qmd. These are 700-shade
+// hues that fail WCAG AA on the #2d2d2d card surface (~2-3.5:1 contrast).
+// Flip each to a 400-shade variant of the same hue so the semantic colour-
+// coding (blue / purple / green / amber sections) is preserved instead of
+// being flattened to slate.
+[style*="color: #1976d2"] { color: #60a5fa !important; }  // blue-700   -> blue-400
+[style*="color: #7b1fa2"] { color: #c084fc !important; }  // purple-700 -> purple-400
+[style*="color: #15803d"] { color: #4ade80 !important; }  // green-700  -> green-400
+[style*="color: #d97706"] { color: #fbbf24 !important; }  // amber-600  -> amber-400
+
+// Light-gradient panels — the [style*="background: #X"] selectors above
+// don't match `linear-gradient(...)` because the substring match is broken
+// by the `linear-gradient(` prefix. One occurrence today (resources.qmd:13);
+// the rule generalises if more soft-blue gradient panels appear.
+[style*="background: linear-gradient(135deg, #e3f2fd"] {
+  background: #2d2d2d !important;
+  border-color: $border-color-dark !important;
+}


### PR DESCRIPTION
## Background

Two narrow extensions to the inline-style safety net in `dark-mode.scss`. Found while QA'ing the tito reference pages and `resources.html` in dark mode after the previous round of fixes.

## Changes

**`tinytorch/quarto/assets/styles/dark-mode.scss`** (one file, +20 lines):

1. **Saturated 700-shade accent text colours** used inline on h4 section headers across `tito/data.qmd`, `tito/modules.qmd`, `tito/overview.qmd` were failing WCAG AA on the `#2d2d2d` card surface (~2–3.5:1 contrast). Flip each to a 400-shade variant of the same hue so semantic colour coding (blue / purple / green / amber sections) survives instead of being flattened to slate:

   | Before | After | Used by |
   |---|---|---|
   | `#1976d2` blue-700 | `#60a5fa` blue-400 | tito/data, tito/modules, tito/overview |
   | `#7b1fa2` purple-700 | `#c084fc` purple-400 | tito/data, tito/modules, tito/overview |
   | `#15803d` green-700 | `#4ade80` green-400 | tito/modules |
   | `#d97706` amber-600 | `#fbbf24` amber-400 | tito/modules, tito/overview |

2. **Light-gradient panels** weren't being caught by the existing `[style*="background: #X"]` selectors because the `linear-gradient(` prefix breaks substring matching. Add a selector that matches the gradient prefix and flips the soft-blue gradient on `resources.qmd:13` to the same `#2d2d2d` surface as solid-fill panels.

## Test plan

- [ ] `cd tinytorch/quarto && quarto render --to html` succeeds for all 52 pages
- [ ] Dark mode visual check on `tito/modules.html` — h4 section headers (Check Environment, Start Module, Resume Work, Export & Complete, Check Progress) keep their semantic blue / purple / green / amber tint but in lightened form, readable on `#2d2d2d`
- [ ] Same check on `tito/overview.html` and `tito/data.html`
- [ ] `resources.html` in dark mode — formerly soft-blue gradient panel now renders as `#2d2d2d` card with readable text
- [ ] Light mode unchanged — `dark-mode.scss` is loaded only in dark mode per `_quarto.yml:251-254`


