### PR TITLE
fix(labs): use ESP32 SRAM capacity field in lab 07

### DIFF
--- a/labs/vol1/lab_07_ml_frameworks.py
+++ b/labs/vol1/lab_07_ml_frameworks.py
@@ -40,7 +40,7 @@ async def _():
     H100_BW_GBS = H100.memory.bandwidth.m_as("GB/s")
     H100_DISPATCH = H100.dispatch_tax.m_as("ms")
     H100_RAM_GB = H100.memory.capacity.m_as("GB")
-    ESP32_RAM_KB = ESP32.memory.capacity.m_as("KiB")
+    ESP32_RAM_KB = ESP32.memory.sram_capacity.m_as("KiB")
 
     # Framework runtime overheads (MB) -- from textbook Table 7.x
     FRAMEWORK_RUNTIMES_MB = {


### PR DESCRIPTION
## Summary

`ESP32.memory.capacity` returns 8 MB **flash storage** (7812 KiB), not SRAM. The correct field is `memory.sram_capacity` (512 KiB).

In lab 07, `ESP32_RAM_KB` is used dynamically in:
- The deployment target label: `ESP32 ({ESP32_RAM_KB:.0f} KB)` -- showed `7812 KB` instead of `512 KB`
- The MathPeek block: `ESP32 memory: {ESP32_RAM_KB:.0f} KB = {ESP32_RAM_KB/1024:.2f} MB` and `Ratio: 1800 / {ESP32_RAM_KB/1024:.2f} = {ratio:,.0f}x` -- showed `7.63 MB` and `~236x` instead of `0.50 MB` and `~3,600x`

The hardcoded explanation text throughout the lab correctly states "3,600x" and "512 KB", so the wrong variable caused a visible contradiction.

## Change

```python
# Before (wrong -- reads 8 MB flash storage)
ESP32_RAM_KB = ESP32.memory.capacity.m_as("KiB")

# After (correct -- reads 512 KiB SRAM)
ESP32_RAM_KB = ESP32.memory.sram_capacity.m_as("KiB")
```

Same root cause as PRs #1625 (lab 01), #1626 (lab 02), #1627 (lab 03).

## Test plan

- [ ] Run lab 07 Part D, confirm deployment target label shows `ESP32 (512 KB)`
- [ ] Confirm MathPeek shows `0.50 MB` and `~3,600x`