### PR TITLE
fix(labs): use ESP32 SRAM capacity field in lab 02

### DIFF
--- a/labs/vol1/lab_02_ml_systems.py
+++ b/labs/vol1/lab_02_ml_systems.py
@@ -55,7 +55,7 @@ async def _():
 
     ESP32_TFLOPS  = Hardware.Tiny.ESP32_S3.compute.peak_flops.m_as("TFLOPs/s")
     ESP32_TDP     = Hardware.Tiny.ESP32_S3.tdp.m_as("W")
-    ESP32_RAM_KB  = Hardware.Tiny.ESP32_S3.memory.capacity.m_as("KiB")
+    ESP32_RAM_KB  = Hardware.Tiny.ESP32_S3.memory.sram_capacity.m_as("KiB")
 
     # ── Model constants ────────────────────────────────────────────────────
     RESNET50_PARAMS = Models.ResNet50.parameters.m_as("count")


### PR DESCRIPTION
## Summary

- `Hardware.Tiny.ESP32_S3.memory.capacity` returns 8 MB **flash storage** (7812 KiB), not SRAM
- The correct field for the 512 KiB SRAM is `memory.sram_capacity`
- Lab 02 line 58 was reading flash instead of SRAM, making `ESP32_RAM_KB = 7812` instead of `512`

Same root cause as PR #1625 (lab 01 fix).

## Change

```python
# Before (wrong -- reads 8 MB flash storage)
ESP32_RAM_KB = Hardware.Tiny.ESP32_S3.memory.capacity.m_as("KiB")

# After (correct -- reads 512 KiB SRAM)
ESP32_RAM_KB = Hardware.Tiny.ESP32_S3.memory.sram_capacity.m_as("KiB")
```

## Test plan

- [ ] Verify `Hardware.Tiny.ESP32_S3.memory.sram_capacity.m_as("KiB")` returns 512 in the mlsysim registry
- [ ] Run lab 02 in Marimo and confirm `ESP32_RAM_KB` shows 512 KiB