### PR TITLE
fix(slides): readable slide-table headers on teaching/vol1/vol2 in dark mode

### DIFF
--- a/slides/assets/styles/dark-mode.scss
+++ b/slides/assets/styles/dark-mode.scss
@@ -178,10 +178,22 @@ pre code {
 .slide-table {
   th {
     background-color: rgba($slides-accent-dark, 0.1) !important;
+    color: $body-color-dark !important;
+    border-bottom-color: $slides-accent-dark !important;
+  }
+
+  td {
+    color: $body-color-dark !important;
+    border-bottom-color: $border-color-dark !important;
   }
 
   tr:hover {
     background-color: rgba($slides-accent-dark, 0.05) !important;
+  }
+
+  .dl-col a {
+    color: $slides-accent-dark !important;
+    &:hover { color: lighten($slides-accent-dark, 15%) !important; }
   }
 }
 


### PR DESCRIPTION
## Summary
- `.slide-table th` hardcodes `color: var(--mls-text)` (#111111) and dark-mode.scss only overrode the header background, leaving the heading text invisible on `teaching.html`, `vol1.html`, and `vol2.html` in dark mode.
- Adds dark-mode `color` overrides for `.slide-table` `th` / `td`, switches the th bottom border to the dark accent, and recolors `.dl-col a` so the download links keep contrast.

## Test plan
- [ ] Open `teaching.html`, `vol1.html`, `vol2.html` in dark mode and confirm headers and rows are readable, including the download links.
- [ ] Toggle to light mode and verify the existing pink header swatch is unchanged.