### PR TITLE
fix(instructors): keep theme toggle visible across breakpoints

### DIFF
--- a/shared/styles/partials/_mobile.scss
+++ b/shared/styles/partials/_mobile.scss
@@ -8,8 +8,8 @@
   // UX: Hide ALL sidebar elements - we'll rely on hamburger menu for everything
   .sidebar-toggle,
   .sidebar-tools,
-  .quarto-navigation-tool,
-  .quarto-navigation .quarto-navigation-tool {
+  .quarto-navigation-tool:not(.quarto-color-scheme-toggle),
+  .quarto-navigation .quarto-navigation-tool:not(.quarto-color-scheme-toggle) {
     display: none !important;
   }
 

--- a/shared/styles/partials/_navbar.scss
+++ b/shared/styles/partials/_navbar.scss
@@ -64,8 +64,8 @@
 // The right-side actions (Support, Star, Subscribe, GitHub) should collapse to
 // icon-only gracefully before the full hamburger breakpoint kicks in.
 // Starts at xl (1200px) because the navbar now has 6 left-side dropdowns.
-@media (min-width: 1200px) and (max-width: 1399px) {
-  .navbar .navbar-nav:last-child .nav-link .menu-text {
+@media (min-width: 1200px) and (max-width: 1590px) {
+  ul.navbar-nav.ms-auto > li:nth-last-child(-n+4) .nav-link  .menu-text {
     display: none;
   }
 }


### PR DESCRIPTION
## Summary
- Exclude the Quarto color-scheme (theme) toggle from the mobile sidebar-hide rule so the dark/light switch stays accessible on small screens.
- Widen the icon-only collapse range for right-side navbar actions to `1200px–1590px` and target the last 4 `ms-auto` items, preventing label overflow at mid-widths.

## Changes
- [shared/styles/partials/_mobile.scss](shared/styles/partials/_mobile.scss): add `:not(.quarto-color-scheme-toggle)` to the `.quarto-navigation-tool` hide selectors.
- [shared/styles/partials/_navbar.scss](shared/styles/partials/_navbar.scss): extend media query upper bound to `1399px → 1590px` and switch selector to `ul.navbar-nav.ms-auto > li:nth-last-child(-n+4) .nav-link .menu-text`.

## Before Desktop
<img width="1915" height="92" alt="before instructor navbar" src="https://github.com/user-attachments/assets/cc00c946-4c44-4cad-8b61-42804338bb68" />


## After Desktop
<img width="1906" height="86" alt="after instructor navbar" src="https://github.com/user-attachments/assets/db04781e-9eb1-467a-928e-8e8f3ef9b543" />

## Before Mobile
<img width="488" height="54" alt="before instructor mobile navbar" src="https://github.com/user-attachments/assets/af2d6504-90a5-4345-a09e-225d2a7cc1e0" />



## After Mobile
<img width="617" height="592" alt="after mobile instructor navbar" src="https://github.com/user-attachments/assets/455dddae-eab1-4213-8707-324b4186a284" />



## Test plan
- [ ] Verify theme toggle is visible on mobile widths (<768px) on the instructors page.
- [ ] Verify right-side navbar actions collapse to icons cleanly between 1200px and 1590px.
- [ ] Confirm no regression at ≥1600px (full labels) and ≥hamburger breakpoint (mobile menu).
- [ ] Toggle dark/light mode from mobile to confirm the switch still works.