### PR TITLE
fix(instructors): improve dark mode dropdown menu contrast

### DIFF
--- a/instructors/assets/styles/dark-mode.scss
+++ b/instructors/assets/styles/dark-mode.scss
@@ -38,6 +38,38 @@ a {
   border-bottom-color: $border-color-dark !important;
 }
 
+// Navbar dropdown menus
+.navbar .dropdown-menu,
+.dropdown-menu {
+  background-color: $bg-elevated !important;
+  border-color: $border-color-dark !important;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.45) !important;
+}
+
+.navbar .dropdown-item,
+.dropdown-menu .dropdown-item {
+  color: $body-color-dark !important;
+  background-color: transparent !important;
+
+  &:hover,
+  &:focus,
+  &.active,
+  &:active {
+    color: $indigo-dark !important;
+    background-color: rgba($indigo-dark, 0.16) !important;
+  }
+}
+
+.navbar .dropdown-header,
+.dropdown-menu .dropdown-header {
+  color: $text-muted-dark !important;
+}
+
+.navbar .dropdown-divider,
+.dropdown-menu .dropdown-divider {
+  border-top-color: $border-color-dark !important;
+}
+
 // ── Sidebar ──────────────────────────────────────────────────────────────────
 
 .sidebar,


### PR DESCRIPTION
## Summary
- Top-navbar dropdown submenus on the instructor site rendered with a white background in dark mode.
- Add a dark-mode block in `instructors/assets/styles/dark-mode.scss` that sets dropdown surface/items/headers/dividers to the Blueprint dark palette with indigo hover/active state.

Before:
<img width="351" height="224" alt="Screenshot 2026-05-03 194720" src="https://github.com/user-attachments/assets/ba610070-ef26-4cba-a33a-4d280fef68dd" />

After:
<img width="451" height="294" alt="Screenshot 2026-05-03 194728" src="https://github.com/user-attachments/assets/97152ca0-a3eb-4ac7-8264-a37009199398" />


## Test plan
- [ ] `cd instructors && quarto preview`
- [ ] Toggle dark mode and open each top-nav dropdown — backgrounds match the dark navbar, items are readable, hover/active uses indigo.
- [ ] Verify light mode is unchanged.