### PR TITLE
fix(staffml): correct wrong answer index in cloud-0024

### DIFF
--- a/interviews/vault/questions/cloud/cloud-0024.yaml
+++ b/interviews/vault/questions/cloud/cloud-0024.yaml
@@ -30,7 +30,7 @@ details:
   - 12 GB. The experimental model requires 7x more memory, significantly increasing the serving cost per
     user in the A/B test.
   - 14 GB. The experimental model needs 14 GB, which is the primary cost driver.
-  correct_index: 2
+  correct_index: 3
 status: published
 provenance: imported
 requires_explanation: false


### PR DESCRIPTION
## Problem

`cloud-0024` asks for the FP16 memory footprint of a 7B parameter model.

The correct calculation: 7B params x 2 bytes (FP16) = **14 GB**

Option at `correct_index: 2` states "12 GB" and "7x more memory." But 7x more than the 1B model (2 GB) is 14 GB, not 12 GB. The option contradicts its own reasoning.

Option at index 3 correctly states 14 GB.

## Fix

Changed `correct_index` from `2` to `3`. No other changes.

## Test plan

- [x] Math verified: 7,000,000,000 x 2 = 14,000,000,000 bytes = 14 GB