### PR TITLE
fix(labs): catch missing wheel before deploy to prevent BadZipFile in browser

### DIFF
--- a/labs/tests/test_static.py
+++ b/labs/tests/test_static.py
@@ -220,6 +220,27 @@ class TestWheelConsistency:
             "Found absolute wheel URL. Use relative path '../../wheels/mlsysim-...' instead."
         )
 
+    def test_wheel_file_exists_on_disk(self):
+        """The wheel file referenced by labs must actually exist in wheels/.
+        If this fails, run: python3 -m build --wheel mlsysim/ && cp mlsysim/dist/mlsysim-*.whl wheels/
+        """
+        try:
+            import tomllib
+        except ImportError:
+            import tomli as tomllib
+
+        pyproject = REPO_ROOT / "mlsysim" / "pyproject.toml"
+        with open(pyproject, "rb") as f:
+            version = tomllib.load(f)["project"]["version"]
+
+        wheel_path = REPO_ROOT / "wheels" / f"mlsysim-{version}-py3-none-any.whl"
+        assert wheel_path.exists(), (
+            f"Wheel file missing: {wheel_path}\n"
+            f"Labs reference version {version} but the wheel is not present in wheels/.\n"
+            f"Fix: python3 -m build --wheel mlsysim/ && cp mlsysim/dist/mlsysim-*.whl wheels/\n"
+            f"This causes BadZipFile in production when micropip fetches the missing URL."
+        )
+
 
 # ── Test: WASM Compatibility ────────────────────────────────────────────────
 

--- a/labs/tools/build_site.sh
+++ b/labs/tools/build_site.sh
@@ -33,6 +33,27 @@ fi
 
 python3 -m build --wheel "${MLSYSIM_DIR}"
 
+# Verify the built wheel version matches what labs reference via micropip.
+# A mismatch causes BadZipFile in the browser (micropip fetches a 404 HTML page).
+BUILT_VERSION=$(python3 -c "
+import tomllib, pathlib
+p = pathlib.Path('${MLSYSIM_DIR}/pyproject.toml')
+print(tomllib.loads(p.read_text())['project']['version'])
+")
+BUILT_WHL="${MLSYSIM_DIR}/dist/mlsysim-${BUILT_VERSION}-py3-none-any.whl"
+if [ ! -f "${BUILT_WHL}" ]; then
+  echo "ERROR: Expected wheel not found after build: ${BUILT_WHL}" >&2
+  exit 1
+fi
+# Spot-check one lab to confirm the micropip URL references the built version
+SAMPLE_LAB="${LABS_DIR}/vol1/lab_01_ml_intro.py"
+if ! grep -q "mlsysim-${BUILT_VERSION}-py3-none-any.whl" "${SAMPLE_LAB}"; then
+  echo "ERROR: Version mismatch -- built wheel is ${BUILT_VERSION} but ${SAMPLE_LAB} references a different version." >&2
+  echo "Update all micropip.install() calls to reference mlsysim-${BUILT_VERSION}-py3-none-any.whl" >&2
+  exit 1
+fi
+echo "Wheel version check passed: ${BUILT_VERSION}"
+
 rm -rf "${LABS_DIR}/_wasm_build" "${LABS_DIR}/_build"
 mkdir -p "${LABS_DIR}/_wasm_build/wheels"
 cp "${MLSYSIM_DIR}"/dist/mlsysim-*.whl "${LABS_DIR}/_wasm_build/wheels/"

--- a/labs/tools/build_site.sh
+++ b/labs/tools/build_site.sh
@@ -36,7 +36,11 @@ python3 -m build --wheel "${MLSYSIM_DIR}"
 # Verify the built wheel version matches what labs reference via micropip.
 # A mismatch causes BadZipFile in the browser (micropip fetches a 404 HTML page).
 BUILT_VERSION=$(python3 -c "
-import tomllib, pathlib
+import pathlib
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
 p = pathlib.Path('${MLSYSIM_DIR}/pyproject.toml')
 print(tomllib.loads(p.read_text())['project']['version'])
 ")
@@ -45,10 +49,19 @@ if [ ! -f "${BUILT_WHL}" ]; then
   echo "ERROR: Expected wheel not found after build: ${BUILT_WHL}" >&2
   exit 1
 fi
-# Spot-check one lab to confirm the micropip URL references the built version
-SAMPLE_LAB="${LABS_DIR}/vol1/lab_01_ml_intro.py"
-if ! grep -q "mlsysim-${BUILT_VERSION}-py3-none-any.whl" "${SAMPLE_LAB}"; then
-  echo "ERROR: Version mismatch -- built wheel is ${BUILT_VERSION} but ${SAMPLE_LAB} references a different version." >&2
+
+# Confirm every lab references the built wheel version.
+BAD_LABS=""
+for lab in "${LABS_DIR}"/vol*/lab_*.py; do
+  if ! grep -q "mlsysim-${BUILT_VERSION}-py3-none-any.whl" "${lab}"; then
+    BAD_LABS="${BAD_LABS} ${lab}"
+  fi
+done
+if [ -n "${BAD_LABS}" ]; then
+  echo "ERROR: Built wheel is ${BUILT_VERSION}, but these labs reference a different wheel:" >&2
+  for lab in ${BAD_LABS}; do
+    echo "  - ${lab}" >&2
+  done
   echo "Update all micropip.install() calls to reference mlsysim-${BUILT_VERSION}-py3-none-any.whl" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

Fixes #1691.

**Root cause:** `micropip.install("../../wheels/mlsysim-0.1.1-py3-none-any.whl")` in the browser resolves to `mlsysbook.ai/labs/wheels/mlsysim-0.1.1-py3-none-any.whl`. The live site was deployed before commit `1eb30f5f8` landed (which bumped the wheel and all lab references from `0.1.0` to `0.1.1`), so the URL returns a 404 HTML page. `micropip` hands that to `zipfile`, which correctly raises `BadZipFile`. Every downstream cell then fails with "Ancestor raised".

**Immediate fix for maintainers:** retrigger `labs-publish-live.yml` via `workflow_dispatch` -- no code change needed for the live site to recover.

**This PR prevents recurrence with two guards:**

- `labs/tests/test_static.py` -- new `test_wheel_file_exists_on_disk` test that asserts `wheels/mlsysim-{version}-py3-none-any.whl` actually exists on disk. This runs in `labs-validate-dev.yml`, which gates the publish workflow via the publish guard. A deploy where the wheel file is absent will now fail CI before any WASM export happens.

- `labs/tools/build_site.sh` -- version-consistency guard added after `python3 -m build --wheel`. Reads the version from `mlsysim/pyproject.toml`, confirms the built wheel exists at the expected path, and spot-checks `lab_01_ml_intro.py` to confirm the `micropip.install()` URL references the same version. Fails the build immediately with a clear error message if there is a mismatch.

## Test plan

- [ ] `python3 -m pytest labs/tests/test_static.py::TestWheelConsistency::test_wheel_file_exists_on_disk -v` passes with wheel present, fails with wheel removed
- [ ] `labs-validate-dev.yml` passes on this branch
- [ ] Retrigger `labs-publish-live.yml` to deploy the `0.1.1` wheel and unblock users hitting #1691