### PR TITLE
fix(book): add body.quarto-dark selectors to video-enhanced.css dark mode

### DIFF
--- a/book/quarto/assets/styles/video-enhanced.css
+++ b/book/quarto/assets/styles/video-enhanced.css
@@ -167,6 +167,7 @@
 }
 
 /* Dark Mode Support */
+/* Both selectors required: @media for OS preference, body.quarto-dark for Quarto toggle */
 @media (prefers-color-scheme: dark) {
   .video-enhanced-container {
     background: linear-gradient(135deg, #2c3e50 0%, #34495e 100%);
@@ -185,4 +186,22 @@
     background: rgba(44, 62, 80, 0.8);
     color: #ecf0f1;
   }
+}
+
+body.quarto-dark .video-enhanced-container {
+  background: linear-gradient(135deg, #2c3e50 0%, #34495e 100%);
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+body.quarto-dark .video-header h4 {
+  color: #ecf0f1;
+}
+
+body.quarto-dark .video-meta {
+  color: #bdc3c7;
+}
+
+body.quarto-dark .video-description {
+  background: rgba(44, 62, 80, 0.8);
+  color: #ecf0f1;
 }


### PR DESCRIPTION
## Bug

Video component containers do not apply dark styling when the reader uses Quarto's **manual dark mode toggle button**.

`video-enhanced.css` used only `@media (prefers-color-scheme: dark)` for its dark mode rules. The toggle button adds `body.quarto-dark` to the body element -- not a media query -- so OS-light users who toggle dark mode see video components rendered with light-mode styles (light gradient background, dark text) against a dark page.

## Fix

Duplicate the dark mode rules under `body.quarto-dark` selectors directly below the existing `@media` block. Both mechanisms now cover the same visual states:

- `@media (prefers-color-scheme: dark)` -- OS-level system preference
- `body.quarto-dark` -- Quarto manual toggle

## Test plan

- [ ] Open a page containing a `video-enhanced-container` with OS in light mode
- [ ] Click the dark mode toggle -- verify video container switches to dark gradient and light text
- [ ] Toggle back to light -- verify video container returns to light styling