### PR TITLE
fix(instructors): repair broken TinyTorch Instructor Guide link

### DIFF
--- a/instructors/_quarto.yml
+++ b/instructors/_quarto.yml
@@ -81,7 +81,7 @@ website:
         contents:
           - faq.qmd
           - text: "TinyTorch Instructor Guide"
-            href: https://mlsysbook.ai/tinytorch/INSTRUCTOR.html
+            href: https://github.com/harvard-edge/cs249r_book/blob/dev/tinytorch/INSTRUCTOR.md
 
   # Footer — ecosystem pattern
   page-footer:


### PR DESCRIPTION
## Summary

The **TinyTorch Instructor Guide** entry in the Instructors sidebar pointed to a URL that 404s.

- Old (broken): `https://mlsysbook.ai/tinytorch/INSTRUCTOR.html` → **404**
- New: `https://github.com/harvard-edge/cs249r_book/blob/dev/tinytorch/INSTRUCTOR.md` → **200**

## Why it was broken

`tinytorch/INSTRUCTOR.md` lives in the `tinytorch/` source tree, but the TinyTorch website is published from `tinytorch/quarto/` — and the instructor guide is not part of that Quarto project. So the file is never rendered or deployed under `mlsysbook.ai/tinytorch/`, and the `INSTRUCTOR.html` URL has never existed.

## Fix

Point the sidebar entry at the canonical GitHub source. This is a one-line stopgap: the cleaner long-term fix is to wire `INSTRUCTOR.md` into the TinyTorch Quarto project so a real `INSTRUCTOR.html` is published — that belongs in a separate change against the TinyTorch site (different deploy pipeline, different reviewer).

## Files changed

- [instructors/_quarto.yml](instructors/_quarto.yml#L84) — single href update.

## Test plan

- [ ] Click the **TinyTorch Instructor Guide** entry in the Instructors sidebar (under "Resources") — confirm it now opens the GitHub-rendered `INSTRUCTOR.md`.