### PR TITLE
fix(instructors): readable blockquote text in dark mode

### DIFF
--- a/instructors/assets/styles/dark-mode.scss
+++ b/instructors/assets/styles/dark-mode.scss
@@ -120,6 +120,19 @@ div[role="doc-toc"] {
   }
 }
 
+// ── Blockquotes ──────────────────────────────────────────────────────────────
+
+blockquote,
+.blockquote,
+main blockquote,
+.content blockquote {
+  color: $body-color-dark !important;
+  background-color: $bg-elevated !important;
+  border-left-color: $indigo-dark !important;
+
+  p, li, strong, em { color: $body-color-dark !important; }
+}
+
 // ── Callouts (preserve semantic left-border colors) ──────────────────────────
 
 .callout {


### PR DESCRIPTION
## Summary
- On the Assessment page (and anywhere else that uses markdown blockquotes), the Sample Decision Log entries rendered with dark text on the dark background, making them nearly unreadable in dark mode.
- Add a `blockquote` rule to `instructors/assets/styles/dark-mode.scss` that applies the dark-mode body color, the elevated surface background, and an indigo left border.

Before:
<img width="643" height="590" alt="Screenshot 2026-05-03 195342" src="https://github.com/user-attachments/assets/336b2280-885f-4be3-9d42-15188889d572" />

After:
<img width="763" height="691" alt="Screenshot 2026-05-03 195315" src="https://github.com/user-attachments/assets/64961c03-7530-4eb4-99c8-b2174dead51b" />


## Test plan
- [ ] `cd instructors && quarto preview`
- [ ] Open http://localhost:6863/assessment.html in dark mode and verify both "Sample Decision Log: Excellent (30/30)" and "Sample Decision Log: Insufficient (6/30)" blockquotes are readable.
- [ ] Confirm light mode is unchanged.