### PR TITLE
fix(kits): improve dark mode dropdown menu contrast

### DIFF
--- a/kits/assets/styles/dark-mode.scss
+++ b/kits/assets/styles/dark-mode.scss
@@ -348,6 +348,38 @@ div[class*="margin"] {
   }
 }
 
+// Navbar dropdown menus
+.navbar .dropdown-menu,
+.dropdown-menu {
+  background-color: #2a2f36 !important;
+  border-color: $border-color-dark !important;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35) !important;
+}
+
+.navbar .dropdown-item,
+.dropdown-menu .dropdown-item {
+  color: #d7dde3 !important;
+  background-color: transparent !important;
+
+  &:hover,
+  &:focus,
+  &.active,
+  &:active {
+    color: $kits-accent-dark !important;
+    background-color: rgba($kits-accent-dark, 0.16) !important;
+  }
+}
+
+.navbar .dropdown-header,
+.dropdown-menu .dropdown-header {
+  color: #adb5bd !important;
+}
+
+.navbar .dropdown-divider,
+.dropdown-menu .dropdown-divider {
+  border-top-color: $border-color-dark !important;
+}
+
 // Dark mode toggle
 .quarto-color-scheme-toggle {
   color: #adb5bd !important;


### PR DESCRIPTION
## Summary
- fix Kits dark mode navbar dropdown background so menus no longer render on a white surface
- improve dropdown item, header, divider, and hover-state contrast for readability

## Before
- 
<img width="723" height="218" alt="Screenshot 2026-05-02 090634" src="https://github.com/user-attachments/assets/e341e0cb-0dd2-4762-a936-01734e819440" />


## After
- 
<img width="650" height="243" alt="Screenshot 2026-05-02 090626" src="https://github.com/user-attachments/assets/04f05781-4373-4f42-a68b-754f8f948d69" />


## Testing
- verified in local Kits preview in dark mode
