### PR TITLE
fix(book): drop non-English TikZ comment that fails codespell

### DIFF
--- a/book/quarto/contents/vol1/nn_computation/nn_computation.qmd
+++ b/book/quarto/contents/vol1/nn_computation/nn_computation.qmd
@@ -964,7 +964,7 @@ to[out=130,in=280](-0.71,-0.70)to[out=105,in=180](-0.61,-0.655)to[out=355,in=160
 to[out=335,in=180](0.07,-0.84)to[out=155,in=330](-0.25,-0.70)to[out=145,in=230](-0.255,-0.643)
 to[out=40,in=185](0.13,-0.54)to[out=170,in=45](-0.28,-0.61)to[out=220,in=340](-0.44,-0.62)
 to[out=160,in=290](-0.95,-0.36)
-to[out=105,in=190](-0.75,-0.11)coordinate(PL1)%pre plave leve plocice
+to[out=105,in=190](-0.75,-0.11)coordinate(PL1)
 to[out=5,in=190](0.10,-0.2)to[out=10,in=200](1.10,0.13)to[out=20,in=170](1.50,0.15)
 to[out=345,in=152](1.88,0.01)to[out=325,in=122](1.95,-0.11)to[out=290,in=95](1.985,-0.30)
 to[out=270,in=100](2,-0.60)
@@ -1020,7 +1020,7 @@ to[out=180,in=340](-0.45,0.01)to[out=166,in=10]cycle;
 \definecolor{col4}{RGB}{0,18,34}
 \definecolor{col5}{RGB}{14,60,102}
 \definecolor{col6}{RGB}{32,112,180}
- 
+
 \ColourTransitionPath[angle=100]
     {col5,col4,col5,col5,col1,col1,col1}
     {
@@ -1030,13 +1030,13 @@ to[out=180,in=340](-0.45,0.01)to[out=166,in=10]cycle;
       to[out=180,in=330](-0.65,-0.17)
       to[out=90,in=240]cycle
     }
- 
+
 \draw[black](-0.6,0.12)coordinate(1X1)
 to[out=5,in=170](-0.17,0.04)
 to[out=290,in=70](-0.23,-0.29)coordinate(1X2)
 to[out=180,in=330](-0.65,-0.17)
 to[out=90,in=240]cycle;
- 
+
 
 \coordinate(1S1)at($(1X1)!0.5!(1X2)$);
 \node[draw=none,ellipse,minimum width=2mm,minimum height=1.2mm,
@@ -1048,7 +1048,7 @@ inner sep=0pt,rotate=-10,fill=col1,anchor=south]at(EL1.south){};
 \node[draw=black,ellipse,minimum width=2mm,minimum height=1.2mm,
 inner sep=0pt,rotate=-10,fill=none](EL1)at(1S1){};
 
-%the second 
+%the second
 \ColourTransitionPath[angle=80]
     {col5,col4,col5,col5,col1,col1,col1}
     {
@@ -1058,7 +1058,7 @@ to[out=300,in=85](0.39,-0.25)
 to[out=200,in=350](-0.09,-0.29)
 to[out=97,in=260]cycle;
     }
-    
+
 \draw[black](-0.09,0.04)coordinate(2X1)
 to[out=0,in=190](0.3,0.09)
 to[out=300,in=85](0.39,-0.25)coordinate(2X2)
@@ -1085,7 +1085,7 @@ to[out=298,in=95](0.86,-0.04)
 to[out=210,in=5](0.48,-0.2)
 to[out=117,in=280]cycle;
     }
-    
+
 \draw[black](0.38,0.1)coordinate(3X1)
 to[out=25,in=190](0.76,0.27)
 to[out=298,in=95](0.86,-0.04)coordinate(3X2)
@@ -1101,7 +1101,7 @@ inner sep=0pt,rotate=25,fill=col2,anchor=south]at(EL3.south){};
 inner sep=0pt,rotate=25,fill=col1,anchor=south]at(EL3.south){};
 \node[draw=black,ellipse,minimum width=2mm,minimum height=1.2mm,
 inner sep=0pt,rotate=25,fill=none]at(3S1){};
-    
+
 %The fourth
 \ColourTransitionPath[angle=65]
     {col5,col4,col5,col5,col1,col1,col1}
@@ -1226,7 +1226,7 @@ inner sep=0pt,rotate=0,fill=none]at(0S1){};
 \node[above=0.1 of B1,font=\usefont{T1}{phv}{m}{n}\small](WE){\textbf{Inputs}};
 \node[Box2,minimum width=12mm,right=2of $(B1)!0.5!(B4)$,
             fill=VioletL2,draw=VioletLine](B5){};
-\draw[VioletLine,dashed,thick](B5.north)--(B5.south);    
+\draw[VioletLine,dashed,thick](B5.north)--(B5.south);
 \node[right=2pt of B5.west]{\textbf{z}};
 \node[left=2pt of B5.east]{\textbf{f}};
 %
@@ -1234,7 +1234,7 @@ inner sep=0pt,rotate=0,fill=none]at(0S1){};
 \node[below right=0 and 0.5 of B5.south,align=left]{Activation\\Function};
 \foreach \x in{1,...,4}{
 \draw[Line](B\x)--coordinate[pos=0.4](S\x)(B5);
-} 
+}
 \node[right=0pt of B1]{$=1$};
 \node[below=0pt of S1]{$b$};
 \node[below=0pt of S2]{$w_1$};
