### PR TITLE
fix(instructors): make left sidebar readable in dark mode

### DIFF
--- a/instructors/assets/styles/dark-mode.scss
+++ b/instructors/assets/styles/dark-mode.scss
@@ -40,19 +40,82 @@ a {
 
 // ── Sidebar ──────────────────────────────────────────────────────────────────
 
-.sidebar {
+.sidebar,
+.sidebar-navigation,
+#quarto-sidebar {
   background-color: $bg-elevated;
   border-right-color: $border-color-dark;
 
-  .sidebar-item a {
+  // Section headers (collapsible toggles)
+  .sidebar-item.sidebar-item-section > .sidebar-item-container > .sidebar-item-toggle,
+  .sidebar-item-toggle,
+  a.sidebar-link.text-start {
+    color: $body-color-dark !important;
+    font-weight: 600;
+
+    &:hover { color: $indigo-dark !important; }
+  }
+
+  // Leaf links
+  a,
+  .sidebar-link,
+  .sidebar-item-text,
+  .menu-text,
+  .chapter-number {
     color: $text-muted-dark !important;
+
     &:hover {
       color: $indigo-dark !important;
       background-color: rgba($indigo-dark, 0.1) !important;
     }
-    &.active {
+
+    &.active,
+    &[aria-current="page"] {
       color: white !important;
       background-color: rgba($indigo-dark, 0.15) !important;
+      font-weight: 500 !important;
+    }
+  }
+}
+
+// High-specificity guards for active/current state
+#quarto-sidebar a.sidebar-link.active,
+#quarto-sidebar a.sidebar-link[aria-current="page"],
+#quarto-sidebar .sidebar-link.active .menu-text {
+  color: white !important;
+}
+
+// Sidebar search input
+.sidebar-search input,
+#quarto-search input {
+  background-color: $body-bg-dark !important;
+  border-color: $border-color-dark !important;
+  color: $body-color-dark !important;
+
+  &::placeholder { color: $text-muted-dark !important; }
+}
+
+// TOC (right "On this page" rail)
+.table-of-contents,
+#TOC,
+nav[role="doc-toc"],
+div[role="doc-toc"] {
+  border-left-color: $border-color-dark;
+
+  .toc-title,
+  .sidebar-title,
+  h2 {
+    color: $body-color-dark !important;
+    border: none !important;
+  }
+
+  a,
+  .nav-link {
+    color: $text-muted-dark !important;
+
+    &:hover,
+    &.active {
+      color: $indigo-dark !important;
     }
   }
 }


### PR DESCRIPTION
## Summary

The left navigation sidebar on the **Instructors** site (`/instructors/`) was unreadable in dark mode — section headers and links kept their light-theme colors against the dark background.

Root cause: the dark-mode rule targeted `.sidebar .sidebar-item a`, but Quarto renders the floating sidebar as `<a class=\"sidebar-link\">` and `<a class=\"sidebar-item-toggle\">` *directly* (not nested inside an `.sidebar-item` anchor wrapper), so none of the existing color overrides matched.

## Changes

`instructors/assets/styles/dark-mode.scss`

- Target the real selectors: `a.sidebar-link`, `.sidebar-item-toggle`, `.menu-text`, `.sidebar-item-text`, `.chapter-number`.
- Section headers (collapsible toggles) → light body color, indigo on hover.
- Leaf links → muted gray, indigo on hover, white-on-indigo for the active page.
- Style the sidebar search input (background, border, placeholder).
- Style the right-side TOC rail (`#TOC` / `nav[role=\"doc-toc\"]`) for consistency.
- Added higher-specificity guards (`#quarto-sidebar a.sidebar-link.active`) so the active state isn't overridden by Bootstrap's `active` link color.

## Before / After

| Before | After |
| 
<img width="1072" height="593" alt="Screenshot 2026-05-03 090224" src="https://github.com/user-attachments/assets/70ffc92c-e6a7-45db-9fa7-a1b42599a986" />
 | 
<img width="1061" height="611" alt="Screenshot 2026-05-03 090240" src="https://github.com/user-attachments/assets/1b8b421e-c17c-465b-8ae3-9b1700e3426c" />
 |


## Test plan

- [ ] `quarto preview instructors` and toggle to dark mode
- [ ] Verify section headers (\"Start Here\", \"Syllabi\", etc.) are clearly visible
- [ ] Verify leaf links are readable and the active page is highlighted in indigo/white
- [ ] Verify hover state (indigo text + faint indigo background tint)
- [ ] Verify the sidebar search input is themed (dark background, light text, muted placeholder)
- [ ] Verify the right-rail TOC (\"On this page\") matches the same accent
- [ ] Re-check light mode is unchanged