### PR TITLE
fix(slides): readable section-list tables on tinyml pages 

### DIFF
--- a/slides/assets/styles/dark-mode.scss
+++ b/slides/assets/styles/dark-mode.scss
@@ -207,6 +207,57 @@ pre code {
   color: $slides-accent-dark !important;
 }
 
+// TinyML course pages: module cards + section lists
+.module-card {
+  background: $bg-elevated !important;
+  border-color: $border-color-dark !important;
+
+  h3, h4 { color: $body-color-dark !important; }
+
+  .module-desc { color: $text-muted-dark !important; }
+
+  .companion {
+    background: rgba(255, 255, 255, 0.04) !important;
+    color: $text-muted-dark !important;
+  }
+  .companion a { color: $slides-accent-dark !important; }
+}
+
+.section-header-sm { color: $body-color-dark !important; }
+
+.section-list {
+  th {
+    color: $text-muted-dark !important;
+    border-bottom-color: $border-color-dark !important;
+  }
+  td {
+    color: $body-color-dark !important;
+    border-bottom-color: $border-color-dark !important;
+  }
+  tr:hover { background-color: rgba(255, 255, 255, 0.03) !important; }
+  .sec-title { color: $body-color-dark !important; }
+  .no-material { color: $text-muted-dark !important; }
+}
+
+// Material badges — tune backgrounds for dark contrast, keep brand colors
+.badge-slides,
+a.badge-slides {
+  background: rgba($slides-accent-dark, 0.18) !important;
+  color: $slides-accent-dark !important;
+}
+
+.badge-reading,
+a.badge-reading {
+  background: rgba(74, 222, 128, 0.15) !important;
+  color: #4ade80 !important;
+}
+
+.badge-colab,
+a.badge-colab {
+  background: rgba(251, 146, 60, 0.18) !important;
+  color: #fb923c !important;
+}
+
 // Inventory tables (What's Included, Related Resources)
 .inv-table {
   td { border-bottom-color: $border-color-dark !important; }


### PR DESCRIPTION
## Summary
- `.module-card` hardcoded `background: #ffffff` while dark-mode.scss colored all `<td>` light gray, making row text invisible on `tinyml-fundamentals.html` (and the other `tinyml-*` pages that share the component).
- Adds dark-mode overrides for `.module-card` (background, headings, description, companion pill), `.section-list` (th/td color, borders, hover, sec-title, no-material), and `.section-header-sm`.
- Tunes the `.badge-slides`, `.badge-reading`, and `.badge-colab` swatches so the Slides/Reading/Colab pills keep adequate contrast on the dark card.

Before:
<img width="736" height="589" alt="Screenshot 2026-05-05 195721" src="https://github.com/user-attachments/assets/5b35f69a-1012-479b-aa87-7c76fb90001a" />

After:
<img width="789" height="642" alt="Screenshot 2026-05-05 195736" src="https://github.com/user-attachments/assets/3c3a74d9-76ce-46e6-96d9-2f58a39f8580" />


## Test plan
- [ ] Open `tinyml-fundamentals.html` in dark mode and confirm every row of every section-list is readable.
- [ ] Spot-check `tinyml-applications.html`, `tinyml-deploying.html`, `tinyml-mlops.html` for the same components.
- [ ] Toggle back to light mode and verify nothing regressed (cards still white, badges keep their original colors).