### PR TITLE
Refined the PDF layout for Chapter 9 (data_selection.qmd).

### DIFF
--- a/book/quarto/contents/vol1/data_selection/data_selection.qmd
+++ b/book/quarto/contents/vol1/data_selection/data_selection.qmd
@@ -151,9 +151,136 @@ class ScalingAsymmetry:
 Trace the trend line in @fig-running-out-of-human-data: foundation models are consuming the stock of human-generated text at an accelerating rate, with projections suggesting exhaustion of high-quality public data on a timeline measured in years, not decades. The exhaustion timeline is not a distant concern. It shapes training strategies today.
 
 ::: {#fig-running-out-of-human-data fig-env="figure" fig-pos="htb" fig-cap="**Dataset Growth Approaching Limits**: Foundation models are increasingly trained on vast datasets, approaching the total stock of human-generated text. Current projections suggest that high-quality public text data faces exhaustion on a near-term horizon, forcing a shift toward data selection, synthetic generation, and multimodal learning." fig-alt="Line chart of dataset size in tokens (10^9 to 10^15 on a log y-axis) vs. year (2012 to 2028). A blue line shows exponential data growth with markers for GPT-3, Chinchilla, Llama 2, and Llama 3. An orange band marks the high-quality public text stock."}
+```{.tikz}
+\begin{tikzpicture}[font=\usefont{T1}{phv}{m}{n}\small]
 
-![](images/png/running_out_of_data.png)
+\pgfplotsset{
+  layers/axis lines on top/.define layer set={
+    axis background,
+    axis grid,
+    axis ticks,
+    axis tick labels,
+    pre main,
+    main,
+    axis lines,
+    axis descriptions,
+    axis foreground,
+  }{/pgfplots/layers/standard},
+}
 
+\begin{axis}[
+   /pgf/number format/.cd,
+   tick label style={/pgf/number format/assume math mode=true},
+   ticklabel style={font=\footnotesize\usefont{T1}{phv}{m}{n}},
+   1000 sep={}, % uklanja zareze
+  yticklabel style={
+  /pgf/number format/.cd,
+  sci,
+  sci generic={mantissa e exponent},
+  precision=0
+},
+    width=15cm,
+    height=9cm,
+    xmin=2012, xmax=2028.5,
+    ymin=1e9, ymax=1.4e15,
+    ymode=log,
+    log basis y=10,
+    xtick={2012,2014,2016,2018,2020,2022,2024,2026,2028},
+    %ytick={1e9,1e10,1e11,1e12,1e13,1e14,1e15},
+    yticklabels={10\textsuperscript{8},10\textsuperscript{9},
+    10\textsuperscript{10},10\textsuperscript{11},
+    10\textsuperscript{12},10\textsuperscript{13},
+    10\textsuperscript{14},10\textsuperscript{15}},
+    xlabel={Year},
+    ylabel={Dataset Size (Tokens)},
+    axis lines*=left,
+    axis line style={gray!70,line width=1pt},
+ % axis on top=true,
+    set layers=axis lines on top,
+    tick style={gray!70},
+    tick label style={font=\usefont{T1}{phv}{m}{n}\footnotesize},
+    ylabel style={font=\small\usefont{T1}{phv}{m}{n},align=center,yshift=-1.2mm},
+    xlabel style={font=\small\usefont{T1}{phv}{m}{n}},
+    grid=both,
+    major grid style={gray!12},
+    minor grid style={gray!6},
+    clip=false,
+    major tick style={thin,black},
+   tick align=outside,
+   major tick length=4pt,
+]
+
+% --- shaded public text stock band ---
+\addplot[
+    draw=none,
+    fill=myorange!07
+] coordinates {
+    (2012,1e13)
+    (2028,1e13)
+    (2028,1e14)
+    (2012,1e14)
+}; %\closedcycle
+
+\node[
+    anchor=center,
+    align=center,
+    text=myorange!75!black,
+    font=\footnotesize\usefont{T1}{phv}{m}{n}
+] at (axis cs:2015.5,3e13)
+{High-Quality Public Text Stock\\(Books, Papers, Code, Web)};
+
+% --- scaling line ---
+\addplot[
+    BlueLine,
+    line width=1.5pt,
+] coordinates {
+    (2017.15,1e9)
+    (2026.60,1e15)
+};
+
+% --- data points ---
+\addplot[
+    only marks,
+    mark=*,
+    mark size=2.5,
+    BlueLine,
+    draw=white,line width=0.95pt
+] coordinates {
+    (2019.0,1.4e10)   % unlabeled low point
+    (2020.0,3.0e11)   % GPT-3
+    (2022.0,1.4e12)   % Chinchilla
+    (2023.0,2.0e12)   % Llama 2
+    (2024.0,1.5e13)   % Llama 3
+};
+
+% --- point labels ---
+\node[anchor=west, text=BlueLine, font=\usefont{T1}{phv}{m}{n}\footnotesize]
+    at (axis cs:2018.5,3.0e11) {GPT-3};
+
+\node[anchor=west, text=BlueLine, font=\usefont{T1}{phv}{m}{n}\footnotesize]
+    at (axis cs:2022.0,9.0e11) {Chinchilla};
+
+\node[anchor=west, text=BlueLine, font=\usefont{T1}{phv}{m}{n}\footnotesize]
+    at (axis cs:2023.1,2.0e12) {Llama 2};
+
+\node[anchor=west, text=BlueLine, font=\usefont{T1}{phv}{m}{n}\footnotesize]
+    at (axis cs:2024.15,1.5e13) {Llama 3};
+
+% --- red curved arrow and label ---
+\node[
+    anchor=west,
+    text=myred,
+    font=\usefont{T1}{phv}{m}{n}\footnotesize
+](PD) at (axis cs:2015.4,1.2e12)
+{Public Data Exhaustion};
+\coordinate(PO)at(axis cs:2023.45,1.05e13);
+\end{axis}
+\draw[myred,line width=0.75pt, <-,>=latex]
+(PO)
+to[bend right=15]
+(PD);
+\end{tikzpicture}
+```
 :::
 
 The gap between what compute can process and what quality data exists continues to widen. Maintaining model relevance requires the *Continuous Training* loops of MLOps (@sec-ml-operations), and intelligent data selection becomes increasingly critical as a result.
@@ -916,7 +1043,7 @@ class IcrCoresetComparison:
 
 - Dataset: ImageNet (`{python} IcrCoresetComparison.imagenet_size_str` images)
 - Model: ResNet-50 Lighthouse (~`{python} IcrCoresetComparison.resnet50_fwd_gflops_str` GFLOPs per forward pass, ~`{python} IcrCoresetComparison.resnet50_fwdbwd_gflops_str` GFLOPs forward + backward)
-- One epoch: `{python} IcrCoresetComparison.imagenet_size_str`$\times$ `{python} IcrCoresetComparison.resnet50_fwdbwd_gflops_str` GFLOPs = **`{python} IcrCoresetComparison.full_epoch_flops_str` FLOPs**
+- One epoch: `{python} IcrCoresetComparison.imagenet_size_str` $\times$ `{python} IcrCoresetComparison.resnet50_fwdbwd_gflops_str` GFLOPs = **`{python} IcrCoresetComparison.full_epoch_flops_str` FLOPs**
 - Accuracy improvement per epoch (early training): ~`{python} IcrCoresetComparison.acc_gain_random_str` percent points
 
 **Random Selection (baseline)**:
@@ -930,10 +1057,10 @@ class IcrCoresetComparison:
 - Process `{python} IcrCoresetComparison.coreset_size_str` high-uncertainty samples selected by EL2N scoring
 - Coreset focuses on decision boundary samples
 - Accuracy gain: `{python} IcrCoresetComparison.acc_gain_coreset_str` percentage points (90 percent of full data performance)
-- Compute: `{python} IcrCoresetComparison.coreset_size_str`$\times$ `{python} IcrCoresetComparison.resnet50_fwdbwd_gflops_str` GFLOPs = **`{python} IcrCoresetComparison.coreset_flops_str` FLOPs**
+- Compute: `{python} IcrCoresetComparison.coreset_size_str` $\times$ `{python} IcrCoresetComparison.resnet50_fwdbwd_gflops_str` GFLOPs = **`{python} IcrCoresetComparison.coreset_flops_str` FLOPs**
 - ICR_coreset = `{python} IcrCoresetComparison.acc_gain_coreset_str` / (`{python} IcrCoresetComparison.coreset_flops_str`) = **`{python} IcrCoresetComparison.icr_coreset_str` per FLOP**
 
-**System Implication:** The coreset achieves **`{python} IcrCoresetComparison.icr_ratio_str`$\times$ higher ICR**, nearly twice the learning per FLOP, by eliminating low-information "easy" samples that contribute little to the decision boundary. The `{python} IcrCoresetComparison.acc_diff_str` percentage point accuracy difference is often acceptable given the `{python} IcrCoresetComparison.coreset_pct_str` percent compute savings.
+**System Implication:** The coreset achieves **`{python} IcrCoresetComparison.icr_ratio_str` $\times$ higher ICR**, nearly twice the learning per FLOP, by eliminating low-information "easy" samples that contribute little to the decision boundary. The `{python} IcrCoresetComparison.acc_diff_str` percentage point accuracy difference is often acceptable given the `{python} IcrCoresetComparison.coreset_pct_str` percent compute savings.
 
 :::
 
@@ -1021,13 +1148,13 @@ class QualityMultiplier:
 **The Multiplier**:
 To reach a target error $\epsilon$:
 
-*   $N_{clean} \propto 1/\epsilon$
-*   $N_{noisy} \propto 1/\epsilon^2$
+*   $N_{\text{clean}} \propto 1/\epsilon$
+*   $N_{\text{noisy}} \propto 1/\epsilon^2$
 
 **Example**: For target error $\epsilon$ = `{python} QualityMultiplier.epsilon_str` (`{python} QualityMultiplier.epsilon_pct_str` percent):
 
-*   $N_{clean}$ ≈ `{python} QualityMultiplier.n_clean_str`
-*   $N_{noisy}$ ≈ `{python} QualityMultiplier.n_noisy_str`
+*   $N_{\text{clean}}$ ≈ `{python} QualityMultiplier.n_clean_str`
+*   $N_{\text{noisy}}$ ≈ `{python} QualityMultiplier.n_noisy_str`
 *   **Ratio**: `{python} QualityMultiplier.ratio_str`$\times$ more data required if noisy.
 
 **System Implication:** Cleaning the dataset (removing label noise) is a **`{python} QualityMultiplier.ratio_str`$\times$ compute accelerator**.
@@ -1047,7 +1174,7 @@ Coreset selection\index{Static Pruning!coreset selection}[^fn-coreset-geometry] 
 The goal is to find a compact set of examples that allows a model to generalize as well as it would if trained on the full dataset. Several algorithmic families have proven effective, each with distinct computational trade-offs.
 
 \index{k-Center Algorithm!coreset selection}
-Geometry-based methods select samples that cover the data distribution without requiring any model training. The k-Center algorithm[^fn-k-center-coverage] (also known as Facility Location) selects samples that minimize the maximum distance from any point to its nearest selected center, ensuring coverage of the entire data manifold.
+Geometry-based methods select samples that cover the data distribution without requiring any model training. The $k$-Center algorithm[^fn-k-center-coverage] (also known as Facility Location) selects samples that minimize the maximum distance from any point to its nearest selected center, ensuring coverage of the entire data manifold.
 
 [^fn-k-center-coverage]: **k-Center Algorithm**: Its greedy strategy directly explains the coverage guarantee: it iteratively picks the point farthest from any existing center, forcing the selection to expand into uncovered regions of the data manifold. This geometric purity is its primary weakness; by ignoring class labels, it can undersample rare but critical examples near a decision boundary, making its provably optimal two-approximation for coverage a poor proxy for downstream model accuracy. \index{k-Center!coverage guarantee}
 
@@ -1066,15 +1193,15 @@ Crucially, these scores transfer across architectures: scores computed on a smal
 
 Gradient-based approaches generally outperform geometry-based methods in selection quality but incur the overhead of proxy model training. The quality advantage justifies the proxy training overhead for most production workloads, as @tbl-coreset-comparison quantifies:
 
-| **Method**     | **Compute Cost**    | **Requires Training** | **Best For**          | **Limitation**            |
-|:---------------|:--------------------|:----------------------|:----------------------|:--------------------------|
-| **k-Center**   | O(N²) or O(NK)      | No                    | Coverage, exploration | Ignores label information |
-| **Herding**    | O(NK)               | No                    | Distribution matching | Assumes Gaussian-like     |
-| **GraNd**      | O(epochs$\times$ N) | Yes (few epochs)      | Decision boundaries   | Requires proxy training   |
-| **Forgetting** | O(full training)    | Yes (full)            | Hard examples         | Expensive to compute      |
-| **EL2N**       | O(epochs$\times$ N) | Yes (few epochs)      | Uncertainty sampling  | Best with proxy model     |
+| **Method**     | **Compute Cost**          | **Requires Training** | **Best For**          | **Limitation**            |
+|:---------------|:--------------------------|:----------------------|:----------------------|:--------------------------|
+| **k-Center**   | $O(N^2)$ or $O(NK)$       | No                    | Coverage, exploration | Ignores label information |
+| **Herding**    | $O(NK)$                   | No                    | Distribution matching | Assumes Gaussian-like     |
+| **GraNd**      | $O$ (epochs $\times$ $N$) | Yes (few epochs)      | Decision boundaries   | Requires proxy training   |
+| **Forgetting** | $O$ (full training)       | Yes (full)            | Hard examples         | Expensive to compute      |
+| **EL2N**       | $O$ (epochs $\times N$)   | Yes (few epochs)      | Uncertainty sampling  | Best with proxy model     |
 
-: **Coreset Selection Algorithm Comparison.** N = dataset size, K = coreset size. The fundamental trade-off is selection quality vs. computational cost: gradient-based methods (GraNd, EL2N, Forgetting) outperform geometry-based methods (k-Center, Herding) because they use training dynamics to identify decision-boundary samples, but this advantage requires proxy model training as an upfront investment. {#tbl-coreset-comparison .striped .hover}
+: **Coreset Selection Algorithm Comparison.** $N =$ dataset size, $K =$ coreset size. The fundamental trade-off is selection quality vs. computational cost: gradient-based methods (GraNd, EL2N, Forgetting) outperform geometry-based methods ($k$-Center, Herding) because they use training dynamics to identify decision-boundary samples, but this advantage requires proxy model training as an upfront investment. {#tbl-coreset-comparison .striped .hover}
 
 Each algorithm in @tbl-coreset-comparison represents a different answer to the ICR framework's central question: where in the compute-vs.-information trade-off should the selection budget be spent to maximize learning signal per FLOP?
 
@@ -1336,6 +1463,8 @@ where $t$ is the current epoch and $T_{\text{warmup}}$ is the epoch at which the
 
 The difficulty scorer can be designed in several ways, each with different computational requirements and applicability (@tbl-difficulty-scoring).
 
+From a systems perspective, curriculum learning improves convergence by reducing wasted gradient updates on samples the model cannot yet learn from. The Information-Compute Ratio is higher in early training because easy samples provide strong learning signal relative to their compute cost. The efficiency gains manifest as faster convergence to target accuracy, not higher final accuracy. @tbl-curriculum-benchmarks summarizes measured speedups from curriculum learning across standard benchmarks.
+
 | **Strategy**          | **Difficulty Score**                      | **Best For**                                |
 |:----------------------|:------------------------------------------|:--------------------------------------------|
 | **Loss-Based**        | Loss from probe model (low = easy)        | General-purpose; requires probe training    |
@@ -1344,8 +1473,6 @@ The difficulty scorer can be designed in several ways, each with different compu
 | **Self-Paced**        | Current model's loss (updated each epoch) | Adaptive; no probe needed                   |
 
 : **Difficulty Scoring Strategies for Curriculum Learning.** Loss-based and confidence-based methods require additional model inference; domain heuristics are free but require expertise; self-paced methods adapt dynamically during training. {#tbl-difficulty-scoring .striped .hover}
-
-From a systems perspective, curriculum learning improves convergence by reducing wasted gradient updates on samples the model cannot yet learn from. The Information-Compute Ratio is higher in early training because easy samples provide strong learning signal relative to their compute cost. The efficiency gains manifest as faster convergence to target accuracy, not higher final accuracy. @tbl-curriculum-benchmarks summarizes measured speedups from curriculum learning across standard benchmarks:
 
 ```{python}
 #| label: curriculum-benchmarks-calc
@@ -1402,7 +1529,7 @@ class CurriculumBenchmarks:
 Observe the varying convergence gains in @tbl-curriculum-benchmarks:
 
 | **Dataset**   | **Model** | **Pacing Strategy** |                                                                                                          **Epochs to Target Acc.** |                                                       **Speedup** |
-|:--------------|----------:|:--------------------|-----------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------------------------:|
+|:--------------|:---------:|:--------------------|:-----------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------:|
 | **CIFAR-10**  | ResNet-18 | Linear warmup       |     `{python} CurriculumBenchmarks.cifar10_curriculum_epochs` vs. `{python} CurriculumBenchmarks.cifar10_baseline_epochs` baseline |   **`{python} CurriculumBenchmarks.cifar10_speedup_str`%** faster |
 | **CIFAR-100** | ResNet-32 | Self-paced          |   `{python} CurriculumBenchmarks.cifar100_curriculum_epochs` vs. `{python} CurriculumBenchmarks.cifar100_baseline_epochs` baseline |  **`{python} CurriculumBenchmarks.cifar100_speedup_str`%** faster |
 | **ImageNet**  | ResNet-50 | Loss-based          |   `{python} CurriculumBenchmarks.imagenet_curriculum_epochs` vs. `{python} CurriculumBenchmarks.imagenet_baseline_epochs` baseline |  **`{python} CurriculumBenchmarks.imagenet_speedup_str`%** faster |
@@ -1422,9 +1549,17 @@ Curriculum learning optimizes the order in which samples are presented but assum
 
 Unlike static pruning, which discards samples permanently, active learning maintains an unlabeled pool and queries it strategically over time. Follow the cycle in @fig-active-learning-loop: the model's current uncertainty determines what gets labeled next, creating a feedback loop where each labeling round improves the model's ability to identify what it still needs to learn.
 
+\index{Uncertainty Sampling!active learning query strategy}
+\index{Query-by-Committee!active learning strategy}
+The effectiveness of active learning depends critically on the query strategy used to select samples for annotation. The simplest approach, uncertainty sampling, selects samples where the model is least confident, such as predictions near 0.5 probability for binary classification. This strategy is computationally cheap and effective in practice. Query-by-committee extends this idea by training multiple models and selecting samples where they disagree most, capturing epistemic uncertainty that a single model might miss.
+
+For practitioners willing to invest more compute, expected model change selects samples that would cause the largest gradient update if labeled. This approach provides a theoretically grounded but expensive alternative. Diversity sampling complements uncertainty-based methods by selecting samples dissimilar from currently labeled data, ensuring the labeled set covers the full input space rather than clustering around ambiguous regions.
+
+Active learning is particularly valuable in domains where labeling requires expertise. In medical imaging, for instance, an AI system diagnosing diseases from X-rays may be confident on common conditions but uncertain about rarer cases. By focusing human annotation on these ambiguous cases, active learning optimizes the use of expensive expert time while accelerating model improvement.
+
 ::: {#fig-active-learning-loop fig-cap="**Active Learning Loop**: Instead of labeling all data, the model selects the most 'confusing' or informative samples from an unlabeled pool. These samples are sent to an Oracle (human annotator) and added to the training set. The model is retrained, and the cycle repeats, creating a feedback loop that maximizes information gain per label." fig-alt="A cycle diagram: Unlabeled Pool -> Selection Strategy -> Oracle -> Labeled Set -> Model Training -> back to Selection Strategy."}
 ```{.tikz}
-\begin{tikzpicture}[font=\small\usefont{T1}{phv}{m}{n}]
+\scalebox{0.8}{\begin{tikzpicture}[font=\small\usefont{T1}{phv}{m}{n}]
 \tikzset{
 Box2/.style={align=flush center, inner sep=2pt,draw=none,fill=black!70,
 font=\fontsize{8pt}{8}\usefont{T1}{phv}{b}{n},text=white,minimum width=20mm, minimum height=5mm },
@@ -1675,18 +1810,9 @@ scale=1.3, every node/.append style={transform shape}]
 \draw[LineA](B3)--node[right,font=\footnotesize\usefont{T1}{phv}{m}{n},text=black!70]{Labels}(B4);
 \draw[LineA](B4)--node[above,font=\footnotesize\usefont{T1}{phv}{m}{n},text=black!70]{Train}(B5);
 \draw[LineD](B5)--node[left,font=\footnotesize\usefont{T1}{phv}{m}{n},text=black!70]{Update}(B1);
-\end{tikzpicture}
+\end{tikzpicture}}
 ```
-
 :::
-
-\index{Uncertainty Sampling!active learning query strategy}
-\index{Query-by-Committee!active learning strategy}
-The effectiveness of active learning depends critically on the query strategy used to select samples for annotation. The simplest approach, uncertainty sampling, selects samples where the model is least confident, such as predictions near 0.5 probability for binary classification. This strategy is computationally cheap and effective in practice. Query-by-committee extends this idea by training multiple models and selecting samples where they disagree most, capturing epistemic uncertainty that a single model might miss.
-
-For practitioners willing to invest more compute, expected model change selects samples that would cause the largest gradient update if labeled. This approach provides a theoretically grounded but expensive alternative. Diversity sampling complements uncertainty-based methods by selecting samples dissimilar from currently labeled data, ensuring the labeled set covers the full input space rather than clustering around ambiguous regions.
-
-Active learning is particularly valuable in domains where labeling requires expertise. In medical imaging, for instance, an AI system diagnosing diseases from X-rays may be confident on common conditions but uncertain about rarer cases. By focusing human annotation on these ambiguous cases, active learning optimizes the use of expensive expert time while accelerating model improvement.
 
 The economic implications are substantial. In production settings, labeling costs often dwarf compute costs because a specialist's time is far more expensive than GPU hours. These query strategies drive each iteration of the active learning loop in @fig-active-learning-loop, and the *active learning ROI* can exceed 10$\times$, as the following example demonstrates.
 
@@ -1761,7 +1887,7 @@ class ActiveLearningRoi:
 **Scenario B: Active Learning**
 
 1.  **Strategy**: Use an uncertainty-based selection to pick the **`{python} ActiveLearningRoi.n_active_str`** "hardest" scans for the doctor to label.
-2.  **Cost**: `{python} ActiveLearningRoi.n_active_str`$\times$ `{python} ActiveLearningRoi.cost_per_label_str` = **\$`{python} ActiveLearningRoi.cost_active_str`**. (`{python} ActiveLearningRoi.cost_active_pct_str` percent under budget).
+2.  **Cost**: `{python} ActiveLearningRoi.n_active_str` $\times$ `{python} ActiveLearningRoi.cost_per_label_str` = **\$`{python} ActiveLearningRoi.cost_active_str`**. (`{python} ActiveLearningRoi.cost_active_pct_str` percent under budget).
 3.  **Training Speed**: With `{python} ActiveLearningRoi.speedup_str`$\times$ less data, each training epoch is **`{python} ActiveLearningRoi.speedup_str`$\times$ faster**.
 4.  **Result**: Empirical studies suggest that these `{python} ActiveLearningRoi.n_active_str` "high-information" samples often achieve higher accuracy than `{python} ActiveLearningRoi.n_random_str` random samples.
 
@@ -1794,7 +1920,7 @@ import numpy as np
 from mlsysim import viz
 
 
-fig, ax, COLORS, plt = viz.setup_plot(figsize=(10, 5))
+fig, ax, COLORS, plt = viz.setup_plot(figsize=(10, 4.5))
 # --- Plot: Active Learning vs Random Sampling ---
 
 # ┌── 2. ARRAYS ────────────────────────────────────────────────────────────────
@@ -1960,7 +2086,7 @@ class FixmatchLabelEfficiency:
 | **`{python} FixmatchLabelEfficiency.cifar10_fixmatch_250_labels_str` (0.5 percent)** | FixMatch         | `{python} FixmatchLabelEfficiency.cifar10_fixmatch_250_acc`% | **`{python} FixmatchLabelEfficiency.cifar10_fixmatch_250_eff`$\times$ more efficient** |
 | **`{python} FixmatchLabelEfficiency.cifar10_fixmatch_40_labels_str` (0.08 percent)** | FixMatch         |  `{python} FixmatchLabelEfficiency.cifar10_fixmatch_40_acc`% |      `{python} FixmatchLabelEfficiency.cifar10_fixmatch_40_eff`$\times$ more efficient |
 
-: **FixMatch Label Efficiency on CIFAR-10.** With 250 labels (0.5 percent of the dataset), FixMatch achieves within 1.2 points of full supervision, demonstrating 200$\times$ label efficiency. {#tbl-fixmatch-cifar10 .striped .hover tbl-colwidths="[23,28,16,34]"}
+: **FixMatch Label Efficiency on CIFAR-10.** With 250 labels (0.5 percent of the dataset), FixMatch achieves within 1.2 points of full supervision, demonstrating 200$\times$ label efficiency. {#tbl-fixmatch-cifar10 .striped .hover tbl-colwidths="[25,25,25,25]"}
 
 With only `{python} FixmatchLabelEfficiency.cifar10_fixmatch_250_labels_str` labeled samples (twenty-five per class), FixMatch achieves `{python} FixmatchLabelEfficiency.cifar10_fixmatch_250_acc` percent accuracy, within `{python} FixmatchLabelEfficiency.acc_loss_str` points of full supervision using `{python} FixmatchLabelEfficiency.cifar10_fixmatch_250_eff`$\times$ fewer labels. The technique works by generating pseudo-labels on weakly augmented unlabeled images (only when model confidence exceeds 0.95), then training to predict these labels on strongly augmented versions of the same images.
 
@@ -2407,7 +2533,7 @@ Selecting the right combination of techniques from these three pipeline stages r
 | **2. Dynamic Selection**    | During training  | Curriculum Learning, Active Learning, Semi-Supervised |       10–30 percent faster convergence |
 | **3. Synthetic Generation** | On-demand        | Augmentation, Generative Models, Distillation         | 2--10$\times$ effective data expansion |
 
-: **Three-Stage Data Selection Pipeline.** Each stage increases ICR by different mechanisms: pruning removes low-value samples, dynamic selection focuses compute on high-value samples, and synthesis creates new high-value samples. {#tbl-data-selection .striped .hover}
+: **Three-Stage Data Selection Pipeline.** Each stage increases ICR by different mechanisms: pruning removes low-value samples, dynamic selection focuses compute on high-value samples, and synthesis creates new high-value samples. {#tbl-data-selection .striped .hover tbl-colwidths="[23,21,28,28]"}
 
 @tbl-technique-selection provides a decision guide for selecting techniques based on the dominant constraint.
 
@@ -2543,7 +2669,7 @@ Dynamic data selection introduces a new bottleneck: *selection latency*. In stan
 
 \index{Selection Inequality!definition}
 For a selection strategy to be systems-efficient, it must satisfy the **Selection Inequality** expressed in @eq-selection-inequality:
-$$ T_{\text{selection}} + T_{train}(N_{\text{subset}}) < T_{\text{train}}(N_{\text{total}}) $$ {#eq-selection-inequality}
+$$ T_{\text{selection}} + T_{\text{train}}(N_{\text{subset}}) < T_{\text{train}}(N_{\text{total}}) $$ {#eq-selection-inequality}
 
 Here $T_{selection}$ is the time spent scoring the pool and $T_{train}$ is the compute time. If $f(x)$ requires a forward pass of a large model, the cost of selection can exceed the cost of training, producing negative ROI. A concrete scenario illustrates this trade-off.
 
@@ -2629,19 +2755,19 @@ class SelectionInequalityCalc:
 
 **Option A: Full Model Selection**
 
-- Score all 1M images with the target ResNet-50: 1M$\times$ 0.01 s = **`{python} SelectionInequalityCalc.score_a_str` seconds** (`{python} SelectionInequalityCalc.score_a_hrs_str` hours)
-- Train on 100k coreset for 100 epochs: 100k$\times$ $100 \times 0.01$ s = **`{python} SelectionInequalityCalc.train_a_str` seconds** (`{python} SelectionInequalityCalc.train_a_hrs_str` hours)
+- Score all 1M images with the target ResNet-50: 1M $\times$ 0.01 s = **`{python} SelectionInequalityCalc.score_a_str` seconds** (`{python} SelectionInequalityCalc.score_a_hrs_str` hours)
+- Train on 100k coreset for 100 epochs: 100k $\times 100 \times 0.01$ s = **`{python} SelectionInequalityCalc.train_a_str` seconds** (`{python} SelectionInequalityCalc.train_a_hrs_str` hours)
 - **Total: `{python} SelectionInequalityCalc.total_a_hrs_str` hours**
 
 **Option B: Proxy Model Selection**
 
-- Score all 1M images with a small proxy (ResNet-18): 1M$\times$ 0.002 s = **`{python} SelectionInequalityCalc.score_b_str` seconds** (`{python} SelectionInequalityCalc.score_b_hrs_str` hours)
+- Score all 1M images with a small proxy (ResNet-18): 1M $\times$ 0.002 s = **`{python} SelectionInequalityCalc.score_b_str` seconds** (`{python} SelectionInequalityCalc.score_b_hrs_str` hours)
 - Train on 100k coreset for 100 epochs: **`{python} SelectionInequalityCalc.train_a_str` seconds** (`{python} SelectionInequalityCalc.train_a_hrs_str` hours)
 - **Total: `{python} SelectionInequalityCalc.total_b_hrs_str` hours**
 
 **Baseline: No Selection**
 
-- Train on full 1M dataset for 100 epochs: 1M$\times$ $100 \times 0.01$ s = **`{python} SelectionInequalityCalc.baseline_str` seconds** (`{python} SelectionInequalityCalc.baseline_hrs_str` hours)
+- Train on full 1M dataset for 100 epochs: 1M $\times 100 \times 0.01$ s = **`{python} SelectionInequalityCalc.baseline_str` seconds** (`{python} SelectionInequalityCalc.baseline_hrs_str` hours)
 
 **Analysis**:
 
@@ -2720,13 +2846,13 @@ class SelectionInequalityMath:
 
 **The Math**:
 
-1.  **Full Training**: `{python} SelectionInequalityMath.n_epochs_full_str` epochs. Total cost = `{python} SelectionInequalityMath.n_epochs_full_str`$\times$ C_epoch.
-2.  **Selection (Full Model)**: Scoring the full dataset is equivalent to **`{python} SelectionInequalityMath.cost_selection_full_str` epoch** of training. T_selection = `{python} SelectionInequalityMath.cost_selection_full_str`$\times$ C_epoch.
-3.  **Subset Training**: `{python} SelectionInequalityMath.n_epochs_full_str` epochs on `{python} SelectionInequalityMath.subset_fraction_pct_str` percent data = `{python} SelectionInequalityMath.n_epochs_full_str`$\times$ `{python} SelectionInequalityMath.subset_fraction_str`$\times$ C_epoch = `{python} SelectionInequalityMath.n_epochs_subset_str`$\times$ C_epoch.
-4.  **Total Time**: `{python} SelectionInequalityMath.cost_selection_full_str` + `{python} SelectionInequalityMath.n_epochs_subset_str` = **`{python} SelectionInequalityMath.cost_total_efficient_str`**$\times$ C_epoch.
+1.  **Full Training**: `{python} SelectionInequalityMath.n_epochs_full_str` epochs. Total cost = `{python} SelectionInequalityMath.n_epochs_full_str` $\times$ C_epoch.
+2.  **Selection (Full Model)**: Scoring the full dataset is equivalent to **`{python} SelectionInequalityMath.cost_selection_full_str` epoch** of training. T_selection = `{python} SelectionInequalityMath.cost_selection_full_str` $\times$ C_epoch.
+3.  **Subset Training**: `{python} SelectionInequalityMath.n_epochs_full_str` epochs on `{python} SelectionInequalityMath.subset_fraction_pct_str` percent data = `{python} SelectionInequalityMath.n_epochs_full_str` $\times$ `{python} SelectionInequalityMath.subset_fraction_str` $\times$ C_epoch = `{python} SelectionInequalityMath.n_epochs_subset_str` $\times$ C_epoch.
+4.  **Total Time**: `{python} SelectionInequalityMath.cost_selection_full_str` + `{python} SelectionInequalityMath.n_epochs_subset_str` = **`{python} SelectionInequalityMath.cost_total_efficient_str`** $\times$ C_epoch.
 5.  **Speedup**: `{python} SelectionInequalityMath.n_epochs_full_str` / `{python} SelectionInequalityMath.cost_total_efficient_str` ≈ **`{python} SelectionInequalityMath.speedup_efficient_str`$\times$**.
 
-**The Trap**: If the selection algorithm is iterative (for example, repeating selection every epoch), T_selection becomes `{python} SelectionInequalityMath.n_epochs_full_str`$\times$ 1 = `{python} SelectionInequalityMath.cost_selection_iterative_str`$\times$ C_epoch. Total time = `{python} SelectionInequalityMath.cost_selection_iterative_str` + `{python} SelectionInequalityMath.n_epochs_subset_str` = `{python} SelectionInequalityMath.cost_total_iterative_str`$\times$ C_epoch. The system is now **slower** than the baseline.
+**The Trap**: If the selection algorithm is iterative (for example, repeating selection every epoch), T_selection becomes `{python} SelectionInequalityMath.n_epochs_full_str` $\times$ 1 = `{python} SelectionInequalityMath.cost_selection_iterative_str` $\times$ C_epoch. Total time = `{python} SelectionInequalityMath.cost_selection_iterative_str` + `{python} SelectionInequalityMath.n_epochs_subset_str` = `{python} SelectionInequalityMath.cost_total_iterative_str` $\times$ C_epoch. The system is now **slower** than the baseline.
 
 **System Implication:** If the cost of selecting data exceeds the cost of training on the discarded data, the optimization has failed. The goal is to spend compute to save *more* compute. As discussed in the coreset selection section, proxy models solve this problem by reducing T_selection by an order of magnitude.
 
@@ -2824,13 +2950,13 @@ Data selection is not free. It introduces a new term to the iron law.
 The selection inequality addresses compute overhead, but data selection introduces a second, often overlooked cost: I/O pattern degradation. Data selection strategies like coresets or dynamic sampling often require **random access** to samples across the dataset, jumping to sample 47,231, then 892,104, then 3,417 based on selection scores. Standard training uses sequential reads that benefit from hardware readahead and OS page caching; random access patterns devastate throughput, especially on distributed filesystems or traditional hard drives. @tbl-io-performance quantifies this penalty across storage tiers.
 
 | **Storage Tier** | **Sequential Throughput** | **Random I/O (IOPS)** | **Random Throughput (approx)** | **Random Penalty** |
-|:-----------------|--------------------------:|----------------------:|-------------------------------:|-------------------:|
+|:-----------------|:-------------------------:|:---------------------:|:------------------------------:|:------------------:|
 | **HDD (7.2k)**   |                 ~150 MB/s |                   ~80 |                      ~0.3 MB/s |    **500$\times$** |
 | **SATA SSD**     |                 ~550 MB/s |                  ~10k |                       ~40 MB/s |     **14$\times$** |
 | **NVMe SSD**     |               ~3,500 MB/s |                 ~500k |                    ~2,000 MB/s |   **1.75$\times$** |
 | **Cloud (S3)**   |      ~100 MB/s (per conn) |       ~10–50 ms (lat) |            Very Low (per conn) |        **Extreme** |
 
-: **The Cost of Randomness.** Comparative I/O throughput for sequential vs. random 4 KB reads across different storage tiers. Standard data loaders optimize for sequential throughput, while data selection strategies often incur the random access penalty. {#tbl-io-performance .striped .hover}
+: **The Cost of Randomness.** Comparative I/O throughput for sequential vs. random 4 KB reads across different storage tiers. Standard data loaders optimize for sequential throughput, while data selection strategies often incur the random access penalty. {#tbl-io-performance .striped .hover tbl-colwidths="[20,20,20,20,20]"}
 
 \index{Vector Index!embedding-based selection}
 High-efficiency systems mitigate this penalty through several techniques. Small proxy models (a 10M parameter "student" scoring on behalf of a 7B "teacher") reduce selection cost by an order of magnitude while preserving ranking quality. Embedding indices (for example, FAISS[^fn-faiss-selection]) transform selection from $O(N)$ linear scans into $O(\log N)$ lookups. Both approaches share a common principle: decoupling selection from training enables independent optimization.
@@ -2853,7 +2979,6 @@ Data echoing[^fn-data-echoing-pipeline] [@choi2020dataechoing] offers an elegant
 Data echoing fills this gap by "echoing" (repeating) each batch $e$ times, applying different augmentations to each repetition so that the model still sees varied inputs.
 
 The optimal echo factor depends on the ratio $R$ of upstream processing time to downstream training time:
-
 $$
 R = \frac{T_{\text{data pipeline}}}{T_{\text{GPU training}}}
 $$
@@ -2941,7 +3066,7 @@ class DataEchoingRoi:
 - Unique images per second: `{python} DataEchoingRoi.pipeline_throughput_str` (unchanged)
 - Training time: $90 \times 1.28$M / `{python} DataEchoingRoi.effective_throughput_str` = **`{python} DataEchoingRoi.echo_sec_str` seconds (`{python} DataEchoingRoi.echo_hrs_str` hours)** if echoed data is equally valuable
 
-**Echoed data has diminishing returns**: Research shows echoed samples provide approximately 70–90 percent of the value of fresh samples, depending on augmentation diversity. Empirically, Choi et al. measured a **3.25$\times$ speedup** on ResNet-50 ImageNet training when reading data over a network, with minimal accuracy degradation.
+**Echoed data has diminishing returns**: Research shows echoed samples provide approximately 70–90 percent of the value of fresh samples, depending on augmentation diversity. Empirically, Choi et al. measured a **3.25 $\times$ speedup** on ResNet-50 ImageNet training when reading data over a network, with minimal accuracy degradation.
 
 **System Implication:** Data echoing trades sample diversity for GPU utilization. It works best when:
 
@@ -2968,20 +3093,19 @@ The systems framing of data selection demands quantitative answers. Practitioner
 
 \index{Total Cost of Data!formula}
 Answering these questions requires understanding what training data actually costs. Total expense encompasses the full lifecycle of data acquisition, preparation, and utilization, extending well beyond storage fees. @tbl-cost-components breaks down the four cost components:
-
 $$
 C_{\text{total}} = C_{\text{acquire}} + C_{\text{label}} + C_{\text{store}} + C_{\text{process}}
 $$
 where:
 
 | **Component**            | **Formula**                                           |                             **Typical Range** |
-|:-------------------------|:------------------------------------------------------|----------------------------------------------:|
+|:------------------------:|:-----------------------------------------------------:|:----------------------------------------------|
 | **$C_{\text{acquire}}$** | $N \times c_{\text{sample}}$                          | \$0.001–\$10/sample (web scrape vs. licensed) |
 | **$C_{\text{label}}$**   | $N_{\text{labeled}} \times c_{\text{label}}$          |        \$0.10–\$100/sample (crowd vs. expert) |
 | **$C_{\text{store}}$**   | $S_{\text{bytes}} \times c_{\text{storage}} \times T$ |                        \$0.02–\$0.10/GB/month |
 | **$C_{\text{process}}$** | $N \times E \times c_{\text{FLOP}}$                   |                Proportional to training FLOPs |
 
-: **Total Cost of Training Data.** The four cost components span the full data lifecycle. Labeling costs ($C_{\text{label}}$) vary by three orders of magnitude depending on whether crowd workers or domain experts are required, making this the component most amenable to optimization through data selection. {#tbl-cost-components .striped .hover}
+: **Total Cost of Training Data.** The four cost components span the full data lifecycle. Labeling costs ($C_{\text{label}}$) vary by three orders of magnitude depending on whether crowd workers or domain experts are required, making this the component most amenable to optimization through data selection. {#tbl-cost-components .striped .hover tbl-colwidths="[20,20,60]"}
 
 For a concrete example, consider training a vision model:
 
@@ -3044,14 +3168,18 @@ class CostBreakdown:
 
 ::: {.callout-example title="Cost Breakdown: ImageNet-Scale Training"}
 
-| **Cost Component**                                                                                            | **Calculation**  | **Amount**                                                                                   |
-|:--------------------------------------------------------------------------------------------------------------|:-----------------|:---------------------------------------------------------------------------------------------|
-| **Raw data (`{python} CostBreakdown.n_labels_str` images)**                                                   | Licensed dataset | `{python} CostBreakdown.c_raw_str`                                                           |
-| **Labels (`{python} CostBreakdown.n_labels_str`$\times$ USD `{python} CostBreakdown.cb_cost_per_label_str`)** | Crowd annotation | `{python} CostBreakdown.c_label_str`                                                         |
-| **Storage (`{python} CostBreakdown.storage_str`)**                                                            | Cloud storage    | `{python} CostBreakdown.c_store_str`                                                         |
-| **Training (`{python} CostBreakdown.train_desc_str`)**                                                        | GPU compute      | `{python} CostBreakdown.c_train_str`                                                         |
-| **Total**                                                                                                     |                  | **`{python} CostBreakdown.c_total_str`**                                                     |
-| **Data vs. Compute ratio**                                                                                    |                  | **`{python} CostBreakdown.p_data_str` data, `{python} CostBreakdown.p_compute_str` compute** |
+::: {tbl-colwidths="[40,20,30]"}
+
+| **Cost Component**                                                                                             | **Calculation**  | **Amount**                                                                                   |
+|:---------------------------------------------------------------------------------------------------------------|:-----------------|:--------------------------------------------------------------------------------------------:|
+| **Raw data (`{python} CostBreakdown.n_labels_str` images)**                                                    | Licensed dataset | `{python} CostBreakdown.c_raw_str`                                                           |
+| **Labels (`{python} CostBreakdown.n_labels_str` $\times$ USD `{python} CostBreakdown.cb_cost_per_label_str`)** | Crowd annotation | `{python} CostBreakdown.c_label_str`                                                         |
+| **Storage (`{python} CostBreakdown.storage_str`)**                                                             | Cloud storage    | `{python} CostBreakdown.c_store_str`                                                         |
+| **Training (`{python} CostBreakdown.train_desc_str`)**                                                         | GPU compute      | `{python} CostBreakdown.c_train_str`                                                         |
+| **Total**                                                                                                      |                  | **`{python} CostBreakdown.c_total_str`**                                                     |
+| **Data vs. Compute ratio**                                                                                     |                  | **`{python} CostBreakdown.p_data_str` data, `{python} CostBreakdown.p_compute_str` compute** |
+
+:::
 
 The ratio, where data costs dominate, is typical for supervised learning. It inverts for self-supervised learning on web-scraped data, where compute dominates.
 
@@ -3074,7 +3202,7 @@ The challenge lies in quantifying both sides accurately. Different techniques of
 | **Active Learning**   | Inference on unlabeled pool + human-in-the-loop latency | 2--10$\times$ reduction in labeling budget for same acc.     |
 | **Data Augmentation** | CPU/GPU cycles for transforms                           | Effective dataset size increase without new data acquisition |
 
-: **ROI Profiles for Data Selection Techniques.** Each technique occupies a different point in the investment-vs.-savings space. Deduplication offers the lowest-risk entry point (minimal investment, guaranteed returns), while active learning offers the highest potential savings but requires the most infrastructure. {#tbl-roi-profiles .striped .hover}
+: **ROI Profiles for Data Selection Techniques.** Each technique occupies a different point in the investment-vs.-savings space. Deduplication offers the lowest-risk entry point (minimal investment, guaranteed returns), while active learning offers the highest potential savings but requires the most infrastructure. {#tbl-roi-profiles .striped .hover tbl-colwidths="[18,41,43]"}
 
 ### Break-even analysis {#sec-data-selection-breakeven-analysis-9a38}
 
@@ -3149,18 +3277,17 @@ Suppose labeling costs \$`{python} BreakevenCalc.cost_label_str`/sample and acti
 
 If active learning reaches target accuracy with only `{python} BreakevenCalc.be_n_active_str` labeled samples:
 
-**Random labeling cost** = `{python} BreakevenCalc.be_n_random_str`$\times$ \$`{python} BreakevenCalc.cost_label_str` = **\$`{python} BreakevenCalc.cost_random_total_str`**
+**Random labeling cost** = `{python} BreakevenCalc.be_n_random_str` $\times$ \$`{python} BreakevenCalc.cost_label_str` = **\$`{python} BreakevenCalc.cost_random_total_str`**
 
-**Active learning cost** = `{python} BreakevenCalc.be_n_active_str`$\times$ \$`{python} BreakevenCalc.cost_label_str` + `{python} BreakevenCalc.n_rounds_str` rounds$\times$ \$`{python} BreakevenCalc.cost_inference_str` = **\$`{python} BreakevenCalc.cost_active_total_str`**
+**Active learning cost** = `{python} BreakevenCalc.be_n_active_str` $\times$ \$`{python} BreakevenCalc.cost_label_str` + `{python} BreakevenCalc.n_rounds_str` rounds $\times$ \$`{python} BreakevenCalc.cost_inference_str` = **\$`{python} BreakevenCalc.cost_active_total_str`**
 
-**ROI** = (\$`{python} BreakevenCalc.cost_random_total_str` − \$`{python} BreakevenCalc.cost_active_total_str`) / \$`{python} BreakevenCalc.cost_active_total_str`$\times$ 100 percent = **`{python} BreakevenCalc.roi_pct_str` percent**
+**ROI** = (\$`{python} BreakevenCalc.cost_random_total_str` − \$`{python} BreakevenCalc.cost_active_total_str`) / \$`{python} BreakevenCalc.cost_active_total_str` $\times$ 100 percent = **`{python} BreakevenCalc.roi_pct_str` percent**
 
 The break-even occurs when the labeling reduction equals the selection overhead. If active learning only reduces labeling by 20 percent, and selection overhead is high, ROI may be negative.
 
 ### Amortization across training runs {#sec-data-selection-amortization-across-training-runs-f6b8}
 
 Break-even analysis captures a snapshot in time, but many data selection investments span multiple projects. Techniques with high upfront costs yield significant returns when their benefits compound across repeated training runs. **Amortized ROI** accounts for this temporal dimension, as @tbl-dedup-costs and @tbl-amortized-roi illustrate for a deduplication pipeline:
-
 $$
 \text{Amortized ROI} = \frac{N_{\text{runs}} \times \text{Per-Run Savings} - \text{One-Time Investment}}{\text{One-Time Investment}}
 $$
@@ -3424,7 +3551,7 @@ fill=GreenLine,text=white] (WW2){\textbf{Worker N}};
 4. **Selection phase** (centralized): Coordinator collects top-20 percent scores from each worker, re-ranks globally, selects final ten percent
 5. **Broadcast**: Selected indices distributed to all workers for training
 
-**Performance** (measured on 8$\times$ A100 cluster):
+**Performance** (measured on 8 $\times$ A100 cluster):
 
 - Embedding: `{python} DistributedOverheadCalc.t_embed_str` (parallel)
 - Deduplication: `{python} DistributedOverheadCalc.t_dedup_str` (distributed hash join)
@@ -3922,7 +4049,7 @@ The optimal balance defines a **compute-optimal frontier**\index{Compute-optimal
 import numpy as np
 from mlsysim import viz
 
-fig, ax, COLORS, plt = viz.setup_plot(figsize=(10, 5))
+fig, ax, COLORS, plt = viz.setup_plot(figsize=(10, 4.5))
 
 # Compute-optimal frontier curve
 
@@ -4031,7 +4158,7 @@ Watch how the two curves diverge in @fig-ppd-curve: a data-efficient selection s
 import numpy as np
 from mlsysim import viz
 
-fig, ax, COLORS, plt = viz.setup_plot(figsize=(10, 5))
+fig, ax, COLORS, plt = viz.setup_plot(figsize=(10, 4.5))
 
 # --- Plot: Efficient vs Random Data Selection ---
 
@@ -4277,7 +4404,7 @@ Conceptual misunderstandings often lead to flawed strategies. Equally damaging a
 
 **Pitfall:** *Optimizing selection without measuring selection overhead.*
 
-A sophisticated coreset algorithm requiring `{python} FpScalingCalc.selection_time_bad_str` hours to select samples for a `{python} FpScalingCalc.training_time_str`-hour training run has `{python} FpScalingCalc.selection_overhead_ratio_str`$\times$ overhead, yielding negative ROI. @sec-data-selection-selection-bottleneck-4d00 establishes the Selection Inequality: $T_{selection} + T_{train}(subset) < T_{train}(full)$. If full training takes `{python} FpScalingCalc.full_training_time_str` hours, selection must remain under ten percent of that time. Use lightweight proxy models (ResNet-18 for five epochs instead of ResNet-50 for 100) or cached embeddings: proxy-based EL2N scoring completes in `{python} FpScalingCalc.selection_time_good_str` minutes (`{python} FpScalingCalc.selection_overhead_good_pct_str` percent overhead), satisfying the inequality while achieving comparable selection quality.
+A sophisticated coreset algorithm requiring `{python} FpScalingCalc.selection_time_bad_str` hours to select samples for a `{python} FpScalingCalc.training_time_str`-hour training run has `{python} FpScalingCalc.selection_overhead_ratio_str`$\times$ overhead, yielding negative ROI. @sec-data-selection-selection-bottleneck-4d00 establishes the Selection Inequality: $T_{\text{selection}} + T_{\text{train}}(\text{subset}) < T_{\text{train}}(\text{full})$. If full training takes `{python} FpScalingCalc.full_training_time_str` hours, selection must remain under ten percent of that time. Use lightweight proxy models (ResNet-18 for five epochs instead of ResNet-50 for 100) or cached embeddings: proxy-based EL2N scoring completes in `{python} FpScalingCalc.selection_time_good_str` minutes (`{python} FpScalingCalc.selection_overhead_good_pct_str` percent overhead), satisfying the inequality while achieving comparable selection quality.
 
 **Pitfall:** *Pruning rare classes into oblivion.*
 

--- a/book/quarto/tex/header-includes.tex
+++ b/book/quarto/tex/header-includes.tex
@@ -1062,6 +1062,56 @@ align=right,font={\fontsize{40pt}{40}\selectfont}]
 }
 
 % =============================================================================
+% LONGTABLE COUNTER FIX FOR UNCAPTIONED TABLES
+% =============================================================================
+% Pandoc/Quarto often renders Markdown tables as longtable.
+% Some longtable versions advance the table counter at the beginning of every
+% longtable environment, even when the table has no caption.
+%
+% We save the table counter at the beginning of each longtable.
+% If the longtable contains a \label command, we treat it as a numbered/captioned
+% table and keep the number.
+% If it has no label, we treat it as an uncaptioned table and restore the counter.
+
+\makeatletter
+
+\newif\ifmlsys@inside@longtable
+\newif\ifmlsys@longtable@numbered
+\newcounter{mlsysSavedTableCounter}
+
+\AtBeginEnvironment{longtable}{%
+  \global\mlsys@inside@longtabletrue
+  \global\mlsys@longtable@numberedfalse
+  \setcounter{mlsysSavedTableCounter}{\value{table}}%
+}
+
+\AfterEndEnvironment{longtable}{%
+  \ifmlsys@longtable@numbered
+    % Captioned/numbered table: keep the number.
+  \else
+    % Uncaptioned table: restore the previous table counter.
+    \setcounter{table}{\value{mlsysSavedTableCounter}}%
+  \fi
+  \global\mlsys@inside@longtablefalse
+}
+
+% Save original \label only once
+\@ifundefined{mlsys@orig@label}{%
+  \let\mlsys@orig@label\label
+}{}
+
+% Detect labels inside longtable.
+% In Quarto/Pandoc output, captioned tables normally have \label{tbl-...}.
+\renewcommand{\label}[1]{%
+  \ifmlsys@inside@longtable
+    \global\mlsys@longtable@numberedtrue
+  \fi
+  \mlsys@orig@label{#1}%
+}
+
+\makeatother
+
+% =============================================================================
 % TABLE STYLING - Clean tables with crimson borders
 % =============================================================================
 % Professional table appearance with:


### PR DESCRIPTION
Tables were reformatted to adjust column widths to ensure the text is neatly aligned and well arranged. 

Refined the chapter layout to ensure pages are well structured and free of unnecessary blank space.

A new TikZ figure has been redrawn (fig. 9.1).

Fix table numbering for uncaptioned longtables: Added a stable fix in `header-includes.tex` for table numbering when Quarto/Pandoc generates Markdown tables as `longtable`, because some uncaptioned `longtable` tables were advancing the table counter, which created gaps in numbering. 