@@ -1265,7 +1265,7 @@ node[below,pos=0.7]{\textbf{Output}};
 \node[above=2pt of Q4,Txt]{Axon firing};
 \node[below=2pt of Q4,Txt]{= Activation (f)};
 
-\end{tikzpicture} 
+\end{tikzpicture}
 
 ```
 
@@ -1600,7 +1600,6 @@ class HistoricalScale:
 ```
 
 While the preceding sections established the technical foundations of deep learning, the term itself gained prominence in the 2010s, coinciding with advances in computational power and data accessibility. The scale of this computational explosion is difficult to grasp without visualization. @fig-trends plots seven decades of AI training compute on a logarithmic scale, revealing two distinct trends: computational capabilities measured in floating-point operations per second (FLOPS) initially followed a 1.4$\times$ improvement pattern from 1952 to 2010, then accelerated to a 3.4-month doubling cycle from 2012 to 2022. Large-scale models emerging between 2015 and 2022 scaled even faster, reaching two to three orders of magnitude beyond the general trend and following an aggressive 10-month doubling cycle.
-
 
 @tbl-historical-performance grounds these trends in concrete systems, showing how parameters, compute, and hardware co-evolved across four decades of neural network development.
 
@@ -3292,7 +3291,6 @@ class MnistTrainingMemoryCalc:
 
 **Step 2**: Activations.
 
-
 ::: {.content-visible when-format="html"}
 ::: {tbl-colwidths="[25,25,25,25]"}
 
@@ -3329,7 +3327,6 @@ class MnistTrainingMemoryCalc:
 **Step 3**: Training-only memory.
 - **Gradients** (same size as parameters): `{python} MnistTrainingMemoryCalc.grad_kib_str` KB
 - **Optimizer state** (Adam stores momentum + velocity, 2$\times$ parameters): `{python} MnistTrainingMemoryCalc.opt_kib_str` KB
-
 
 **Summary**:
 
@@ -5096,15 +5093,14 @@ Neural network-based ZIP code recognition transformed USPS mail processing opera
 
 ::: {.callout-example title="USPS Digit Recognition: By the Numbers"}
 
-
 | **Metric**           | **Neural Network** | **Human Operators** |
 |:---------------------|:------------------:|:-------------------:|
-| **Error rate**       |        1.0 percent | 2.5 percent         |
-| **Rejection rate**   |          9 percent | N/A                 |
-| **Throughput**       |   10–30 digits/sec | ~1 digit/sec        |
-| **Model parameters** |            ~10,000 | N/A                 |
-| **Training time**    | 3 days (Sun-4/260) | N/A                 |
-| **Training epochs**  |                 23 | N/A                 |
+| **Error rate**       |    1.0 percent     |     2.5 percent     |
+| **Rejection rate**   |     9 percent      |         N/A         |
+| **Throughput**       |  10–30 digits/sec  |     ~1 digit/sec    |
+| **Model parameters** |      ~10,000       |         N/A         |
+| **Training time**    | 3 days (Sun-4/260) |         N/A         |
+| **Training epochs**  |         23         |         N/A         |
 
 : **USPS LeNet Deployment Results**: LeNet achieved lower error rates than human operators (1.0 percent vs. 2.5 percent) while processing digits 10--30$\times$ faster—demonstrating that neural networks could surpass human performance on constrained pattern recognition tasks even with 1989-era hardware. The nine percent rejection rate represents the optimal economic balance between automation throughput and misrouting cost. {#tbl-usps-numbers}
 


### PR DESCRIPTION
## Summary

Codespell on dev started failing after #1636 was merged. Single typo flagged at `book/quarto/contents/vol1/nn_computation/nn_computation.qmd:967`:

```
to[out=105,in=190](-0.75,-0.11)coordinate(PL1)%pre plave leve plocice
```

The trailing `%pre plave leve plocice` is a Croatian inline comment in the TikZ source for fig 5.8. Codespell flags `leve` as a typo for `level` / `levee`. The `%` prefix means TikZ ignores it, so removing the comment has zero rendering impact.

## Why not add to ignore list

`leve` could be a real English typo elsewhere in the corpus later. Surgical removal is cleaner than weakening the dictionary.

## Diff

- 1 line: drop the trailing comment after `coordinate(PL1)`
- Pre-commit auto-stripped trailing whitespace across the rest of the file (same hook run); kept those changes alongside the fix since they are pure whitespace.

## Test plan

- [x] `codespell --toml pyproject.toml book/quarto/contents/vol1/nn_computation/nn_computation.qmd` exits 0
- [ ] Codespell workflow on this PR turns green
- [ ] Fig 5.8 still renders identically (no rendering impact from a dropped `%` comment)

## Note on figure-placement warnings

The `book-check-figure-placement` pre-commit hook also flags 4 pre-existing `early_float` warnings in #1636's content (`fig-trends`, `fig-channel-layer-pruning`, `fig-iterative-pruning`, `fig-quantization-error-dist`). Those are out of scope for this PR; tracking separately.