### PR TITLE
fix(ci/staffml): validate trailing-slash page paths in dev preview

### DIFF
--- a/.github/workflows/staffml-preview-dev.yml
+++ b/.github/workflows/staffml-preview-dev.yml
@@ -150,14 +150,22 @@ jobs:
           echo "✅ StaffML built: $PAGE_COUNT pages"
           echo "📊 Build size: $(du -sh "$STAFFML_ROOT/out" | cut -f1)"
 
-          # Verify critical pages exist
+          # Verify critical pages exist.
+          # next.config.mjs sets `trailingSlash: true`, so /<page> emits
+          # out/<page>/index.html (not out/<page>.html). The 404 page is the
+          # one exception — Next.js still ships it flat as out/404.html so
+          # GitHub Pages can serve it as the not-found template.
           MISSING=0
-          for page in practice gauntlet progress about 404; do
-            if [ ! -f "$STAFFML_ROOT/out/${page}.html" ]; then
-              echo "❌ MISSING: ${page}.html"
+          for page in practice gauntlet progress about; do
+            if [ ! -f "$STAFFML_ROOT/out/${page}/index.html" ]; then
+              echo "❌ MISSING: ${page}/index.html"
               MISSING=$((MISSING + 1))
             fi
           done
+          if [ ! -f "$STAFFML_ROOT/out/404.html" ]; then
+            echo "❌ MISSING: 404.html"
+            MISSING=$((MISSING + 1))
+          fi
           if [ "$MISSING" -gt 0 ]; then
             echo "❌ $MISSING critical pages missing. Aborting."
             exit 1


### PR DESCRIPTION
## Summary
- The dev preview deploy was failing at the validate-build step because it checked for `out/<page>.html`, but `next.config.mjs` sets `trailingSlash: true` — Next.js emits `out/<page>/index.html`. The build itself was always fine; only the validator was wrong.
- Updated the loop to check `<page>/index.html` for the four content pages (practice / gauntlet / progress / about) and keep `404.html` as the flat exception. Mirrors the check already in `staffml-validate-dev.yml`.

## Context
Failing run that motivated the fix: https://github.com/harvard-edge/cs249r_book/actions/runs/25106312447

## Test plan
- [x] Built StaffML locally with the same env vars as CI (`NEXT_PUBLIC_BASE_PATH=/cs249r_book_dev/staffml`, etc.) — 16 pages, 15M, identical to the failing run.
- [x] Ran the fixed validator logic against the local `out/` — all four `<page>/index.html` files plus `404.html` resolve.
- [ ] Watch the preview-dev workflow re-run on this branch / after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)