### PR TITLE
fix(staffml): use summary fallback when Worker fetch fails in gauntlet

### DIFF
--- a/interviews/staffml/src/app/gauntlet/page.tsx
+++ b/interviews/staffml/src/app/gauntlet/page.tsx
@@ -199,8 +199,10 @@ export default function GauntletPage() {
     // worker responses come back, swap the questions state to the hydrated
     // copies. Until then the UI shows summaries (empty scenario/details).
     Promise.all(selected.map(q => getQuestionFullDetail(q.id))).then(results => {
-      const hydrated = results.filter((q): q is Question => q !== undefined);
-      if (hydrated.length === selected.length) setQuestions(hydrated);
+      // Fall back to the original summary for any question the Worker couldn't hydrate
+      // rather than silently discarding the entire batch when even one fetch fails.
+      const merged = selected.map((s, i) => results[i] ?? s);
+      setQuestions(merged);
     });
   }, [selectedTrack, selectedLevel, selectedDuration]);
 


### PR DESCRIPTION
## Summary

- `startGauntlet` fires `Promise.all` to pre-hydrate every question's scenario/details from the Cloudflare Worker before the gauntlet starts.
- The previous guard was `if (hydrated.length === selected.length) setQuestions(hydrated)` -- meaning if **even one** Worker response came back `undefined`, the entire hydrated batch was silently dropped and `setQuestions` was never called.
- Users then played the whole gauntlet with empty `scenario` and `details` fields on every question, regardless of which questions actually succeeded.

**Fix:** Map results back to the original `selected` array per-index, falling back to the summary for any question the Worker couldn't hydrate. Partial Worker failures now degrade gracefully instead of wiping all hydrated data.

```ts
// Before
const hydrated = results.filter((q): q is Question => q !== undefined);
if (hydrated.length === selected.length) setQuestions(hydrated);

// After
const merged = selected.map((s, i) => results[i] ?? s);
setQuestions(merged);
```

## Test plan

- [ ] Start a gauntlet normally -- verify questions show scenario/details as before
- [ ] Simulate a Worker outage (DevTools: block `staffml-vault.*` requests) -- verify gauntlet still starts and shows summary text per question rather than blank scenario
- [ ] Verify gauntlet timer, scoring, and results phases work correctly after the change