### PR TITLE
fix(instructors): readable landing tables and footer CTA

### DIFF
--- a/instructors/assets/styles/dark-mode.scss
+++ b/instructors/assets/styles/dark-mode.scss
@@ -297,6 +297,36 @@ pre code {
   }
 }
 
+// Inventory tables (Course Materials, Teaching Resources)
+.inv-table {
+  td {
+    border-bottom-color: $border-color-dark !important;
+  }
+  td:first-child { color: $body-color-dark !important; }
+  td:nth-child(2) { color: $text-muted-dark !important; }
+  tr:hover { background: rgba(255, 255, 255, 0.03) !important; }
+
+  td:last-child a {
+    color: $indigo-dark !important;
+    &:hover { color: lighten($indigo-dark, 15%) !important; }
+  }
+}
+
+// Footer CTA card ("Ready to Adopt?" / "Start teaching AI Systems")
+.footer-cta {
+  background: $bg-elevated !important;
+  border-color: $border-color-dark !important;
+
+  h2 { color: $body-color-dark !important; border: none !important; padding: 0 !important; }
+  p { color: $text-muted-dark !important; }
+
+  .btn-secondary {
+    border-color: $border-color-dark !important;
+    color: $text-muted-dark !important;
+    &:hover { border-color: $indigo-dark !important; color: $indigo-dark !important; }
+  }
+}
+
 // Numbers bar
 .number-item .big {
   color: $indigo-dark !important;


### PR DESCRIPTION
## Summary
- `.inv-table` (Course Materials, Teaching Resources) hardcoded `#1a1a2e` / `#4a5568` text and light hover background, making cells unreadable against the dark theme.
- `.footer-cta` card hardcoded a light `#f8fafc` background, hiding the "Start teaching AI Systems" heading.
- Added scoped overrides in `instructors/assets/styles/dark-mode.scss` for both, plus indigo accent for the last-column action links.

Before:
<img width="664" height="691" alt="Screenshot 2026-05-04 084820" src="https://github.com/user-attachments/assets/17543dc6-6685-4ae6-8037-75f6c3f6e199" />

After:
<img width="687" height="729" alt="Screenshot 2026-05-04 084810" src="https://github.com/user-attachments/assets/adbf8d7b-79ac-4c14-a72e-da4253676517" />


## Test plan
- [ ] Open `/instructors/` in dark mode — Course Materials and Teaching Resources tables are readable.
- [ ] Hover row tints subtly (no flash to light).
- [ ] Last-column links render in the indigo accent; inline body links keep crimson.
- [ ] "Ready to Adopt?" card uses the elevated dark background; heading and copy are readable.
- [ ] Light mode is unchanged.