### PR TITLE
fix(labs): correct cold start time in lab 13 Part D

### DIFF
--- a/labs/vol1/lab_13_model_serving.py
+++ b/labs/vol1/lab_13_model_serving.py
@@ -268,7 +268,7 @@ def _(mo):
         options={
             "A) ~200 ms (normal inference latency)": "200ms",
             "B) ~2 seconds (some loading overhead)": "2s",
-            "C) ~15 seconds (loading 140 GB over PCIe Gen5)": "15s",
+            "C) ~26 seconds (NVMe read bottleneck + deserialization)": "26s",
             "D) ~60 seconds (loading from network storage)": "60s",
         },
         label="Auto-scaling Llama-2 70B during traffic spike. First-user wait?",
@@ -891,9 +891,10 @@ Total        = {_t_total:.1f} s
         """))
 
         _ref = 130/7.0 + 130/20.0 + 0.8 + 0.5
-        if partD_pred.value == "15s":
+        if partD_pred.value == "26s":
             items.append(mo.callout(mo.md(
-                f"**Correct.** 140 GB from NVMe over Gen5: ~{_ref:.0f}s total."), kind="success"))
+                f"**Correct.** NVMe bottleneck (7 GB/s): ~{130/7:.0f}s read + "
+                f"~{130/20:.0f}s deserialize + 1.3s overhead = ~{_ref:.0f}s total."), kind="success"))
         elif partD_pred.value == "200ms":
             items.append(mo.callout(mo.md(
                 "**200 ms is inference latency, not cold start.** 140 GB must "


### PR DESCRIPTION
## Summary

Part D asks: "Auto-scaling Llama-2 70B during traffic spike. First-user wait?"

The answer option C said **"~15 seconds (loading 140 GB over PCIe Gen5)"** but this is wrong. The code uses NVMe sequential read (7 GB/s) as the storage source, not PCIe Gen5 (64 GB/s). The actual bottleneck is NVMe:

```
Disk read:       130 GB / 7 GB/s  ≈ 19 s   (NVMe, not PCIe Gen5)
Deserialization: 130 GB / 20 GB/s ≈  7 s
CUDA init:                           0.8 s
Warmup:                              0.5 s
Total:                             ~26 s
```

The dynamic display (`_t_total`) already showed ~26s, but the answer option and the "Correct" callout both said "~15 seconds" -- a visible contradiction.

## Changes

- Option C text: `"~15 seconds (loading 140 GB over PCIe Gen5)"` → `"~26 seconds (NVMe read bottleneck + deserialization)"`
- Answer key: `"15s"` → `"26s"`
- Correct callout: updated to show the NVMe breakdown

## Test plan

- [ ] Open lab 13 Part D with defaults (70B, NVMe SSD, PCIe Gen5)
- [ ] Confirm the live cold start display shows ~26s
- [ ] Select "C) ~26 seconds" -- confirm "Correct" callout with breakdown