### PR TITLE
fix(slides): readable inventory tables on landing page

### DIFF
--- a/slides/assets/styles/dark-mode.scss
+++ b/slides/assets/styles/dark-mode.scss
@@ -207,6 +207,19 @@ pre code {
   color: $slides-accent-dark !important;
 }
 
+// Inventory tables (What's Included, Related Resources)
+.inv-table {
+  td { border-bottom-color: $border-color-dark !important; }
+  td:first-child { color: $body-color-dark !important; }
+  td:nth-child(2) { color: $text-muted-dark !important; }
+  tr:hover { background: rgba(255, 255, 255, 0.03) !important; }
+
+  td:last-child a {
+    color: $slides-accent-dark !important;
+    &:hover { color: lighten($slides-accent-dark, 15%) !important; }
+  }
+}
+
 .info-section {
   background-color: $bg-elevated !important;
 }


### PR DESCRIPTION
## Summary
- The `.inv-table` blocks on the slides landing page (What's Included, Related Resources) hardcoded light-mode text/border colors, so the rows became unreadable against the dark theme.
- Added scoped overrides in `slides/assets/styles/dark-mode.scss` for the column text, row hover, and last-column action links (using the slides accent).

Before:
<img width="673" height="685" alt="Screenshot 2026-05-04 085909" src="https://github.com/user-attachments/assets/93012c88-5678-470b-b575-5ed8ade5e873" />

After:
<img width="677" height="716" alt="Screenshot 2026-05-04 085914" src="https://github.com/user-attachments/assets/1be757b1-54a5-4816-9321-8b0d72b2453e" />


## Test plan
- [ ] Open `/slides/` in dark mode — What's Included and Related Resources rows are readable.
- [ ] Hover row tints subtly without flashing to light.
- [ ] Last-column action links use the rose accent (`$slides-accent-dark`).
- [ ] Light mode is unchanged.