### PR TITLE
fix(tinytorch): tito module status milestone tracking (#1612, #1615)

### DIFF
--- a/tinytorch/tito/commands/module/workflow.py
+++ b/tinytorch/tito/commands/module/workflow.py
@@ -1505,12 +1505,15 @@ class ModuleWorkflowCommand(BaseCommand):
         self.console.print(status_table)
         self.console.print()
 
-        # Milestones section (if any are unlocked)
+        # Milestones section (if any are unlocked or ready)
+        # Show every milestone with state — slicing to the first few hid later
+        # milestones once early ones were unlocked (issue #1615), so students
+        # never saw that milestones 04+ were ready to be unlocked.
         if completed_count >= 1:
             milestone_unlocks = self._check_milestone_readiness(completed)
             if milestone_unlocks:
                 self.console.print("[bold magenta]🏆 Milestones Unlocked:[/bold magenta]")
-                for milestone_id, milestone_name, ready in milestone_unlocks[:3]:  # Show first 3
+                for milestone_id, milestone_name, ready in milestone_unlocks:
                     if ready == "unlocked":
                         self.console.print(f"  [magenta]✅ {milestone_id} - {milestone_name}[/magenta]")
                     elif ready == "ready":

--- a/tinytorch/tito/commands/module/workflow.py
+++ b/tinytorch/tito/commands/module/workflow.py
@@ -1531,16 +1531,24 @@ class ModuleWorkflowCommand(BaseCommand):
         return 0
 
     def _check_milestone_readiness(self, completed_modules: list) -> list:
-        """Check which milestones are unlocked or ready."""
+        """Check which milestones are unlocked or ready.
+
+        The required-modules list for each milestone must match the canonical
+        definition in ``tito milestone`` (``MILESTONE_SCRIPTS`` in
+        ``tinytorch/tito/commands/milestone.py``) and in
+        ``_get_milestone_for_module`` above. Diverging copies have caused
+        ``tito module status`` to advertise milestones as ready before the
+        student has actually completed every prerequisite module (issue #1612).
+        """
         import json
 
         milestones = [
             ("01", "Perceptron (1958)", [1, 2, 3]),
             ("02", "XOR Crisis (1969)", [1, 2, 3]),
-            ("03", "MLP Revival (1986)", [1, 2, 3, 4, 5, 6]),
-            ("04", "CNN Revolution (1998)", [1, 2, 3, 4, 5, 6, 8, 9]),
-            ("05", "Transformer Era (2017)", [1, 2, 3, 4, 5, 6, 11, 12, 13]),
-            ("06", "MLPerf (2018)", [1, 2, 3, 4, 5, 6, 14, 15, 16, 17, 18, 19]),
+            ("03", "MLP Revival (1986)", [1, 2, 3, 4, 5, 6, 7, 8]),
+            ("04", "CNN Revolution (1998)", [1, 2, 3, 4, 5, 6, 7, 8, 9]),
+            ("05", "Transformer Era (2017)", [1, 2, 3, 4, 5, 6, 7, 8, 11, 12, 13]),
+            ("06", "MLPerf (2018)", [1, 2, 3, 4, 5, 6, 7, 8, 14, 15, 16, 17, 18, 19]),
         ]
 
         # Check which milestones have been completed (run successfully)


### PR DESCRIPTION
## Summary

Two related bugs in `tito module status` reported by `andre` against TinyTorch v0.1.10. Both live in `tinytorch/tito/commands/module/workflow.py`.

### Issue #1612 — Milestone 03 advertised as ready after module 6

`_check_milestone_readiness` carried its own copy of the milestone-to-modules mapping that had drifted from the canonical `MILESTONE_SCRIPTS` definition in `tito/commands/milestone.py` (and from `_get_milestone_for_module` higher up in the same file).

The drifted list said milestone 03 (MLP Revival, 1986) needed only modules `[1, 2, 3, 4, 5, 6]`, so the dashboard told students it was ready to unlock as soon as module 6 was done. The milestone actually requires the full training stack through module 8. Milestones 04–06 had similar gaps that omitted modules 7 and/or 8.

**Fix:** updated the list to match the canonical requirements, and added a docstring noting that this list mirrors `MILESTONE_SCRIPTS` and must stay in sync.

| Milestone | Before | After |
|---|---|---|
| 03 MLP Revival | `[1..6]` | `[1..8]` |
| 04 CNN Revolution | `[1..6, 8, 9]` | `[1..9]` |
| 05 Transformer Era | `[1..6, 11..13]` | `[1..8, 11..13]` |
| 06 MLPerf | `[1..6, 14..19]` | `[1..8, 14..19]` |

### Issue #1615 — Milestones after 03 disappear from status

The status display sliced the milestone list with `[:3]`, so once any three milestones appeared (unlocked or ready), every milestone after that vanished from the output. Once milestones 01, 02, 03 were unlocked, the student would no longer see that milestones 04, 05, 06 were ready to unlock — they appeared to drop off the dashboard entirely.

**Fix:** iterate over the full readiness list. The list has at most six entries, so output stays compact and "ready" milestones beyond the third unlocked one are now visible.

## Verification

Reproduced the readiness logic in isolation and confirmed:

- After completing modules 01–06, milestone 03 is **not** listed as ready (only 01 and 02 are).
- After completing module 08, milestone 03 becomes ready.
- With milestones 01/02/03 unlocked and module 09 done, milestone 04 now appears as ready (the old `[:3]` slice would have hidden it).

No existing pytest coverage exists for `_check_milestone_readiness` or `show_status`. `python3 -m py_compile` on the modified file passes.

## Test plan

- [ ] Manual: in a working TinyTorch checkout, complete modules 1–6 only and run `tito module status`; confirm milestone 03 is not listed as ready.
- [ ] Manual: complete modules 1–8 and confirm milestone 03 now shows as ready to unlock.
- [ ] Manual: unlock milestones 01–03 (`tito milestone run 01/02/03`) with all required modules done, then run `tito module status`; confirm milestone 04 is still visible as ready (and 01–03 still listed as unlocked).

Relates to #1612
Relates to #1615