### PR TITLE
fix(labs/tests): open lab files with explicit UTF-8 encoding

### DIFF
--- a/labs/tests/test_static.py
+++ b/labs/tests/test_static.py
@@ -29,7 +29,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
 def read_source(lab_path: str) -> str:
-    with open(lab_path) as f:
+    with open(lab_path, encoding="utf-8") as f:
         return f.read()
 
 


### PR DESCRIPTION
## Summary

- `read_source()` in `test_static.py` used `open()` without specifying an encoding
- On Windows, the default codec is `cp1252`, which cannot decode UTF-8 byte sequences like `0x90` (used in em-dash and similar characters present in lab markdown strings)
- All 33 `TestWidgetReturnCompleteness` tests failed on Windows with `UnicodeDecodeError`; passing `PYTHONUTF8=1` made them all green
- Fix: add `encoding="utf-8"` to the single `open()` call in `read_source()`

## Root cause

```python
# before
def read_source(lab_path: str) -> str:
    with open(lab_path) as f:  # uses platform default (cp1252 on Windows)
        return f.read()

# after
def read_source(lab_path: str) -> str:
    with open(lab_path, encoding="utf-8") as f:
        return f.read()
```

## Test plan

- [ ] `pytest labs/tests/test_static.py -q` passes (755 passed, 4 skipped, 1 xfailed) on both Linux and Windows without `PYTHONUTF8=1`