### PR TITLE
fix(mlsysim): replace hardcoded Mac path in interviewer.py with relative Path

### DIFF
--- a/mlsysim/mlsysim/cli/interviewer.py
+++ b/mlsysim/mlsysim/cli/interviewer.py
@@ -1,5 +1,6 @@
 import json
 import random
+from pathlib import Path
 from typing import Optional
 from pydantic import BaseModel
 
@@ -71,7 +72,8 @@ FORMAT YOUR RESPONSE AS JSON:
 
 if __name__ == "__main__":
     # Test loading
-    corpus = InterviewCorpus("/Users/VJ/GitHub/MLSysBook/interviews/corpus.json")
+    _repo_root = Path(__file__).resolve().parents[3]
+    corpus = InterviewCorpus(_repo_root / "interviews" / "corpus.json")
     q = corpus.get_random(track="cloud", level="L4")
     print(f"Random Q: {q.title} ({q.level})")
     print(f"Scenario: {q.scenario}")


### PR DESCRIPTION
## Bug

`mlsysim/mlsysim/cli/interviewer.py` line 74 had a hardcoded Mac-specific absolute path in its `__main__` smoke-test block:

```python
corpus = InterviewCorpus("/Users/VJ/GitHub/MLSysBook/interviews/corpus.json")
```

This crashes immediately on any non-Mac machine (Windows, Linux, CI).

## Fix

Replaced with a `Path(__file__)`-relative path that resolves correctly on all platforms:

```python
_repo_root = Path(__file__).resolve().parents[3]
corpus = InterviewCorpus(_repo_root / "interviews" / "corpus.json")
```

Also added the missing `from pathlib import Path` import.

`interviewer.py` is at `mlsysim/mlsysim/cli/interviewer.py` -- `.parents[3]` correctly resolves to the repo root.