### PR TITLE
fix(staffml): correct cloud-0013 INT4 throughput math and unit error in distractor

### DIFF
--- a/interviews/vault/questions/cloud/cloud-0013.yaml
+++ b/interviews/vault/questions/cloud/cloud-0013.yaml
@@ -22,13 +22,15 @@ details:
     incorrectly try to calculate the FLOPs required per token and divide by the H100's TFLOPS rating.
     This ignores the fact that autoregressive decoding is a memory-bound operation, as the entire model's
     weights must be read from HBM for each token generated.
-  napkin_math: 1. **Identify the Bottleneck:** Autoregressive token generation (TPOT) is memory-bandwidth
-    bound.
+  napkin_math: '1. **Identify the Bottleneck:** Autoregressive token generation (TPOT) is memory-bandwidth
+    bound. 2. **Calculate model size:** INT4 = 0.5 bytes/param. 70B x 0.5 = 35 GB. 3. **Calculate throughput:**
+    35 GB / 3.35 TB/s = 10.4 ms/token = ~96 tokens/sec. This comfortably exceeds the 20 tok/s requirement,
+    so the bottleneck is real but the hardware can theoretically meet the user expectation.'
   options:
   - No, the H100 is compute-bound during generation and cannot meet this demand.
-  - No, the H100's memory bandwidth is only 3.35 GB/s, making this impossible.
-  - Yes, the H100's memory bandwidth supports a theoretical speed of ~24 tokens/sec, so the issue is likely
-    in the software.
+  - No, the H100's memory bandwidth is only 3.35 TB/s, making it impossible to meet the 20 tok/s target.
+  - Yes, the H100's memory bandwidth supports a theoretical speed of ~96 tokens/sec for this INT4 model,
+    so the issue is likely in the software stack.
   - Yes, because the KV-cache makes all subsequent token generation instantaneous.
   correct_index: 2
 status: published


### PR DESCRIPTION
## Bug

`cloud-0013` (The TPOT Memory Wall) presents an INT4-quantized 70B model but the `napkin_math` field showed FP16 arithmetic:

- **Before (wrong):** implied ~24 tokens/sec (FP16: 140 GB / 3.35 TB/s)
- **After (correct):** ~96 tokens/sec (INT4: 70B x 0.5 bytes = 35 GB, 35 GB / 3.35 TB/s = 10.4 ms/token)

Separately, distractor option 1 contained a 1000x unit error: \"3.35 GB/s\" should be \"3.35 TB/s\".

## Changes

- `interviews/vault/questions/cloud/cloud-0013.yaml`
  - `napkin_math`: complete INT4 calculation showing 35 GB model size and ~96 tok/s throughput
  - Option 1 (distractor): fixed unit \"GB/s\" -> \"TB/s\"
  - Option 2 (correct answer): updated from \"~24 tokens/sec\" to \"~96 tokens/sec for this INT4 model\"
  - `correct_index` unchanged (still 2)

**Question text and scenario are untouched.** Only the answer explanation and option text were corrected to match the precision specified in the scenario.

## Verification

INT4 math: 70B params x 0.5 bytes/param = 35 GB. H100 HBM bandwidth = 3.35 TB/s. Theoretical throughput = 3.35e12 / 35e9 = 95.7 tok/s, comfortably above the 20 tok/s requirement stated in the scenario.

**Related:** PR #1590 (cloud-0024 correct_index fix) is a companion StaffML audit fix.