### PR TITLE
fix(kits): make code blocks readable in dark mode

### DIFF
--- a/kits/assets/styles/dark-mode.scss
+++ b/kits/assets/styles/dark-mode.scss
@@ -265,20 +265,68 @@ pre {
   border: 1px solid #454d55;
 }
 
-// Inline code
+// Inline code (need !important to beat the light bootstrap rule that
+// Quarto re-loads via the "-extra" stylesheet in dark mode).
 code {
-  background-color: #2c2c2c;
-  color: #1ABC9C;  // Teal for visibility
+  background-color: #2c2c2c !important;
+  color: #1ABC9C !important;  // Teal for visibility
   padding: 0.2em 0.4em;
   border-radius: 3px;
 }
 
 // Code blocks inside pre (override inline styling)
 pre code {
-  color: #e6e6e6;
-  background-color: transparent;
-  padding: 0;
+  color: #e6e6e6 !important;
+  background-color: transparent !important;
+  padding: 0 !important;
 }
+
+// Force dark background on Quarto sourceCode blocks. The "-extra" light
+// syntax stylesheet (see comment near token overrides below) sets
+// `div.sourceCode pre.sourceCode { background: #f6f8fa }` and loads last,
+// so we need matching specificity + !important to win.
+div.sourceCode,
+div.sourceCode pre.sourceCode,
+pre.sourceCode {
+  background-color: #2c2c2c !important;
+  color: #e6e6e6 !important;
+  border-color: #454d55 !important;
+}
+
+// Syntax highlighting token overrides for dark mode.
+// Quarto emits a third "quarto-color-scheme-extra" stylesheet that points
+// back to the LIGHT syntax CSS and is never disabled by the color toggle,
+// so it clobbers the dark syntax theme. Force the github-dark palette here
+// with !important so it wins regardless of load order.
+code span.al { color: #f97583 !important; font-weight: bold; }
+code span.an { color: #6a737d !important; font-style: italic; }
+code span.at { color: #79b8ff !important; }
+code span.bn { color: #79b8ff !important; }
+code span.bu { color: #b392f0 !important; }
+code span.cf { color: #f97583 !important; }
+code span.ch { color: #9ecbff !important; }
+code span.cn { color: #79b8ff !important; }
+code span.co { color: #6a737d !important; font-style: italic; }
+code span.cv { color: #6a737d !important; font-style: italic; }
+code span.do { color: #6a737d !important; font-style: italic; }
+code span.dt { color: #79b8ff !important; }
+code span.dv { color: #79b8ff !important; }
+code span.er { color: #f97583 !important; font-weight: bold; }
+code span.ex { color: #e1e4e8 !important; font-weight: bold; }
+code span.fl { color: #79b8ff !important; }
+code span.fu { color: #b392f0 !important; }
+code span.im { color: #f97583 !important; }
+code span.in { color: #6a737d !important; font-style: italic; }
+code span.kw { color: #f97583 !important; }
+code span.op { color: #e1e4e8 !important; }
+code span.ot { color: #79b8ff !important; }
+code span.pp { color: #f97583 !important; }
+code span.sc { color: #9ecbff !important; }
+code span.ss { color: #9ecbff !important; }
+code span.st { color: #9ecbff !important; }
+code span.va { color: #e1e4e8 !important; }
+code span.vs { color: #9ecbff !important; }
+code span.wa { color: #f97583 !important; font-weight: bold; }
 
 // Figures and captions
 .figure-caption,

--- a/kits/config/_quarto-html.yml
+++ b/kits/config/_quarto-html.yml
@@ -154,7 +154,9 @@ format:
     number-sections: false
     code-copy: true
     code-overflow: wrap
-    highlight-style: github
+    highlight-style:
+      light: github
+      dark: github-dark
     link-external-icon: false
     link-external-newwindow: true
     anchor-sections: true


### PR DESCRIPTION
## Summary

Code blocks (both fenced source blocks and inline `code`) were unreadable in dark mode on the kits site — the text rendered in the light syntax-theme colors (e.g. `#24292e` operators, `#032f62` strings) on an off-white `#f6f8fa` background, on a body that was otherwise dark.

**Before:**

<img width="772" height="610" alt="Screenshot 2026-05-02 095522" src="https://github.com/user-attachments/assets/4faf996c-4076-480f-9fea-5b181d956577" />

<img width="784" height="337" alt="Screenshot 2026-05-02 095600" src="https://github.com/user-attachments/assets/b59a4848-b09f-456a-a1a5-79ace7fac55e" />


**After:**

<img width="785" height="630" alt="Screenshot 2026-05-02 095733" src="https://github.com/user-attachments/assets/53c4bb97-cbe9-423c-84ca-cd82fae68059" />

<img width="780" height="344" alt="Screenshot 2026-05-02 095741" src="https://github.com/user-attachments/assets/c675c8de-0b53-434b-a4a0-034911c86721" />



### Root cause

When `format.html.theme` defines both a `light:` and a `dark:` SCSS bundle, Quarto emits **three** syntax-highlighting `<link>` tags into every page:

```html
<link class="quarto-color-scheme"                        ... syntax-highlighting.css      (light) >
<link class="quarto-color-scheme quarto-color-alternate" ... syntax-highlighting-dark.css  (dark)  >
<link class="quarto-color-scheme-extra"                  ... syntax-highlighting.css      (light) >
