### PR TITLE
fix(labs): correct error cascade amplification factor in lab 04

### DIFF
--- a/labs/vol1/lab_04_data_engr.py
+++ b/labs/vol1/lab_04_data_engr.py
@@ -686,7 +686,7 @@ data is cheaper than moving data to compute.
 
         _error_pct = partC_error_rate.value
         _stages = partC_stages.value
-        _amp_factor = 1.4  # from chapter
+        _amp_factor = 1.5  # from chapter
 
         _errors_by_stage = []
         for _s in range(_stages + 1):


### PR DESCRIPTION
## Summary

Part C simulates a data error cascade through a pipeline. With the default settings (2% ingestion error, 5 stages), the amplification factor of `1.4` produced ~10.8% output error -- but the answer key marks **"~15% (significant amplification)"** as correct, and the MathPeek accordion explains that 2% error "can degrade accuracy by ~15%."

## Change

```python
# Before: 2% * 1.4^5 = 10.8%  (wrong -- doesn't match answer key)
_amp_factor = 1.4

# After: 2% * 1.5^5 = 15.2%  (correct -- matches answer key and MathPeek)
_amp_factor = 1.5
```

## Test plan

- [ ] Open lab 04 Part C with default sliders (2% error, 5 stages)
- [ ] Confirm output error displays ~15%
- [ ] Confirm "Correct" callout appears when selecting "~15% (significant amplification)"