### PR TITLE
fix(lab11): correct Part E Tiling Dividend answer key from option C to option D

### DIFF
--- a/labs/vol1/lab_11_hw_accel.py
+++ b/labs/vol1/lab_11_hw_accel.py
@@ -956,7 +956,7 @@ At low AI (memory-bound), the $E_{\\text{DRAM}}/\\text{AI}$ term dominates. At A
         </div>
         """))
 
-        if pE_pred.value == "2_4":
+        if pE_pred.value == "10x":
             items.append(mo.callout(mo.md(f"**Correct.** FlashAttention achieves {_speedup:.1f}x by tiling "
                 "the attention computation to fit in SRAM, eliminating redundant HBM round-trips. "
                 "Increase sequence length to see even larger gains."), kind="success"))


### PR DESCRIPTION
## Summary

In Lab 11 Part E (The Tiling Dividend), the answer key marks **option C (~2-4x)** as correct when the formula in the same cell computes a ~10x speedup -- matching **option D**.

## Root cause

Lines 900-909 compute the FlashAttention tiling speedup at defaults (seq_len=4096, tile=256, d=128):

```
_std_bytes   = 2 * 4096 * 4096 * 2  ≈ 67 MB
_tiled_bytes = 2 * 16 * 256 * 128 * 2 + 4096 * 128 * 2  ≈ 3.3 MB
_speedup     = 67 / 3.3 ≈ 20x  -->  capped to 10x  (line 909)
```

The displayed `{_speedup:.1f}x` stat card therefore shows **10x**, but the answer key at line 959 checked `pE_pred.value == "2_4"` (option C), so selecting the answer that matches the computed and displayed value would incorrectly show the "wrong answer" callout.

## Fix

```python
# Before (line 959)
if pE_pred.value == "2_4":

# After
if pE_pred.value == "10x":
```

One line change -- no formula or option text modified.

## Verification

At seq_len=4096 with tile=256: select option D (~10x) -- green "Correct" callout now fires. All other options correctly show the "wrong answer" callout.