### PR TITLE
fix(staffml): add pickRandom to keyboard effect and pickNext dep arrays

### DIFF
--- a/interviews/staffml/src/app/practice/page.tsx
+++ b/interviews/staffml/src/app/practice/page.tsx
@@ -392,6 +392,22 @@ function PracticePage() {
     setNapkinResult(null);
   }, [mounted, selectedTrack, selectedLevel, selectedArea, selectedZone, napkinOnly, chainsOnly, visualOnly]);
 
+  const pickRandom = useCallback((fromPool?: Question[]) => {
+    // Track skip if there was a current question that wasn't scored
+    if (current && !showAnswer) {
+      track({ type: 'question_skipped', topic: current.topic, level: current.level });
+    }
+    const p = fromPool || pool;
+    if (p.length === 0) return;
+    const idx = Math.floor(Math.random() * p.length);
+    setCurrent(p[idx]);
+    questionShownAt.current = Date.now();
+    setShowAnswer(false);
+    setUserAnswer("");
+    setNapkinResult(null);
+    setRubricItems([]);
+  }, [pool, current, showAnswer]);
+
   // Keyboard shortcuts: Enter to reveal, 1-4 for scoring, N to skip
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -412,23 +428,7 @@ function PracticePage() {
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [showAnswer, current]);
-
-  const pickRandom = useCallback((fromPool?: Question[]) => {
-    // Track skip if there was a current question that wasn't scored
-    if (current && !showAnswer) {
-      track({ type: 'question_skipped', topic: current.topic, level: current.level });
-    }
-    const p = fromPool || pool;
-    if (p.length === 0) return;
-    const idx = Math.floor(Math.random() * p.length);
-    setCurrent(p[idx]);
-    questionShownAt.current = Date.now();
-    setShowAnswer(false);
-    setUserAnswer("");
-    setNapkinResult(null);
-    setRubricItems([]);
-  }, [pool, current, showAnswer]);
+  }, [showAnswer, current, pickRandom]);
 
   // Submit-gradient guard: intercept reveals that look like
   // "didn't really try." The restructured layout puts the Reveal
@@ -577,7 +577,7 @@ function PracticePage() {
       setReviewMode(false);
     }
     pickRandom();
-  }, [reviewMode, pool]);
+  }, [reviewMode, pool, pickRandom]);
 
   if (!mounted) {
     return (


### PR DESCRIPTION
## Summary

Two related stale-closure bugs in `practice/page.tsx`:

**Bug 1 -- keyboard shortcut `N` picks from wrong pool after filter change**

`pickRandom` is a `useCallback` with deps `[pool, current, showAnswer]`. When the user changes a filter (track, level, area, etc.), `pool` updates and `pickRandom` gets a new identity. But the keyboard `useEffect` only listed `[showAnswer, current]` as deps -- it never re-registered the listener with the new `pickRandom`. Pressing `N` after a filter change would pick from the stale pre-filter question pool.

**Bug 2 -- `pickNext` also calls stale `pickRandom`**

Same issue in `pickNext`: deps were `[reviewMode, pool]` but it calls `pickRandom()`, so the same staleness applied after a pool change.

**Fix:**
- Move `pickRandom` declaration before the keyboard `useEffect` (satisfies declaration-before-use order)
- Add `pickRandom` to the keyboard effect dep array: `[showAnswer, current, pickRandom]`
- Add `pickRandom` to `pickNext` dep array: `[reviewMode, pool, pickRandom]`

## Repro steps

1. Open `/practice`, select "Cloud" + "L3"
2. Answer one question, then switch track to "Edge"
3. Press `N` on the keyboard
4. Before fix: the picked question is often from the "Cloud" pool
5. After fix: the picked question is always from the current "Edge" pool

## Test plan

- [ ] Change filters and immediately press `N` -- verify picked question matches the new filter
- [ ] Score a question with 1-4 keyboard keys -- verify scoring still works
- [ ] Cmd+Enter in the textarea -- verify reveal shortcut still works
- [ ] Spaced repetition review mode -- verify `pickNext` correctly transitions to `pickRandom` when due queue is empty