### PR TITLE
fix(instructors): correct lab subtitles in foundations syllabus (labs 09-15)

### DIFF
--- a/instructors/foundations-syllabus.qmd
+++ b/instructors/foundations-syllabus.qmd
@@ -162,7 +162,7 @@ By Week 8, students should have a working TinyTorch that can: create tensors, ap
 | Component | Assignment |
 |:---|:---|
 | **Read** | [Model Compression](https://mlsysbook.ai/vol1/model_compression.html) |
-| **Lab** | [Lab 09](https://mlsysbook.ai/labs/vol1/lab_09_data_selection.html): Quantization (INT8/INT4) |
+| **Lab** | [Lab 09](https://mlsysbook.ai/labs/vol1/lab_09_data_selection.html): The Data Selection Paradox |
 | **Build** | [TinyTorch Module 08: Training](https://mlsysbook.ai/tinytorch/modules/08_training_ABOUT.html) |
 | **Due** | Module 07 notebook + Lab 09 Decision Log |
 
@@ -178,7 +178,7 @@ Lab 09 is where students viscerally experience the accuracy-efficiency tradeoff.
 | Component | Assignment |
 |:---|:---|
 | **Read** | [Hardware Acceleration](https://mlsysbook.ai/vol1/hw_acceleration.html) |
-| **Lab** | [Lab 10](https://mlsysbook.ai/labs/vol1/lab_10_model_compress.html): The Roofline Model |
+| **Lab** | [Lab 10](https://mlsysbook.ai/labs/vol1/lab_10_model_compress.html): The Compression Paradox |
 | **Build** | TinyTorch Module 08: Training (continued) |
 | **Due** | Module 08 notebook + Lab 10 Decision Log |
 
@@ -189,7 +189,7 @@ Lab 09 is where students viscerally experience the accuracy-efficiency tradeoff.
 | Component | Assignment |
 |:---|:---|
 | **Read** | [Benchmarking](https://mlsysbook.ai/vol1/benchmarking.html) |
-| **Lab** | [Lab 11](https://mlsysbook.ai/labs/vol1/lab_11_hw_accel.html): Benchmarking Methodology |
+| **Lab** | [Lab 11](https://mlsysbook.ai/labs/vol1/lab_11_hw_accel.html): The Hardware Roofline |
 | **Build** | *No new module — catch-up week* |
 | **Due** | Lab 11 Decision Log |
 
@@ -206,7 +206,7 @@ Lab 09 is where students viscerally experience the accuracy-efficiency tradeoff.
 | Component | Assignment |
 |:---|:---|
 | **Read** | [Model Serving](https://mlsysbook.ai/vol1/serving.html) |
-| **Lab** | [Lab 12](https://mlsysbook.ai/labs/vol1/lab_12_perf_bench.html): Tail Latency (P99) |
+| **Lab** | [Lab 12](https://mlsysbook.ai/labs/vol1/lab_12_perf_bench.html): The Benchmarking Trap |
 | **Build** | *Capstone prep* |
 | **Due** | Lab 12 Decision Log |
 
@@ -217,7 +217,7 @@ Lab 09 is where students viscerally experience the accuracy-efficiency tradeoff.
 | Component | Assignment |
 |:---|:---|
 | **Read** | [ML Operations](https://mlsysbook.ai/vol1/ops.html) |
-| **Lab** | [Lab 13](https://mlsysbook.ai/labs/vol1/lab_13_model_serving.html): Drift Detection |
+| **Lab** | [Lab 13](https://mlsysbook.ai/labs/vol1/lab_13_model_serving.html): The Tail Latency Trap |
 | **Build** | *Capstone prep* |
 | **Due** | Lab 13 Decision Log |
 
@@ -228,7 +228,7 @@ Lab 09 is where students viscerally experience the accuracy-efficiency tradeoff.
 | Component | Assignment |
 |:---|:---|
 | **Read** | [Responsible Engineering](https://mlsysbook.ai/vol1/responsible_engr.html) |
-| **Lab** | [Lab 14](https://mlsysbook.ai/labs/vol1/lab_14_ml_ops.html): Fairness and Efficiency |
+| **Lab** | [Lab 14](https://mlsysbook.ai/labs/vol1/lab_14_ml_ops.html): The Silent Degradation Problem |
 | **Build** | *Capstone work* |
 | **Due** | Lab 14 Decision Log + Capstone draft |
 
@@ -239,7 +239,7 @@ Lab 09 is where students viscerally experience the accuracy-efficiency tradeoff.
 | Component | Assignment |
 |:---|:---|
 | **Read** | [Conclusion](https://mlsysbook.ai/vol1/conclusion.html) |
-| **Lab** | [Lab 15](https://mlsysbook.ai/labs/vol1/lab_15_responsible_engr.html): Capstone Integration |
+| **Lab** | [Lab 15](https://mlsysbook.ai/labs/vol1/lab_15_responsible_engr.html): No Free Fairness |
 | **Capstone** | AI Olympics Competition |
 | **Due** | Final submission + 1,000-word design report |
 


### PR DESCRIPTION
## Summary

Lab subtitles in `foundations-syllabus.qmd` were shifted one position ahead of the actual lab content from Week 10 onward. The hyperlink URLs were correct -- clicking them would open the right lab -- but the displayed subtitle text described the *next* lab, misleading instructors about each week's content.

## The bug

All 7 subtitles from Lab 09 through Lab 15 were wrong:

| Week | Lab URL (correct) | Old subtitle (wrong) | Correct subtitle |
|------|-------------------|----------------------|-----------------|
| 10 | `lab_09_data_selection` | Quantization (INT8/INT4) | The Data Selection Paradox |
| 11 | `lab_10_model_compress` | The Roofline Model | The Compression Paradox |
| 12 | `lab_11_hw_accel` | Benchmarking Methodology | The Hardware Roofline |
| 13 | `lab_12_perf_bench` | Tail Latency (P99) | The Benchmarking Trap |
| 14 | `lab_13_model_serving` | Drift Detection | The Tail Latency Trap |
| 15 | `lab_14_ml_ops` | Fairness and Efficiency | The Silent Degradation Problem |
| 16 | `lab_15_responsible_engr` | Capstone Integration | No Free Fairness |

Subtitles verified against the opening title string in each lab source file (`labs/vol1/lab_NN_*.py`).

## Test plan

- [ ] Open the rendered instructors site and confirm each week's lab subtitle matches the actual lab content
- [ ] Verify all lab URLs still resolve correctly (they were not changed)