### PR TITLE
docs(tinytorch): add GELU implementation and explanation

### DIFF
--- a/tinytorch/quarto/modules/02_activations.qmd
+++ b/tinytorch/quarto/modules/02_activations.qmd
@@ -552,10 +552,7 @@ Below is the complete implementation from your module:
 class GELU:
     def forward(self, x: Tensor) -> Tensor:
         """Apply GELU activation using the fast sigmoid approximation."""
-        # GELU approximation: x * sigmoid(1.702 * x)
-        sigmoid_part = 1.0 / (1.0 + np.exp(-1.702 * x.data))
-        result = x.data * sigmoid_part
-        return Tensor(result)
+        return Sigmoid()(x * 1.702) * x
 ```
 
 While ReLU remains the default in CNNs and MLPs, GELU has become the standard choice for modern transformers like GPT and BERT.

--- a/tinytorch/quarto/modules/02_activations.qmd
+++ b/tinytorch/quarto/modules/02_activations.qmd
@@ -542,11 +542,11 @@ class Tanh:
 
 Zero-centering is the only real difference, and it matters more than it sounds. Sigmoid outputs are always positive, which biases the gradient updates of the next layer in one direction; tanh outputs straddle zero, so positive and negative gradients cancel naturally. That's why tanh, not sigmoid, was the activation of choice inside LSTM and GRU cells where the same weights see the same hidden state hundreds of times. Tanh still saturates at the extremes, so deep stacks still vanish — but for bounded, recurrent settings it remains the right pick.
 
-### GELU 
+### GELU
 
-GELU (Gaussian Error Linear Unit) applies a more complex gate than ReLU. Rather than taking the `max(0, x)` threshold, GELU applies a smooth, probabilistic transformation. 
+GELU (Gaussian Error Linear Unit) applies a more complex gate than ReLU. Rather than taking the `max(0, x)` threshold, GELU applies a smooth, probabilistic transformation.
 
-Below is the complete implementation from your module:
+The implementation uses the fast sigmoid approximation from your module.
 
 ```python
 class GELU:
@@ -554,6 +554,8 @@ class GELU:
         """Apply GELU activation using the fast sigmoid approximation."""
         return Sigmoid()(x * 1.702) * x
 ```
+
+: **Listing 2.2 — GELU using the fast sigmoid approximation, reusing the Sigmoid implementation from this module.** {#lst-02-activations-gelu}
 
 While ReLU remains the default in CNNs and MLPs, GELU has become the standard choice for modern transformers like GPT and BERT.
 
@@ -586,7 +588,7 @@ class Softmax:
         return result
 ```
 
-: **Listing 2.2 — Softmax with max-subtraction for numerical stability (the log-sum-exp trick).** {#lst-02-activations-softmax}
+: **Listing 2.3 — Softmax with max-subtraction for numerical stability (the log-sum-exp trick).** {#lst-02-activations-softmax}
 
 **Why the max subtraction matters — the load-bearing trick of this chapter.**
 

--- a/tinytorch/quarto/modules/02_activations.qmd
+++ b/tinytorch/quarto/modules/02_activations.qmd
@@ -542,6 +542,26 @@ class Tanh:
 
 Zero-centering is the only real difference, and it matters more than it sounds. Sigmoid outputs are always positive, which biases the gradient updates of the next layer in one direction; tanh outputs straddle zero, so positive and negative gradients cancel naturally. That's why tanh, not sigmoid, was the activation of choice inside LSTM and GRU cells where the same weights see the same hidden state hundreds of times. Tanh still saturates at the extremes, so deep stacks still vanish — but for bounded, recurrent settings it remains the right pick.
 
+### GELU 
+
+GELU (Gaussian Error Linear Unit) applies a more complex gate than ReLU. Rather than taking the `max(0, x)` threshold, GELU applies a smooth, probabilistic transformation. 
+
+Below is the complete implementation from your module:
+
+```python
+class GELU:
+    def forward(self, x: Tensor) -> Tensor:
+        """Apply GELU activation using the fast sigmoid approximation."""
+        # GELU approximation: x * sigmoid(1.702 * x)
+        sigmoid_part = 1.0 / (1.0 + np.exp(-1.702 * x.data))
+        result = x.data * sigmoid_part
+        return Tensor(result)
+```
+
+While ReLU remains the default in CNNs and MLPs, GELU has become the standard choice for modern transformers like GPT and BERT.
+
+**The tradeoff:** because it relies on transcendental operations (exponentials and divisions) rather than simple comparisons, it is roughly 4–5x more computationally expensive per element than ReLU. In the context of a billion-parameter model, this "GELU tax" is a deliberate choice: we trade raw throughput for the training stability and improved accuracy that a smooth activation provides at scale.
+
 ### Softmax and Numerical Stability
 
 Softmax converts any vector into a valid probability distribution. All outputs are positive, and they sum to exactly 1. This makes it essential for multi-class classification:


### PR DESCRIPTION
## Problem
Closes #1689 

The "Activations" module (Module 02) mentioned the GELU activation function is referenced throughout the docs and is required in the coding module, but the actual implementation and explanation were missing from the core content.

## Fix
- Added the `GELU` class implementation to `02_activations.qmd` 
- Documented the computational tradeoff (4–5x cost vs ReLU)