### PR TITLE
fix(404): support Quarto dark mode toggle on all 404 pages

### DIFF
--- a/book/quarto/404.qmd
+++ b/book/quarto/404.qmd
@@ -39,6 +39,16 @@ title: "Page Not Found"
   .j404-nav a { color: #aaa !important; }
   .j404-nav a:hover { color: #ff6b80 !important; }
 }
+body.quarto-dark .j404-joke { color: #f0f0f0; }
+body.quarto-dark .j404-sub { color: #aaa; }
+body.quarto-dark .j404-btn-secondary { background: transparent !important; color: #f0f0f0 !important; border-color: #444; }
+body.quarto-dark .j404-btn-secondary:hover { border-color: #ff6b80 !important; color: #ff6b80 !important; }
+body.quarto-dark .j404-refresh { color: #999; }
+body.quarto-dark .j404-refresh:hover { color: #ff6b80 !important; }
+body.quarto-dark .j404-meta-sep { color: #555; }
+body.quarto-dark .j404-nav { border-top-color: #333; }
+body.quarto-dark .j404-nav a { color: #aaa !important; }
+body.quarto-dark .j404-nav a:hover { color: #ff6b80 !important; }
 </style>
 
 <div class="j404-wrap">

--- a/instructors/404.qmd
+++ b/instructors/404.qmd
@@ -39,6 +39,16 @@ title: "Page Not Found"
   .j404-nav a { color: #aaa !important; }
   .j404-nav a:hover { color: #ff6b80 !important; }
 }
+body.quarto-dark .j404-joke { color: #f0f0f0; }
+body.quarto-dark .j404-sub { color: #aaa; }
+body.quarto-dark .j404-btn-secondary { background: transparent !important; color: #f0f0f0 !important; border-color: #444; }
+body.quarto-dark .j404-btn-secondary:hover { border-color: #ff6b80 !important; color: #ff6b80 !important; }
+body.quarto-dark .j404-refresh { color: #999; }
+body.quarto-dark .j404-refresh:hover { color: #ff6b80 !important; }
+body.quarto-dark .j404-meta-sep { color: #555; }
+body.quarto-dark .j404-nav { border-top-color: #333; }
+body.quarto-dark .j404-nav a { color: #aaa !important; }
+body.quarto-dark .j404-nav a:hover { color: #ff6b80 !important; }
 </style>
 
 <div class="j404-wrap">

--- a/kits/404.qmd
+++ b/kits/404.qmd
@@ -47,6 +47,20 @@ title: "Page Not Found"
   .j404-nav a { color: #aaa !important; }
   .j404-nav a:hover { color: #ff6b80 !important; }
 }
+body.quarto-dark .j404-joke { color: #f0f0f0; }
+body.quarto-dark .j404-sub { color: #aaa; }
+body.quarto-dark .j404-btn-secondary { background: transparent !important; color: #f0f0f0 !important; border-color: #444; }
+body.quarto-dark .j404-btn-secondary:hover { border-color: #ff6b80 !important; color: #ff6b80 !important; }
+body.quarto-dark .j404-refresh { color: #999; }
+body.quarto-dark .j404-refresh:hover { color: #ff6b80 !important; }
+body.quarto-dark .j404-meta-sep { color: #555; }
+body.quarto-dark .j404-kits-row { color: #aaa; }
+body.quarto-dark .j404-kits-row a { color: #aaa !important; }
+body.quarto-dark .j404-kits-row a:hover { color: #ff6b80 !important; }
+body.quarto-dark .j404-kits-row span { color: #555; }
+body.quarto-dark .j404-nav { border-top-color: #333; }
+body.quarto-dark .j404-nav a { color: #aaa !important; }
+body.quarto-dark .j404-nav a:hover { color: #ff6b80 !important; }
 </style>
 
 <div class="j404-wrap">

--- a/labs/404.qmd
+++ b/labs/404.qmd
@@ -39,6 +39,16 @@ title: "Page Not Found"
   .j404-nav a { color: #aaa !important; }
   .j404-nav a:hover { color: #ff6b80 !important; }
 }
+body.quarto-dark .j404-joke { color: #f0f0f0; }
+body.quarto-dark .j404-sub { color: #aaa; }
+body.quarto-dark .j404-btn-secondary { background: transparent !important; color: #f0f0f0 !important; border-color: #444; }
+body.quarto-dark .j404-btn-secondary:hover { border-color: #ff6b80 !important; color: #ff6b80 !important; }
+body.quarto-dark .j404-refresh { color: #999; }
+body.quarto-dark .j404-refresh:hover { color: #ff6b80 !important; }
+body.quarto-dark .j404-meta-sep { color: #555; }
+body.quarto-dark .j404-nav { border-top-color: #333; }
+body.quarto-dark .j404-nav a { color: #aaa !important; }
+body.quarto-dark .j404-nav a:hover { color: #ff6b80 !important; }
 </style>
 
 <div class="j404-wrap">

--- a/mlsysim/docs/404.qmd
+++ b/mlsysim/docs/404.qmd
@@ -41,6 +41,16 @@ page-layout: custom
   .j404-nav a { color: #aaa !important; }
   .j404-nav a:hover { color: #ff6b80 !important; }
 }
+body.quarto-dark .j404-joke { color: #f0f0f0; }
+body.quarto-dark .j404-sub { color: #aaa; }
+body.quarto-dark .j404-btn-secondary { background: transparent !important; color: #f0f0f0 !important; border-color: #444; }
+body.quarto-dark .j404-btn-secondary:hover { border-color: #ff6b80 !important; color: #ff6b80 !important; }
+body.quarto-dark .j404-refresh { color: #999; }
+body.quarto-dark .j404-refresh:hover { color: #ff6b80 !important; }
+body.quarto-dark .j404-meta-sep { color: #555; }
+body.quarto-dark .j404-nav { border-top-color: #333; }
+body.quarto-dark .j404-nav a { color: #aaa !important; }
+body.quarto-dark .j404-nav a:hover { color: #ff6b80 !important; }
 </style>
 
 <div class="j404-wrap">

--- a/site/404.qmd
+++ b/site/404.qmd
@@ -129,6 +129,16 @@ format:
   .j404-nav a { color: #aaa !important; }
   .j404-nav a:hover { color: #ff6b80 !important; }
 }
+body.quarto-dark .j404-joke { color: #f0f0f0; }
+body.quarto-dark .j404-sub { color: #aaa; }
+body.quarto-dark .j404-btn-secondary { background: transparent !important; color: #f0f0f0 !important; border-color: #444; }
+body.quarto-dark .j404-btn-secondary:hover { border-color: #ff6b80 !important; color: #ff6b80 !important; }
+body.quarto-dark .j404-refresh { color: #999; }
+body.quarto-dark .j404-refresh:hover { color: #ff6b80 !important; }
+body.quarto-dark .j404-meta-sep { color: #555; }
+body.quarto-dark .j404-nav { border-top-color: #333; }
+body.quarto-dark .j404-nav a { color: #aaa !important; }
+body.quarto-dark .j404-nav a:hover { color: #ff6b80 !important; }
 </style>
 
 <div class="j404-wrap">

--- a/slides/404.qmd
+++ b/slides/404.qmd
@@ -39,6 +39,16 @@ title: "Slide Not Found"
   .j404-nav a { color: #aaa !important; }
   .j404-nav a:hover { color: #ff6b80 !important; }
 }
+body.quarto-dark .j404-joke { color: #f0f0f0; }
+body.quarto-dark .j404-sub { color: #aaa; }
+body.quarto-dark .j404-btn-secondary { background: transparent !important; color: #f0f0f0 !important; border-color: #444; }
+body.quarto-dark .j404-btn-secondary:hover { border-color: #ff6b80 !important; color: #ff6b80 !important; }
+body.quarto-dark .j404-refresh { color: #999; }
+body.quarto-dark .j404-refresh:hover { color: #ff6b80 !important; }
+body.quarto-dark .j404-meta-sep { color: #555; }
+body.quarto-dark .j404-nav { border-top-color: #333; }
+body.quarto-dark .j404-nav a { color: #aaa !important; }
+body.quarto-dark .j404-nav a:hover { color: #ff6b80 !important; }
 </style>
 
 <div class="j404-wrap">

--- a/tinytorch/quarto/404.qmd
+++ b/tinytorch/quarto/404.qmd
@@ -40,6 +40,16 @@ search: false
   .j404-nav a { color: #aaa !important; }
   .j404-nav a:hover { color: #ff6b80 !important; }
 }
+body.quarto-dark .j404-joke { color: #f0f0f0; }
+body.quarto-dark .j404-sub { color: #aaa; }
+body.quarto-dark .j404-btn-secondary { background: transparent !important; color: #f0f0f0 !important; border-color: #444; }
+body.quarto-dark .j404-btn-secondary:hover { border-color: #ff6b80 !important; color: #ff6b80 !important; }
+body.quarto-dark .j404-refresh { color: #999; }
+body.quarto-dark .j404-refresh:hover { color: #ff6b80 !important; }
+body.quarto-dark .j404-meta-sep { color: #555; }
+body.quarto-dark .j404-nav { border-top-color: #333; }
+body.quarto-dark .j404-nav a { color: #aaa !important; }
+body.quarto-dark .j404-nav a:hover { color: #ff6b80 !important; }
 </style>
 
 <div class="j404-wrap">


### PR DESCRIPTION
## Problem

All 8 x 404.qmd files style their dark mode content using only `@media (prefers-color-scheme: dark)`. This responds to the OS-level dark preference but does **not** respond to the Quarto dark mode toggle button, which works by adding `body.quarto-dark` to the document body instead of setting the OS preference.

This means users who click the toggle button to switch to dark mode see the 404 pages stay in light mode.

## Fix

For each of the 8 files, added `body.quarto-dark` selector blocks immediately after the `@media (prefers-color-scheme: dark)` block, with identical rules. Both mechanisms now work independently -- OS dark preference still works, and the Quarto toggle button also works.

## Files changed

- `book/quarto/404.qmd`
- `instructors/404.qmd`
- `labs/404.qmd`
- `slides/404.qmd`
- `tinytorch/quarto/404.qmd`
- `kits/404.qmd` (includes kits-specific `.j404-kits-row` rules in the `body.quarto-dark` block)
- `mlsysim/docs/404.qmd`
- `site/404.qmd`