### PR TITLE
fix(staffml): correct mobile-0534 napkin_math numbers to match scenario

### DIFF
--- a/interviews/vault/questions/mobile/mobile-0534.yaml
+++ b/interviews/vault/questions/mobile/mobile-0534.yaml
@@ -27,10 +27,11 @@ details:
     slow model must be compute-bound. They might also confuse memory capacity (total GB of RAM) with memory
     bandwidth (GB/s), which is the actual bottleneck for data-hungry layers. The key is the *ratio* of
     compute to memory access, known as Arithmetic Intensity.
-  napkin_math: 1. **Calculate Arithmetic Intensity (AI):** Assume the style transfer layer performs 500
-    MFLOPs and reads 10 MB of data. AI = 500e6 / 10e6 = 50 FLOPs/Byte. 2. **A17 Pro Ridge Point:** ~683
-    Ops/Byte (typical for ANE). 3. **Diagnosis:** AI (50) << Ridge Point (683) → memory-bound. 4. **Achievable
-    throughput:** 50 FLOPs/Byte × memory bandwidth → the compute units are severely underutilized.
+  napkin_math: 1. **Calculate Arithmetic Intensity (AI):** The scenario states the layer executes 200
+    GOps (INT8) and reads 500 MB of data. AI = 200e9 / 500e6 = 400 Ops/Byte. 2. **A17 Pro Ridge Point:**
+    ~683 Ops/Byte (typical for ANE). 3. **Diagnosis:** AI (400) < Ridge Point (683) -- memory-bound. 4.
+    **Achievable throughput:** 400 Ops/Byte x memory bandwidth -- the compute units are underutilized
+    and reducing memory traffic is the key optimization lever.
   options:
   - Compute-bound. The 35 TOPS of the A17 Pro is insufficient to execute 200 Giga-ops within the 16ms
     time budget.


### PR DESCRIPTION
## Bug

`mobile-0534` (The Mobile Style Transfer Jank) has a napkin_math that uses completely different numbers than the scenario:

| | Scenario (correct) | napkin_math (wrong) |
|--|--|--|
| Compute | 200 GOps | 500 MFLOPs (1000x smaller) |
| Data moved | 500 MB | 10 MB (50x smaller) |
| Calculated AI | 400 Ops/Byte | 50 FLOPs/Byte |

The correct option at `correct_index: 1` already says "Arithmetic Intensity (400 Ops/Byte)", which is correct per the scenario. The napkin_math was just never updated to match.

## Fix

`interviews/vault/questions/mobile/mobile-0534.yaml`

Updated `napkin_math` to use the scenario's actual numbers: 200 GOps / 500 MB = 400 Ops/Byte, then compare to A17 Pro ridge point of ~683 Ops/Byte to confirm memory-bound diagnosis.

**Question text, scenario, options, and correct_index are all untouched.**

**Related:** PR #1591 (cloud-0013 INT4 math fix) and PR #1590 (cloud-0024 correct_index fix) are companion StaffML audit fixes from the same audit pass.