### PR TITLE
fix(labs): correct debt multiplier answer in lab 14 Part D

### DIFF
--- a/labs/vol1/lab_14_ml_ops.py
+++ b/labs/vol1/lab_14_ml_ops.py
@@ -113,7 +113,7 @@ def _(COLORS, mo):
                 <div style="margin-bottom: 3px;">2. <strong>Calculate optimal retraining cadence</strong>
                     &mdash; T* = sqrt(2C / C_drift) produces a 6-day interval when drift costs $500/day.</div>
                 <div style="margin-bottom: 3px;">3. <strong>Quantify technical debt compounding</strong>
-                    &mdash; 3 deferred retraining cycles produce 5&ndash;6x accumulated loss, not 3x.</div>
+                    &mdash; 3 deferred retraining cycles produce ~10x accumulated loss, not 3x.</div>
             </div>
         </div>
         <div style="border-top: 1px solid {COLORS['Border']}; margin: 0 -28px; padding: 0 28px;"></div>
@@ -237,7 +237,7 @@ def _(mo):
         options={
             "A) 3x (linear accumulation)": "3x",
             "B) 4x (slightly superlinear)": "4x",
-            "C) ~5-6x (debt compounds)": "5x",
+            "C) ~10x (debt compounds)": "10x",
             "D) 9x (quadratic)": "9x",
         },
         label="You defer retraining for 3 consecutive T* cycles. Total accuracy loss vs single miss?",
@@ -855,7 +855,7 @@ Debt multiplier:      {_total_with_cascade:.1f} / {_single_loss:.1f} = {_debt_mu
 *Source: technical debt model from @sec-ml-operations-debt-cascade*
         """))
 
-        if partD_pred.value == "5x":
+        if partD_pred.value == "10x":
             items.append(mo.callout(mo.md(
                 f"**Correct.** Debt compounds: {_N} missed cycles at {_bl} pp/cycle "
                 f"with {_nd} downstream models = {_debt_mult:.1f}x, not {_N}x."), kind="success"))
@@ -904,7 +904,7 @@ $$
             ), kind="info"),
             mo.callout(mo.md(
                 "**3. Technical debt compounds, not accumulates.**\n\n"
-                "3 missed retraining cycles produce 5-6x the loss of 1 missed cycle. "
+                "3 missed retraining cycles produce ~10x the loss of 1 missed cycle. "
                 "Downstream model dependencies multiply the damage."
             ), kind="info"),
             mo.Html(f"""


### PR DESCRIPTION
## Summary

Part D asks: "You defer retraining for 3 consecutive T* cycles. Total accuracy loss vs single miss?"

The answer key marked **"C) ~5-6x (debt compounds)"** as correct, but the debt cascade formula with default sliders (N=3 missed cycles, 2 downstream models, 2 pp/cycle, alpha=1.3) computes:

```
compound loss = sum(2 * k^1.3, k=1..3)  = 2*(1 + 2.46 + 4.73) = 16.4 pp
cascade cost  = 3 * 2 * 2.0 * 0.3       =                        3.6 pp
total                                    =                       20.0 pp
multiplier    = 20.0 / 2.0              =                        ~10x
```

The dynamic display card already showed `~10x` while the answer marked `~5-6x` as correct -- a visible contradiction.

## Changes

All four places that stated the wrong "5-6x" figure are corrected to "~10x":
- Learning objective text
- Radio option C label: `"~5-6x (debt compounds)"` → `"~10x (debt compounds)"`
- Answer key value: `"5x"` → `"10x"`
- Synthesis summary callout

## Test plan

- [ ] Open lab 14 Part D with default sliders (3 cycles, 2 downstream, 2 pp/cycle)
- [ ] Confirm debt multiplier card shows ~10x
- [ ] Select "C) ~10x (debt compounds)" -- confirm "Correct" callout appears