### PR TITLE
Fix MLSysim docs inline code dark mode

### DIFF
--- a/mlsysim/docs/styles/dark-mode.scss
+++ b/mlsysim/docs/styles/dark-mode.scss
@@ -209,6 +209,33 @@ pre code {
   padding: 0;
 }
 
+// Inline code needs a stronger selector than Quarto/Bootstrap defaults on
+// content-heavy docs pages like getting-started.html.
+p code,
+li code,
+td code,
+th code,
+.callout code,
+.callout-body code,
+.table code,
+.content code,
+main code,
+article code,
+#quarto-content code {
+  background-color: #2c2c2c !important;
+  color: #7dd3fc !important;
+  border: 1px solid #454d55;
+  border-radius: 4px;
+}
+
+pre code,
+div.sourceCode code,
+code.sourceCode {
+  background-color: transparent !important;
+  border: none !important;
+  color: #e6e6e6 !important;
+}
+
 // Figures and captions
 .figure-caption,
 .caption,


### PR DESCRIPTION
## Summary
- fix dark-mode styling for inline code across MLSysim docs pages
- use stronger selectors for inline code in content, tables, and callouts
- keep local preview-only _quarto.yml and generated notebook artifacts out of the PR

**Before**:

<img width="687" height="647" alt="Screenshot 2026-05-13 165818" src="https://github.com/user-attachments/assets/9eed33a7-cf52-4f06-ad69-a2bb402d3298" />

**After**:

<img width="743" height="707" alt="Screenshot 2026-05-13 165810" src="https://github.com/user-attachments/assets/9a47d116-6606-496a-bc94-efbb5b2e6129" />


## Testing
- verified the MLSysim preview remains available at http://127.0.0.1:4210/
- confirmed the inline code contrast issue is resolved across getting-started and similar docs pages
- confirmed the commit only includes mlsysim/docs/styles/dark-mode.scss