### PR TITLE
Clean up StaffML analytics visibility listener

### DIFF
--- a/interviews/staffml/src/components/Providers.tsx
+++ b/interviews/staffml/src/components/Providers.tsx
@@ -25,11 +25,15 @@ export default function Providers({ children }: { children: React.ReactNode }) {
 
     // Flush pending analytics on page unload
     const handleUnload = () => flushAnalytics();
-    window.addEventListener('visibilitychange', () => {
+    const handleVisibilityChange = () => {
       if (document.visibilityState === 'hidden') flushAnalytics();
-    });
+    };
+    window.addEventListener('visibilitychange', handleVisibilityChange);
     window.addEventListener('pagehide', handleUnload);
-    return () => window.removeEventListener('pagehide', handleUnload);
+    return () => {
+      window.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.removeEventListener('pagehide', handleUnload);
+    };
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
This fixes a small lifecycle bug in interviews/staffml/src/components/Providers.tsx.

## What changed
- replace the inline visibilitychange listener with a named handler
- remove both visibilitychange and pagehide listeners in the effect cleanup

## Problem solved
Providers was registering visibilitychange with an inline callback and only removing the pagehide listener on cleanup. During remounts or local HMR, that can leave duplicate visibility listeners behind and trigger repeated lushAnalytics() calls for a single visibility change.

## Impact
- no UI change
- keeps analytics flush behavior the same in normal use
- avoids listener accumulation across remounts/hot reloads