### PR TITLE
Fix MLSysim bibliography dark mode

### DIFF
--- a/mlsysim/docs/styles/dark-mode.scss
+++ b/mlsysim/docs/styles/dark-mode.scss
@@ -216,6 +216,34 @@ figure figcaption {
   color: #c0c0c0 !important;
 }
 
+// Bibliography / appendix references
+#quarto-appendix,
+#quarto-bibliography,
+#quarto-appendix .quarto-appendix-contents {
+  background-color: $body-bg-dark !important;
+  color: #cbd5e1 !important;
+}
+
+#quarto-bibliography .quarto-appendix-heading,
+#quarto-appendix h2,
+#quarto-appendix h3 {
+  color: #e6e6e6 !important;
+}
+
+#quarto-bibliography #refs,
+#quarto-bibliography .references,
+#quarto-bibliography .csl-entry,
+#quarto-bibliography .csl-left-margin,
+#quarto-bibliography .csl-right-inline,
+#quarto-bibliography .csl-indent {
+  color: #cbd5e1 !important;
+}
+
+#quarto-bibliography a,
+#quarto-bibliography .csl-entry a {
+  color: #7dd3fc !important;
+}
+
 // Navbar
 .navbar {
   background-color: $navbar-bg-dark !important;


### PR DESCRIPTION
## Summary
- fix dark-mode styling for Quarto bibliography and references appendices across MLSysim docs pages
- style bibliography headings, entries, and links for the shared dark theme
- keep local preview-only _quarto.yml and generated notebook artifacts out of the PR

## Testing
- verified the MLSysim preview remains available at http://127.0.0.1:4210/
- confirmed the References section on /zoo/fleets.html is readable in dark mode
- confirmed the commit only includes mlsysim/docs/styles/dark-mode.scss