### PR TITLE
fix(dev): rewrite shared navbar URLs by page depth in dev preview

### DIFF
--- a/.github/scripts/rewrite-dev-urls.sh
+++ b/.github/scripts/rewrite-dev-urls.sh
@@ -38,16 +38,11 @@ declare -A SUBSITES=(
 )
 
 # ── Compute prefix ────────────────────────────────────────────────────────────
-# PREFIX is the number of "../" hops needed to climb from the *current build
-# location* on dev back to the dev site root. It depends on how deep the
-# subsite lives on dev. With every subsite at top level, depth is 1 and
-# PREFIX is "../". The depth computation below stays generic so a future
-# nested subsite (depth > 1) would still resolve correctly.
-#
-# SELF_PREFIX is "./" — a self-link rewrites to the current dir.
-SELF_PREFIX="./"
+# We still compute from the subsite path, but the actual "../" prefix now has
+# to be derived per rendered HTML file, not once per subsite. That lets nested
+# pages like kits/contents/... rewrite navbar URLs correctly.
 if [[ "$SUBSITE" == "root" ]]; then
-  PREFIX=""
+  SUBSITE_DEPTH=0
 else
   # Note: under `set -u`, indexing an associative array with a missing key
   # triggers an unbound-variable error in some bash builds. Probe with the
@@ -62,13 +57,20 @@ else
   fi
   SELF_DEV_PATH="${SUBSITES[$SUBSITE]}"
   # Depth = number of path segments in the dev-side path (book/vol1 → 2).
-  DEPTH=$(awk -F/ '{print NF}' <<< "$SELF_DEV_PATH")
-  PREFIX=""
-  for ((i = 0; i < DEPTH; i++)); do PREFIX+="../"; done
+  SUBSITE_DEPTH=$(awk -F/ '{print NF}' <<< "$SELF_DEV_PATH")
 fi
 
+repeat_parent_prefix() {
+  local depth="${1:-0}"
+  local prefix=""
+  for ((i = 0; i < depth; i++)); do
+    prefix+="../"
+  done
+  printf '%s' "$prefix"
+}
+
 # ── Rewrite ───────────────────────────────────────────────────────────────────
-echo "🔗 Rewriting mlsysbook.ai URLs for dev site (subsite=$SUBSITE, prefix='$PREFIX')..."
+echo "🔗 Rewriting mlsysbook.ai URLs for dev site (subsite=$SUBSITE, subsite_depth=$SUBSITE_DEPTH)..."
 
 FIND_DEPTH=""
 if [[ "$SHALLOW" == "--shallow" ]]; then
@@ -76,23 +78,46 @@ if [[ "$SHALLOW" == "--shallow" ]]; then
 fi
 
 find "$BUILD_DIR" $FIND_DEPTH -name "*.html" -type f | while read -r f; do
+  file_dir="$(dirname "$f")"
+  rel_dir="${file_dir#$BUILD_DIR}"
+  rel_dir="${rel_dir#/}"
+
+  if [[ -z "$rel_dir" || "$rel_dir" == "." ]]; then
+    FILE_DEPTH=0
+  else
+    FILE_DEPTH=$(awk -F/ '{print NF}' <<< "$rel_dir")
+  fi
+
+  ROOT_PREFIX="$(repeat_parent_prefix $((SUBSITE_DEPTH + FILE_DEPTH)))"
+  if [[ "$FILE_DEPTH" -eq 0 ]]; then
+    SELF_PREFIX="./"
+  else
+    SELF_PREFIX="$(repeat_parent_prefix "$FILE_DEPTH")"
+  fi
+
   for key in "${!SUBSITES[@]}"; do
     dev_path="${SUBSITES[$key]}"
+
     # Self-link match is by mlsysbook.ai key, not dev_path. Previously this
     # compared dev_path to SUBSITE which silently failed for nested subsites.
     if [[ "$SUBSITE" != "root" && "$key" == "$SUBSITE" ]]; then
