### PR TITLE
Fix MLSysim landing page dark mode code and references

### DIFF
--- a/mlsysim/docs/styles/landing.css
+++ b/mlsysim/docs/styles/landing.css
@@ -776,6 +776,91 @@ a.im-tutorial-card-link:hover .im-tutorial-card h4 {
   color: #94a3b8;
 }
 
+[data-bs-theme="dark"] .im-section div.sourceCode,
+[data-bs-theme="dark"] .im-section pre {
+  background: #0f172a !important;
+  border: 1px solid #334155 !important;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+}
+
+[data-bs-theme="dark"] .im-section pre.sourceCode,
+[data-bs-theme="dark"] .im-section pre code {
+  background: transparent !important;
+  color: #e2e8f0 !important;
+}
+
+[data-bs-theme="dark"] .im-section code:not(.im-cmd) {
+  background: rgba(148, 163, 184, 0.14) !important;
+  color: #7dd3fc !important;
+}
+
+[data-bs-theme="dark"] .im-section .sourceCode .kw,
+[data-bs-theme="dark"] .im-section .sourceCode .cf,
+[data-bs-theme="dark"] .im-section .sourceCode .im {
+  color: #c084fc !important;
+}
+
+[data-bs-theme="dark"] .im-section .sourceCode .st,
+[data-bs-theme="dark"] .im-section .sourceCode .vs,
+[data-bs-theme="dark"] .im-section .sourceCode .ss {
+  color: #86efac !important;
+}
+
+[data-bs-theme="dark"] .im-section .sourceCode .dv,
+[data-bs-theme="dark"] .im-section .sourceCode .bn,
+[data-bs-theme="dark"] .im-section .sourceCode .fl {
+  color: #fbbf24 !important;
+}
+
+[data-bs-theme="dark"] .im-section .sourceCode .co {
+  color: #94a3b8 !important;
+}
+
+[data-bs-theme="dark"] .im-section .sourceCode .fu,
+[data-bs-theme="dark"] .im-section .sourceCode .va {
+  color: #7dd3fc !important;
+}
+
+[data-bs-theme="dark"] .im-section .references,
+[data-bs-theme="dark"] .im-section #refs,
+[data-bs-theme="dark"] .im-section .csl-entry,
+[data-bs-theme="dark"] .im-section .hanging-indent {
+  color: #cbd5e1 !important;
+}
+
+[data-bs-theme="dark"] .im-section .references a,
+[data-bs-theme="dark"] .im-section #refs a,
+[data-bs-theme="dark"] .im-section .csl-entry a {
+  color: #7dd3fc !important;
+}
+
+[data-bs-theme="dark"] #quarto-appendix,
+[data-bs-theme="dark"] #quarto-bibliography,
+[data-bs-theme="dark"] #quarto-appendix .quarto-appendix-contents {
+  background: #1a1a1a !important;
+  color: #cbd5e1 !important;
+}
+
+[data-bs-theme="dark"] #quarto-bibliography .quarto-appendix-heading,
+[data-bs-theme="dark"] #quarto-appendix h2,
+[data-bs-theme="dark"] #quarto-appendix h3 {
+  color: #e2e8f0 !important;
+}
+
+[data-bs-theme="dark"] #quarto-bibliography #refs,
+[data-bs-theme="dark"] #quarto-bibliography .references,
+[data-bs-theme="dark"] #quarto-bibliography .csl-entry,
+[data-bs-theme="dark"] #quarto-bibliography .csl-left-margin,
+[data-bs-theme="dark"] #quarto-bibliography .csl-right-inline,
+[data-bs-theme="dark"] #quarto-bibliography .csl-indent {
+  color: #cbd5e1 !important;
+}
+
+[data-bs-theme="dark"] #quarto-bibliography a,
+[data-bs-theme="dark"] #quarto-bibliography .csl-entry a {
+  color: #7dd3fc !important;
+}
+
 [data-bs-theme="dark"] .im-question {
   background: #1e293b;
   border-color: #334155;


### PR DESCRIPTION
## Summary
- fix dark-mode styling for code blocks on the MLSysim landing page
- fix dark-mode styling for the root-page bibliography appendix and reference links
- keep the local mlsysim/docs/_quarto.yml preview workaround out of this PR

Before:
<img width="842" height="516" alt="Screenshot 2026-05-13 164314" src="https://github.com/user-attachments/assets/2e8f0c0c-3199-48bb-8bd4-4d3f72a8773d" />

<img width="821" height="392" alt="Screenshot 2026-05-13 164326" src="https://github.com/user-attachments/assets/e2b12e17-08d7-4e74-bbf2-3022b182714f" />

<img width="1436" height="146" alt="Screenshot 2026-05-13 164333" src="https://github.com/user-attachments/assets/e6ebd6b6-b125-4459-8c81-f681c5d3687e" />

**After:**

<img width="1080" height="629" alt="Screenshot 2026-05-13 164349" src="https://github.com/user-attachments/assets/fc25981e-f6a3-4cbf-b1b8-c72597dc06a6" />

<img width="1039" height="476" alt="Screenshot 2026-05-13 164402" src="https://github.com/user-attachments/assets/0e717eb7-9aa4-45d1-83b5-d2d308384b85" />

<img width="1901" height="204" alt="Screenshot 2026-05-13 164414" src="https://github.com/user-attachments/assets/d9902305-83a1-4092-a85f-e7a96d43e39a" />



## Testing
- verified the MLSysim Quarto preview responds locally on http://127.0.0.1:4210/
- confirmed the dark-mode CSS is served by the live preview
- confirmed the commit only includes mlsysim/docs/styles/landing.css