### PR TITLE
Fix navbar dropdown styling

### DIFF
--- a/mlsysim/docs/styles/dark-mode.scss
+++ b/mlsysim/docs/styles/dark-mode.scss
@@ -289,6 +289,31 @@ figure figcaption {
   }
 }
 
+// Navbar dropdowns
+.navbar .dropdown-menu {
+  background-color: #212529 !important;
+  border: 1px solid $border-color-dark !important;
+  box-shadow: 0 0.75rem 1.5rem rgba(0, 0, 0, 0.35);
+}
+
+.navbar .dropdown-item,
+.navbar .dropdown-menu a,
+.navbar .dropdown-header {
+  color: #e6e6e6 !important;
+}
+
+.navbar .dropdown-item:hover,
+.navbar .dropdown-item:focus,
+.navbar .dropdown-menu a:hover,
+.navbar .dropdown-menu a:focus {
+  color: #ffffff !important;
+  background-color: rgba($mlsysim-accent-dark, 0.18) !important;
+}
+
+.navbar .dropdown-divider {
+  border-top-color: $border-color-dark !important;
+}
+
 // Dark mode toggle - sun icon
 .quarto-color-scheme-toggle {
   color: #adb5bd !important;


### PR DESCRIPTION
Summary
Fix the MLSysim dark-mode navbar dropdown so menu items remain readable and the dropdown matches the rest of the dark theme.

Changes

- add explicit dark-mode styles for navbar dropdown menus
- set readable dropdown text colors in dark mode
- add hover/focus and divider styling for dropdown items

Before:
<img width="355" height="210" alt="Screenshot 2026-05-16 100008" src="https://github.com/user-attachments/assets/e621a2c9-2065-41f8-b41d-b2f6bf44bd25" />

After:

<img width="418" height="297" alt="Screenshot 2026-05-16 100014" src="https://github.com/user-attachments/assets/b0627b8b-23ec-431c-ab3c-9017324a709b" />