-      # Self-links: mlsysbook.ai/<key>/ → ./ (when building <key>)
+      # Self-links: mlsysbook.ai/<key>/ → current subsite root from this file.
       sed -i "s|https://mlsysbook.ai/${key}/|${SELF_PREFIX}|g" "$f"
     else
-      sed -i "s|https://mlsysbook.ai/${key}/|${PREFIX}${dev_path}/|g" "$f"
+      sed -i "s|https://mlsysbook.ai/${key}/|${ROOT_PREFIX}${dev_path}/|g" "$f"
     fi
   done
+
   # Catch-all: any remaining mlsysbook.ai/ base URL → dev root.
   # (Used by the navbar title-href and footer site links.)
   if [[ "$SUBSITE" == "root" ]]; then
-    sed -i 's|https://mlsysbook.ai/|./|g' "$f"
+    if [[ "$FILE_DEPTH" -eq 0 ]]; then
+      sed -i 's|https://mlsysbook.ai/|./|g' "$f"
+    else
+      sed -i "s|https://mlsysbook.ai/|${SELF_PREFIX}|g" "$f"
+    fi
   else
-    sed -i "s|https://mlsysbook.ai/|${PREFIX}|g" "$f"
+    sed -i "s|https://mlsysbook.ai/|${ROOT_PREFIX}|g" "$f"
   fi
 done
 


### PR DESCRIPTION
## Summary
- fix dev-preview navbar/footer link rewriting for nested HTML pages
- compute relative prefixes per rendered file instead of once per subsite
- keep self-links and cross-site links resolving correctly from deep pages

## Issue
The shared navbar uses absolute production URLs like `https://mlsysbook.ai/labs/` and `https://mlsysbook.ai/kits/`. In dev preview, `.github/scripts/rewrite-dev-urls.sh` rewrites those URLs for `https://harvard-edge.github.io/cs249r_book_dev/`.

The bug was that the rewrite script used one static `../` prefix per subsite. That worked for top-level pages like `kits/index.html`, but it broke on nested pages like:

- `kits/contents/arduino/nicla_vision/image_classification/image_classification.html`

From a deep page, navbar links like `Labs` were rewritten too shallowly and resolved under the current chapter path, producing broken URLs like:

- `https://harvard-edge.github.io/cs249r_book_dev/kits/contents/arduino/nicla_vision/labs/`

## Why Local Worked
Local Quarto preview serves the site in project context, so this post-build dev rewrite mismatch does not show up there.

The published dev site is different: it rewrites production URLs after render so each subsite lives under `cs249r_book_dev/`. That rewrite logic was where the bug lived.

## Fix
Update `.github/scripts/rewrite-dev-urls.sh` to compute prefixes per rendered HTML file:
- detect each file's depth relative to the build directory
- compute a root prefix back to the dev-site root
- compute a self prefix back to the current subsite root
- rewrite cross-site links with the root prefix
- rewrite self-links with the self prefix

## Test Plan
### Script verification
- create a top-level HTML file with links to `https://mlsysbook.ai/labs/`, `https://mlsysbook.ai/kits/`, and `https://mlsysbook.ai/`
- create a nested HTML file under `contents/arduino/nicla_vision/image_classification/` with the same links
- run:
  - `bash .github/scripts/rewrite-dev-urls.sh kits tmp/rewrite-verify`
- verify:
  - top-level page rewrites to `../labs/`, `./`, and `../`
  - nested page rewrites to `../../../../../labs/`, `../../../../`, and `../../../../../`

### Manual dev-preview verification
- open:
  - `https://harvard-edge.github.io/cs249r_book_dev/kits/contents/arduino/nicla_vision/image_classification/image_classification.html`
- click from the shared navbar:
  - `Build -> Labs`
  - `Build -> Hardware Kits`
  - navbar brand/home
  - another shared-nav destination like `About` or `Community`
- confirm each lands at the correct `cs249r_book_dev/<subsite>/...` path rather than under the current chapter directory

### Regression checks
- verify top-level Kits pages still navigate correctly
- verify self-links still resolve to the Kits root
- optionally spot-check another subsite using the same rewrite script
