### PR TITLE
fix(tinytorch): perceptron weights deterministic across runs (#1611)

### DIFF
--- a/tinytorch/milestones/01_1958_perceptron/01_rosenblatt_forward.py
+++ b/tinytorch/milestones/01_1958_perceptron/01_rosenblatt_forward.py
@@ -85,7 +85,9 @@ This milestone shows you WHY training is essential - the model won't work withou
 import sys
 import os
 import numpy as np
-rng = np.random.default_rng(7)
+# Unseeded RNG: each run draws different cluster points so the demo lives up
+# to the on-screen "No random seed - each run will be different!" promise.
+rng = np.random.default_rng()
 import argparse
 
 # Add project root to path for correct tinytorch imports

--- a/tinytorch/src/03_layers/03_layers.py
+++ b/tinytorch/src/03_layers/03_layers.py
@@ -62,7 +62,10 @@ from tinytorch.core.activations import ReLU, Sigmoid  # Module 02 - intelligence
 #| export
 
 import numpy as np
-rng = np.random.default_rng(7)
+# Module-level RNG is intentionally UNSEEDED so freshly-constructed layers
+# (e.g., Linear) produce different weights on every run. Tests/demos that
+# need determinism create their own seeded RNG locally (see below).
+rng = np.random.default_rng()
 
 # Import from TinyTorch package (previous modules must be completed and exported)
 from tinytorch.core.tensor import Tensor


### PR DESCRIPTION
## Summary

Fixes the bug reported in #1611: every run of Milestone 1 produced the same Perceptron weights, even though the on-screen text promises *"No random seed - each run will be different!"*.

### Root cause

`tinytorch/src/03_layers/03_layers.py` had a module-level

```python
rng = np.random.default_rng(7)
```

just under the imports (line 65). `Linear.__init__` reused this single seeded RNG for every weight init via `rng.standard_normal(...)`, so every freshly-constructed `Linear` produced identical weights across processes. The milestone script `01_rosenblatt_forward.py` had its own seeded `rng = np.random.default_rng(7)` (line 88) used for the data clusters too, contradicting the displayed message.

### Fix

Drop the seed in two places:

1. **`tinytorch/src/03_layers/03_layers.py`** - module-level `rng` is now unseeded (`np.random.default_rng()`). Local seeded RNGs inside test/demo blocks (lines ~829, 848, 981) are intentionally left alone since those want determinism for reproducible self-tests.
2. **`tinytorch/milestones/01_1958_perceptron/01_rosenblatt_forward.py`** - the data-generation `rng` is also unseeded so cluster points vary too.

```diff
-rng = np.random.default_rng(7)
+rng = np.random.default_rng()
```

### Verification

After re-exporting `tinytorch/core/layers.py` via `nbdev.export.nb_export`, ran the milestone twice and compared (excerpt of `diff /tmp/run1.txt /tmp/run2.txt`):

```
< │ Predictions │ [1 1 1 1 1 0 0 0 0 0] │
< │ Matches     │ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓   │
< │ Accuracy    │ 100.0% 🎲 Got Lucky!  │
---
> │ Predictions │ [0 0 0 0 0 1 1 1 1 1]    │
> │ Matches     │ ✗ ✗ ✗ ✗ ✗ ✗ ✗ ✗ ✗ ✗      │
> │ Accuracy    │ 0.0% ❌ Random Guessing! │
```

Cluster points, predictions, and final accuracy all differ between runs — exactly what the milestone advertises. Independent `Linear(8,4)` constructions within the same process also produce distinct weight matrices (`np.array_equal(a, b) == False`).

Relates to #1611

## Test plan

- [ ] Re-export Module 03 (`tito dev export 03`) and confirm `tinytorch/core/layers.py` now has unseeded `rng = np.random.default_rng()`
- [ ] Run the milestone twice (`python3 tinytorch/milestones/01_1958_perceptron/01_rosenblatt_forward.py < /dev/null`) and verify accuracy/cluster output differs
- [ ] `python3 -m pytest tinytorch/tests/03_layers/ -k "linear or layers_core" -v` (after exporting full package)
- [ ] Spot-check that pedagogical reproducibility tests further down `03_layers.py` (lines ~829, 848, 981) still see deterministic output thanks to their local `rng = np.random.default_rng(7)` — those were left intact