### PR TITLE
docs(tinytorch): expand OOM acronym in Module 01 checklist item

### DIFF
--- a/tinytorch/quarto/modules/01_tensor.qmd
+++ b/tinytorch/quarto/modules/01_tensor.qmd
@@ -831,7 +831,7 @@ Before moving on, verify you can articulate each of the following:
 - [ ] How right-to-left broadcasting lets `(32, 1, 768) + (512, 768)` produce `(32, 512, 768)` without materializing a tiled copy.
 - [ ] Why matmul is O(n^3) — and why doubling matrix size multiplies runtime by 8x, not 4x.
 - [ ] The memory distinction between views (share bytes with source) and copies (fresh allocation), and why silent mutation through a view is a systems bug.
-- [ ] How a scalar logit of 32 × 3 × 224 × 224 image batch lands at ~18.4 MB in float32, and why batch size is the first knob to turn when OOM hits.
+- [ ] How a scalar logit of 32 × 3 × 224 × 224 image batch lands at ~18.4 MB in float32, and why batch size is the first knob to turn when the GPU runs Out of Memory (OOM).
 
 If any of these feels fuzzy, revisit Core Concepts (Broadcasting, Views vs. Copies, Matrix Multiplication, Computational Complexity) before moving on.
 :::


### PR DESCRIPTION
## Problem

Closes #1685

The checklist item in the "Check Your Understanding" section of Module 01 used "OOM" without defining it:

> "...and why batch size is the first knob to turn when OOM hits."

A student encountering this for the first time had no context for the acronym. The explanation in the collapsible Q&A below says "training runs out of GPU memory" but the checklist above it assumed prior knowledge of OOM as a term.

## Fix

Expanded the acronym inline so the checklist item is self-contained:

> "...and why batch size is the first knob to turn when the GPU runs Out of Memory (OOM)."

One line change in `tinytorch/quarto/modules/01_tensor.qmd`.