### PR TITLE
fix(kits/raspi/llm): wrap context-token array to prevent page overflow

### DIFF
--- a/kits/contents/raspi/llm/llm.qmd
+++ b/kits/contents/raspi/llm/llm.qmd
@@ -564,7 +564,12 @@ As we can see, several pieces of information are generated, such as:
     - `The capital of France is **Paris**. 🇫🇷`
 
 - **context**: the token IDs representing the input and context used by the model. Tokens are numerical representations of text used for processing by the language model.
-    - `[106, 1645, 108, 1841, 603, 573, 6037, 576, 6081, 235336, 107, 108, 106, 2516, 108, 651, 6037, 576, 6081, 603, 5231, 29437, 168428, 235248, 244304, 241035, 235248, 108]`
+
+    ```text
+    [106, 1645, 108, 1841, 603, 573, 6037, 576, 6081, 235336,
+     107, 108, 106, 2516, 108, 651, 6037, 576, 6081, 603,
+     5231, 29437, 168428, 235248, 244304, 241035, 235248, 108]
+    ```
 
 The Performance Metrics:
 


### PR DESCRIPTION
## Summary
- On `kits/contents/raspi/llm/llm.qmd`, the 26-token `context` array was authored as **inline code** (single backtick) under a sub-bullet. Inline code does not wrap, so the array stretched the page wider than the viewport and forced horizontal scroll on the entire page (see *Before*).
- Moved the array into a fenced ```` ```text ```` code block with the values broken across three lines. Fenced code blocks scroll within their own width, so the page itself no longer overflows.
- Content of the array is unchanged; only formatting.

## Before
<img width="1769" height="318" alt="Screenshot 2026-04-30 101044" src="https://github.com/user-attachments/assets/81cdfcb5-d020-47ff-8599-1b23460d5b07" />



## After
<img width="1638" height="387" alt="Screenshot 2026-04-30 101116" src="https://github.com/user-attachments/assets/45aad65e-f245-4735-ad1e-1bbc286195cc" />


## Test plan
- [ ] `cd kits && quarto preview` → open `/contents/raspi/llm/llm.html`.
- [ ] Scroll to the section after "*As we can see, several pieces of information are generated*".
- [ ] Confirm the page itself has no horizontal scrollbar at standard widths (e.g. 1280px, 1024px).
- [ ] Confirm the token array is rendered inside a code block and scrolls within its own bounds if the viewport is narrowed.
- [ ] Verify other code blocks on the page still render correctly.