### PR TITLE
fix(labs): readability for navbar dropdowns and landing-page headings

### DIFF
--- a/labs/assets/styles/dark-mode.scss
+++ b/labs/assets/styles/dark-mode.scss
@@ -365,6 +365,47 @@ div[class*="margin"] {
   }
 }
 
+// Navbar dropdown panels (Teach / Prepare / Connect menus). Bootstrap's
+// default .dropdown-menu is a light surface, so on a dark page the items
+// fall back to the global teal link color on a near-white panel that the
+// dark navbar washes out. Force a dark surface with legible items.
+.navbar .dropdown-menu {
+  background-color: #2a2a2a !important;
+  border-color: $border-color-dark !important;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+
+  .dropdown-item {
+    color: #e6e6e6 !important;
+    background-color: transparent !important;
+
+    .bi,
+    svg {
+      color: inherit !important;
+      fill: currentColor !important;
+    }
+
+    &:hover,
+    &:focus {
+      color: $kits-accent-dark !important;
+      background-color: rgba($kits-accent-dark, 0.15) !important;
+    }
+
+    &.active,
+    &:active {
+      color: white !important;
+      background-color: rgba($kits-accent-dark, 0.25) !important;
+    }
+  }
+
+  .dropdown-divider {
+    border-top-color: $border-color-dark !important;
+  }
+
+  .dropdown-header {
+    color: #adb5bd !important;
+  }
+}
+
 // Dark mode toggle
 .quarto-color-scheme-toggle {
   color: #adb5bd !important;

--- a/labs/assets/styles/dark-mode.scss
+++ b/labs/assets/styles/dark-mode.scss
@@ -694,6 +694,30 @@ small {
 // CO-LABS LANDING PAGE - DARK MODE
 // =============================================================================
 
+// Lab Inventory headings on the landing page. The inline <style> block in
+// labs/index.qmd hard-codes #1e293b with !important, which is invisible on
+// the dark body. Override via the html[data-bs-theme="dark"] attribute so
+// these selectors beat the inline rules without needing more !important.
+html[data-bs-theme="dark"] {
+  .volume-heading {
+    color: #e6e6e6 !important;
+    border-bottom-color: $kits-accent-dark !important;
+  }
+
+  section.volume-heading ~ section.volume-heading {
+    border-top-color: $border-color-dark !important;
+  }
+
+  h3.volume-heading::after,
+  h4.cluster-heading::after {
+    color: #adb5bd;
+  }
+
+  .cluster-heading {
+    color: #e6e6e6 !important;
+  }
+}
+
 // Hero section - already dark, but ensure consistency
 .hero-section {
   background: linear-gradient(135deg, #0d0d1a 0%, #111827 50%, #0a1628 100%);


### PR DESCRIPTION
## Summary

Two scoped fixes to `labs/assets/styles/dark-mode.scss` for the Co-Labs site in dark mode:

- **Navbar dropdown panels** (Teach / Prepare / Connect): Bootstrap's default `.dropdown-menu` keeps its light surface on the dark navbar, and items inherit the global teal link color — combined, the popover is unreadable. Adds a dark surface plus item, divider, and header styling.
- **Landing-page Lab Inventory headings**: `labs/index.qmd` ships an inline `<style>` block that hard-codes `#1e293b !important` on `.volume-heading` and `.cluster-heading`, making "Volume I: Foundations", "Volume II: At Scale", "I. Foundations", "II. Build", "III. Optimize", "IV. Deploy", and "Capstone" invisible on the dark body. Overrides are scoped under `html[data-bs-theme="dark"]` so they outrank the inline rules without piling on more `!important`.

Lab cards keep their white background in dark mode by design, so the in-card title / question colors were left untouched — only the headings sitting on the dark page background changed.

## Test plan

- [ ] `quarto preview` the labs site (or `labs/tools/build_site.sh`) and toggle dark mode.
- [ ] Open each navbar dropdown (Teach, Prepare, Connect) — items and hover states must be readable on a dark panel.
- [ ] On the landing page in dark mode, verify "Volume I: Foundations", "Volume II: At Scale", and every cluster heading (`I. Foundations`, `II. Build`, `III. Optimize`, `IV. Deploy`, `Capstone`) plus their `· Labs 00–04` meta suffixes are readable.
- [ ] Light mode is unchanged (overrides are gated on `[data-bs-theme="dark"]` / the dark-mode SCSS bundle).