### PR TITLE
tinytorch modules clarity

### DIFF
--- a/tinytorch/src/04_losses/04_losses.py
+++ b/tinytorch/src/04_losses/04_losses.py
@@ -128,11 +128,11 @@ Loss Landscape for MSE:
      Loss
       ^
       |
-   4  |     *
-      |    / \
-   2  |   /   \
-      |  /     \
-   0  |_/_______\\____> Prediction Error
+   4  |  |       |
+      |   \     /
+   2  |    |   |
+      |     \ /
+   0  |______*______> Prediction Error
       0  -2  0  +2
 
 Quadratic growth: small errors → small penalty, large errors → huge penalty

--- a/tinytorch/src/05_dataloader/05_dataloader.py
+++ b/tinytorch/src/05_dataloader/05_dataloader.py
@@ -130,7 +130,7 @@ Raw Data Storage          Dataset Interface         DataLoader Batching         
 
 **Batch Processing (DataLoader)**: GPUs are parallel machines - they're much faster processing 32 images simultaneously than 1 image 32 times.
 
-**Memory Efficiency**: Loading all 50,000 images into memory would require ~150GB. Instead, we load only the current batch (~150MB).
+**Memory Efficiency**: Loading all 50,000 images into memory would require \~150GB. Instead, we load only the current batch (\~150MB).
 
 **Training Variety**: Shuffling ensures the model sees different combinations each epoch, preventing memorization.
 
@@ -141,12 +141,9 @@ The Dataset class provides a uniform interface for accessing data, regardless of
 ```
 Dataset Interface
 ┌─────────────────────────────────────┐
-│ __len__()     → "How many samples?" │
-│ __getitem__(i) → "Give me sample i" │
+│ __len__()     → "How many samples?" │ ← Enables for loops/iteration
+│ __getitem__(i) → "Give me sample i" │ ← Enables indexing dataset[index]
 └─────────────────────────────────────┘
-          ↑                ↑
-     Enables for     Enables indexing
-    loops/iteration   dataset[index]
 ```
 
 **Connection to systems**: This abstraction is crucial because it separates *how data is stored* from *how it's accessed*, enabling optimizations like caching, prefetching, and parallel loading.
@@ -1738,8 +1735,8 @@ def analyze_memory_usage():
 
     print("\n💾 Memory Usage by Batch Configuration:")
 
-    feature_sizes = [784, 3072, 50176]  # MNIST, CIFAR-10, ImageNet-like
-    feature_names = ["MNIST (28×28)", "CIFAR-10 (32×32×3)", "ImageNet (224×224×1)"]
+    feature_sizes = [784, 3072, 150528]  # MNIST, CIFAR-10, ImageNet-like
+    feature_names = ["MNIST (28×28)", "CIFAR-10 (32×32×3)", "ImageNet (224×224×3)"]
     batch_sizes = [1, 32, 128, 512]
 
     for feature_size, name in zip(feature_sizes, feature_names):

--- a/tinytorch/src/06_autograd/06_autograd.py
+++ b/tinytorch/src/06_autograd/06_autograd.py
@@ -1142,8 +1142,9 @@ class PermuteBackward(Function):
         return (grad_x,)
         ### END SOLUTION
 
-#| export
 
+# %% nbgrader={"grade": false, "grade_id": "slice-backward", "solution": true}
+#| export
 class SliceBackward(Function):
     """
     Gradient computation for tensor slicing/indexing operations.


### PR DESCRIPTION
Increases clarity in tinytorch modules 05, 06, and 07 as well as fixes diagram misrepresentations which cause confusion.
--

Tested through `tito module test NN` for affected modules, where `NN` was `05`, `06`, and `07`.

* Fixes MSE diagram in module 04
* Fixes typos and diagram confusions in module 05
* Fixes clarity for gradient computation by fixing inconsistency in representation of each operation

---
*By submitting this PR, you agree to release your contribution under the project's license.*
