### PR TITLE
fix(tinytorch): reuse Sigmoid class in GELU solution

### DIFF
--- a/tinytorch/src/02_activations/02_activations.py
+++ b/tinytorch/src/02_activations/02_activations.py
@@ -624,12 +624,7 @@ class GELU:
         HINT: The 1.702 constant is empirically fitted so that sigmoid(1.702x) ≈ Φ(x)
         """
         ### BEGIN SOLUTION
-        # GELU approximation: x * sigmoid(1.702 * x)
-        # First compute sigmoid part
-        sigmoid_part = 1.0 / (1.0 + np.exp(-1.702 * x.data))
-        # Then multiply by x
-        result = x.data * sigmoid_part
-        return Tensor(result)
+        return Sigmoid()(x * 1.702) * x
         ### END SOLUTION
 
     def __call__(self, x: Tensor) -> Tensor:


### PR DESCRIPTION
## Summary

- GELU's `forward()` solution used raw `np.exp` to compute the sigmoid, bypassing the `Sigmoid` class students built earlier in the same module.
- The docstring explicitly says "reuse sigmoid (which you just built!)" -- the old solution contradicted this hint.
- Replaced the 6-line implementation with `return Sigmoid()(x * 1.702) * x`, which is numerically identical and demonstrates class composition.

## Fix

**Before:**
```python
### BEGIN SOLUTION
# GELU approximation: x * sigmoid(1.702 * x)
# First compute sigmoid part
sigmoid_part = 1.0 / (1.0 + np.exp(-1.702 * x.data))
# Then multiply by x
result = x.data * sigmoid_part
return Tensor(result)
### END SOLUTION
```

**After:**
```python
### BEGIN SOLUTION
return Sigmoid()(x * 1.702) * x
### END SOLUTION
```

Verified numerically: both produce identical outputs across positive and negative inputs.

Fixes #1692

## Test plan

- [ ] Confirm `np.allclose(Sigmoid()(x * 1.702) * x, old_impl(x))` passes for representative inputs
- [ ] Run TinyTorch test suite: `pytest tests/`
- [ ] Regenerate notebook via `tito src export 02_activations` and confirm the student-facing cell is still a blank stub