### PR TITLE
fix(labs): correct FLOP scaling answer key in lab 05 Part C

### DIFF
--- a/labs/vol1/lab_05_nn_compute.py
+++ b/labs/vol1/lab_05_nn_compute.py
@@ -831,16 +831,18 @@ The quadratic term dominates as W grows.
 
         _actual_256 = (2*784*256 + 2*256*256 + 2*256*10) / (2*784*128 + 2*128*128 + 2*128*10)
         _pred = partC_prediction.value
-        if _pred == "4x":
+        if _pred == "2x":
             items.append(mo.callout(mo.md(
                 f"**Correct.** Doubling width from 128 to 256 increases total FLOPs by "
-                f"~{_actual_256:.1f}x. The hidden-to-hidden layer scales as W^2. "
-                f"Architecture decisions -- not just hardware -- dominate the Operations term."
+                f"~{_actual_256:.1f}x. The hidden-to-hidden layer scales as W^2, but the "
+                f"input and output layers scale linearly, pulling the total below 4x."
             ), kind="success"))
-        elif _pred == "2x":
+        elif _pred == "4x":
             items.append(mo.callout(mo.md(
-                f"**Linear intuition fails here.** Doubling width actually yields ~{_actual_256:.1f}x "
-                f"FLOPs. The hidden-to-hidden layer has FLOPs=2*W*W. Double W: 4x that layer."
+                f"**The quadratic layer dominates but doesn't tell the whole story.** "
+                f"The hidden-to-hidden layer (2*W^2) quadruples, but the input layer "
+                f"(2*784*W) and output layer (2*W*10) only double, pulling total to "
+                f"~{_actual_256:.1f}x."
             ), kind="warn"))
         else:
             items.append(mo.callout(mo.md(
@@ -857,7 +859,7 @@ Layer 2: 2 * {_w} * {_w} = {_flops_l2:,}
 Layer 3: 2 * {_w} * 10  = {_flops_l3:,}
 Total = {_total_flops:,}
 ```
-Doubling 128->256: ratio = {_actual_256:.2f}x (not 2x!)
+Doubling 128->256: ratio = {_actual_256:.2f}x (not 4x!)
 
 Source: @sec-nn-computation-flop-counting
 """),

--- a/labs/vol1/lab_05_nn_compute.py
+++ b/labs/vol1/lab_05_nn_compute.py
@@ -141,7 +141,8 @@ def _(COLORS, mo):
                     a layer's activations land in given batch size and width, and identify the
                     batch size threshold where a 10x latency cliff appears.</div>
                 <div style="margin-bottom: 3px;">3. <strong>Calculate the Floating Point Operations (FLOPs) scaling law</strong>
-                    for dense layers: doubling width yields ~4x FLOPs, not 2x.</div>
+                    for dense layers: doubling width yields ~2x total FLOPs (hidden-to-hidden
+                    layer quadruples, but input/output layers only double).</div>
                 <div style="margin-bottom: 3px;">4. <strong>Compare forward vs. backward memory</strong>:
                     training stores all layer activations simultaneously, creating a 4-10x
                     memory multiplier over inference.</div>


### PR DESCRIPTION
## Summary

Part C asks: "A 3-layer MLP has hidden layers of width 128. You double hidden width to 256. By how much do total FLOPs increase?"

The answer key marked **"C) ~4x (quadratic)"** as correct, but the code itself computes:

```
_actual_256 = (2*784*256 + 2*256*256 + 2*256*10) / (2*784*128 + 2*128*128 + 2*128*10)
            = 537,600 / 236,032
            ≈ 2.28x
```

The 4x scaling only applies to the hidden-to-hidden layer (2*W^2). The input layer (2*784*W) and output layer (2*W*10) scale linearly, pulling the total to ~2.3x. The correct answer is **"A) 2x"**.

The "Correct" callout itself was already printing `~{_actual_256:.1f}x` = `~2.3x` while saying "Correct" for 4x -- a visible contradiction. The MathPeek also said "(not 2x!)" when it should say "(not 4x!)".

## Changes

- Correct answer: `"4x"` → `"2x"`
- "2x" callout: now shows "Correct" with accurate explanation
- "4x" callout: now shows why it's wrong (quadratic layer alone is 4x, but total is ~2.3x)
- MathPeek note: `(not 2x!)` → `(not 4x!)`

## Test plan

- [ ] Open lab 05 Part C, confirm the live ratio displays ~2.3x
- [ ] Select "A) 2x" -- confirm "Correct" callout appears
- [ ] Select "C) ~4x" -- confirm correction callout explains the ~2.3x actual value