### PR TITLE
fix(kits): fix TFLite size typo and broken pth command in raspi image-classification lab

### DIFF
--- a/kits/contents/raspi/image_classification/image_classification.qmd
+++ b/kits/contents/raspi/image_classification/image_classification.qmd
@@ -497,7 +497,7 @@ Let's get a TFLite model trained from scratch. For that, you can follow the Note
 
  In the notebook, we trained a model using the CIFAR10 dataset, which contains 60,000 images from 10 classes of CIFAR (*airplane, automobile, bird, cat, deer, dog, frog, horse, ship, and truck*). CIFAR has $32\times 32$ color images (3 color channels) where the objects are not centered and can have the object with a background, such as airplanes that might have a cloudy sky behind them! In short, small but real images.
 
-The CNN trained model (*cifar10_model.keras*) had a size of 2.0MB. Using the *TFLite Converter*, the model *cifar10.tflite* became with 674MB (around 1/3 of the original size).
+The CNN trained model (*cifar10_model.keras*) had a size of 2.0MB. Using the *TFLite Converter*, the model *cifar10.tflite* became with 674KB (around 1/3 of the original size).
 
 \noindent
 ![](images/png/cifar10_model.png)
@@ -521,8 +521,7 @@ On the notebook [Cifar 10 - Image Classification on a Raspi with TFLite](https:/
 
     ```bash
     echo "/usr/lib/python3/dist-packages" > \
-     $VIRTUAL_ENV/lib/python3.11/
-    site-packages/system_site_packages.pth
+      $VIRTUAL_ENV/lib/python3.11/site-packages/system_site_packages.pth
     ```
 
     > Note: If your Python version differs, replace  `python3.11` with the appropriate version.


### PR DESCRIPTION
## Summary

Two bugs in `kits/contents/raspi/image_classification/image_classification.qmd`:

### Bug 1 -- Wrong size unit for cifar10.tflite (674MB → 674KB)

The text described the quantized TFLite model as **674MB** -- but the original `.keras` model is only 2.0MB, and "around 1/3 of the original size" is ~**674KB**. 674MB would be 337x larger than the source model and bigger than the entire ImageNet training set, which is physically impossible for a CIFAR-10 classifier.

```diff
-The CNN trained model had a size of 2.0MB. Using TFLite Converter, cifar10.tflite became with 674MB (around 1/3 of the original size).
+The CNN trained model had a size of 2.0MB. Using TFLite Converter, cifar10.tflite became with 674KB (around 1/3 of the original size).
```

### Bug 2 -- Broken bash command for picamera2 venv setup

The redirect target path was split across two lines with a stray newline inside the path, producing two invalid shell commands when copy-pasted:

```bash
# Before (broken -- newline splits the path)
echo "/usr/lib/python3/dist-packages" > \
 $VIRTUAL_ENV/lib/python3.11/
site-packages/system_site_packages.pth

# After (fixed -- path on one continuation line)
echo "/usr/lib/python3/dist-packages" > \
  $VIRTUAL_ENV/lib/python3.11/site-packages/system_site_packages.pth
```

The broken form would: (1) redirect stdout into a directory -- shell error, and (2) try to execute `site-packages/system_site_packages.pth` as a command -- another error. Students following the lab would get confusing errors and be unable to use picamera2 inside the venv.

## Test plan

- [ ] Verify the cifar10 size description reads "674KB" and makes sense in context (2.0MB → ~674KB after INT8 quantization)
- [ ] Copy-paste the fixed pth command into a terminal and confirm it creates the `.pth` file correctly