### PR TITLE
fix(quarto/scss): scope light-text overrides to dark theme

### DIFF
--- a/tinytorch/quarto/assets/styles/style.scss
+++ b/tinytorch/quarto/assets/styles/style.scss
@@ -589,8 +589,10 @@ $callout-secondary-bg: rgba($callout-secondary, 0.08);
   &.btn-blue { background: #3b82f6; }
 }
 
-#quarto-content h3 { color: #d0d0d0 !important; code { color:black; } }
-pre code { color: #e6e6e6; }
+// Scope light-text overrides to dark theme — the unscoped versions bled
+// near-white text into light mode, leaving h3/pre code unreadable.
+[data-bs-theme="dark"] #quarto-content h3 { color: #d0d0d0 !important; code { color:black; } }
+[data-bs-theme="dark"] pre code { color: #e6e6e6; }
 
 // --- Light-fill panel text-color safety net (mode-shared half) ---
 //


### PR DESCRIPTION
## Summary
- Wrap the `#quarto-content h3` and `pre code` color overrides in `[data-bs-theme="dark"]` so they only apply in dark mode.
- Add an inline comment explaining the scoping.

## Why
The unscoped rules forced near-white text (`#d0d0d0`, `#e6e6e6`) on h3 headings and `pre code` blocks regardless of theme, which left those elements unreadable in light mode. Gating on the dark-theme attribute restores Quarto's default light-mode contrast while preserving the dark-mode appearance.

## Test plan
- [ ] `quarto preview` from `tinytorch/quarto/` and confirm h3 / `pre code` render correctly in light mode.
- [ ] Toggle to dark mode and confirm light text is still applied.