### PR TITLE
fix(labs): use ESP32 SRAM capacity and correct OOM badge in lab 03

### DIFF
--- a/labs/vol1/lab_03_ml_workflow.py
+++ b/labs/vol1/lab_03_ml_workflow.py
@@ -36,7 +36,7 @@ async def _():
 
     H100_TFLOPS = Hardware.Cloud.H100.compute.peak_flops.m_as("TFLOPs/s")
     H100_RAM    = Hardware.Cloud.H100.memory.capacity.m_as("GB")
-    ESP32_RAM_KB = Hardware.Tiny.ESP32_S3.memory.capacity.m_as("KiB")
+    ESP32_RAM_KB = Hardware.Tiny.ESP32_S3.memory.sram_capacity.m_as("KiB")
 
     RESNET50_PARAMS = Models.ResNet50.parameters.m_as("count")
     RESNET50_SIZE_MB = RESNET50_PARAMS * 2 / (1024 * 1024)
@@ -96,7 +96,7 @@ def _(LAB_CSS, mo):
             <div style="display: flex; gap: 10px; flex-wrap: wrap;">
                 <span class="badge badge-info">Exponential Cost Curve 2^(N-1)</span>
                 <span class="badge badge-warn">Iteration Velocity &gt; Starting Accuracy</span>
-                <span class="badge badge-fail">200x OOM Discovered at Stage 5</span>
+                <span class="badge badge-fail">~100x OOM Discovered at Stage 5</span>
             </div>
         </div>
         """),


### PR DESCRIPTION
## Summary

- `Hardware.Tiny.ESP32_S3.memory.capacity` returns 8 MB **flash storage** (7812 KiB), not SRAM
- The correct field for the 512 KiB SRAM is `memory.sram_capacity`
- Lab 03 line 39 was reading flash instead of SRAM, making `ESP32_RAM_KB = 7812` instead of `512`
- This caused the dynamic OOM ratio on line 348 (`~{size}x over`) to render as `~6x` instead of the correct `~98x`
- The hardcoded badge `200x OOM Discovered at Stage 5` is updated to `~100x OOM Discovered at Stage 5` to match

Same root cause as PR #1625 (lab 01) and PR #1626 (lab 02).

## Changes

```python
# Before (wrong -- reads 8 MB flash storage)
ESP32_RAM_KB = Hardware.Tiny.ESP32_S3.memory.capacity.m_as("KiB")

# After (correct -- reads 512 KiB SRAM)
ESP32_RAM_KB = Hardware.Tiny.ESP32_S3.memory.sram_capacity.m_as("KiB")
```

Badge: `200x OOM Discovered at Stage 5` -> `~100x OOM Discovered at Stage 5`

## Test plan

- [ ] Verify `Hardware.Tiny.ESP32_S3.memory.sram_capacity.m_as("KiB")` returns 512
- [ ] Run lab 03 and confirm the Engine.solve() block shows `~98x over`
- [ ] Confirm badge reads `~100x OOM`