### PR TITLE
fix(site): dark mode for nav-footer, dropdown-menu, and star-history image

### DIFF
--- a/shared/config/footer-site.yml
+++ b/shared/config/footer-site.yml
@@ -20,5 +20,5 @@ website:
       - icon: github
         href: https://github.com/harvard-edge/cs249r_book
         aria-label: "View source on GitHub"
-    background: light
+    background: none
     border: true

--- a/shared/styles/_site-dark.scss
+++ b/shared/styles/_site-dark.scss
@@ -143,10 +143,44 @@ table {
 }
 
 // Footer dark mode
-.page-footer {
-  background-color: #212529;
-  border-top-color: #454d55;
+// Quarto renders the footer as .nav-footer; .page-footer is the SCSS variable name.
+// Both selectors are needed so the footer background is dark regardless of which
+// class Quarto generates.
+.page-footer,
+.nav-footer {
+  background-color: #212529 !important;
+  border-top-color: #454d55 !important;
   color: #adb5bd;
+
+  a {
+    color: #adb5bd !important;
+    &:hover { color: $accent-dark !important; }
+  }
+}
+
+// Navbar dropdown menus dark mode
+.navbar .dropdown-menu,
+.dropdown-menu {
+  background-color: #252525 !important;
+  border-color: #454d55 !important;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.4) !important;
+}
+
+.navbar .dropdown-item,
+.dropdown-menu .dropdown-item {
+  color: #d1d5db !important;
+  background-color: transparent !important;
+
+  &:hover,
+  &:focus {
+    color: $accent-dark !important;
+    background-color: rgba(165, 28, 48, 0.12) !important;
+  }
+}
+
+.navbar .dropdown-divider,
+.dropdown-menu .dropdown-divider {
+  border-top-color: #454d55 !important;
 }
 
 // Buttons

--- a/site/about/index.qmd
+++ b/site/about/index.qmd
@@ -63,12 +63,30 @@ It started with one course at one university in 2020. Within two years, ten univ
 ```{=html}
 <div style="text-align: center; margin: 1.5rem 0 2rem; background: var(--ab-card-bg); border: 1px solid var(--ab-border); border-radius: 12px; padding: 1.5rem;">
   <a href="https://www.star-history.com/?repos=harvard-edge%2Fcs249r_book&type=date&legend=top-left" target="_blank" rel="noopener">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=harvard-edge/cs249r_book&type=date&theme=dark&legend=top-left" />
-      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=harvard-edge/cs249r_book&type=date&legend=top-left" />
-      <img src="https://api.star-history.com/image?repos=harvard-edge/cs249r_book&type=date&legend=top-left" alt="GitHub star growth chart showing adoption over time" style="max-width: 550px; width: 100%; border-radius: 6px;" loading="lazy" />
-    </picture>
+    <img id="star-history-img"
+         src="https://api.star-history.com/image?repos=harvard-edge/cs249r_book&type=date&legend=top-left"
+         alt="GitHub star growth chart showing adoption over time"
+         style="max-width: 550px; width: 100%; border-radius: 6px;"
+         loading="lazy" />
   </a>
+  <script>
+  (function () {
+    var DARK_SRC  = "https://api.star-history.com/image?repos=harvard-edge/cs249r_book&type=date&theme=dark&legend=top-left";
+    var LIGHT_SRC = "https://api.star-history.com/image?repos=harvard-edge/cs249r_book&type=date&legend=top-left";
+    var img = document.getElementById("star-history-img");
+    function syncSrc() {
+      if (!img) return;
+      img.src = document.body.classList.contains("quarto-dark") ? DARK_SRC : LIGHT_SRC;
+    }
+    syncSrc();
+    var observer = new MutationObserver(function (mutations) {
+      mutations.forEach(function (m) {
+        if (m.attributeName === "class") syncSrc();
+      });
+    });
+    observer.observe(document.body, { attributes: true, attributeFilter: ["class"] });
+  })();
+  </script>
   <p style="color: var(--ab-text-muted); font-size: 0.85rem; margin: 1rem 0 0;">Everything here is free — our only ask is a <a href="https://github.com/harvard-edge/cs249r_book" target="_blank" rel="noopener" style="color: var(--ab-accent); font-weight: 600;">⭐ star on GitHub</a>. It tells universities, publishers, and funders that AI engineering education matters.</p>
 </div>
 </div>


### PR DESCRIPTION
## Summary

- **Footer stays white in dark mode** (toggle path): `footer-site.yml` set `background: light` which pins Bootstrap's `bg-light` class on the `.nav-footer` element regardless of theme. Changed to `background: none` so the CSS dark override can apply.
- **`.nav-footer` missing from `_site-dark.scss`**: Added `.nav-footer` alongside `.page-footer` with `!important` dark background/border so the Quarto-rendered footer element goes dark when the toggle is active.
- **`.dropdown-menu` stays white in dark mode**: Added `.dropdown-menu` and `.dropdown-item` dark overrides in `_site-dark.scss` for the site pages (community, about, newsletter, landing). The site dark file previously had no dropdown styling at all.
- **Star-history `<picture>` element ignores Quarto toggle**: The `<picture>` element in `site/about/index.qmd` used `media="(prefers-color-scheme: dark)"` which only reads OS preference. Replaced with a single `<img>` whose `src` is swapped via a `MutationObserver` on `document.body.classList` -- same pattern used elsewhere in the ecosystem.

## Files changed

- `shared/styles/_site-dark.scss` -- add `.nav-footer` + dropdown dark selectors
- `shared/config/footer-site.yml` -- change `background: light` to `background: none`
- `site/about/index.qmd` -- replace `<picture>` with JS `MutationObserver` img swap

## Instructors audit findings

No new bugs found in `instructors/` that are not already covered:
- `instructors/404.qmd` already has `body.quarto-dark` selectors alongside its `@media` block.
- `instructors/foundations-syllabus.qmd` lab subtitle fixes (labs 09-15) are already present in local `dev` -- identical to `fork/fix/instructors-lab-subtitle-mismatch`.
- `instructors/assets/styles/dark-mode.scss` handles dark mode via SCSS dark theme file (loaded as Quarto dark theme layer), not via `@media` -- correct pattern.
- `site/about/about.css` and `site/community/community.css` already use `.quarto-dark` CSS custom property overrides with no `@media (prefers-color-scheme)` blocks -- no fix needed.

## Test plan

- [ ] Toggle dark mode on `mlsysbook.ai/about/` -- footer background should go dark
- [ ] Open a navbar dropdown in dark mode -- menu background should be dark (#252525)
- [ ] Toggle dark mode on the star-history chart section -- image should swap to dark variant without page reload
- [ ] Toggle back to light -- image should swap back to light variant