### PR TITLE
fix(tinytorch): correct MatmulBackward gradients for 1D vector inputs

### DIFF
--- a/tinytorch/src/06_autograd/06_autograd.py
+++ b/tinytorch/src/06_autograd/06_autograd.py
@@ -966,21 +966,25 @@ class MatmulBackward(Function):
 
         # Gradient for first input: grad_output @ b.T
         if isinstance(a, Tensor) and a.requires_grad:
-            # For batched tensors, transpose only last two dims
             if b.data.ndim >= 2:
+                # Batched: transpose only the last two dims
                 b_T = np.swapaxes(b.data, -2, -1)
+                grad_a = np.matmul(grad_output, b_T)
             else:
-                b_T = b.data.T
-            grad_a = np.matmul(grad_output, b_T)
+                # 1D b: A(m,k) @ b(k,) -> out(m,)
+                # grad_A = outer(grad_output, b): (m,) x (k,) -> (m, k)
+                grad_a = np.outer(grad_output, b.data)
 
         # Gradient for second input: a.T @ grad_output
         if isinstance(b, Tensor) and b.requires_grad:
-            # For batched tensors, transpose only last two dims
             if a.data.ndim >= 2:
+                # Batched: transpose only the last two dims
                 a_T = np.swapaxes(a.data, -2, -1)
+                grad_b = np.matmul(a_T, grad_output)
             else:
-                a_T = a.data.T
-            grad_b = np.matmul(a_T, grad_output)
+                # 1D a: a(k,) @ B(k,n) -> out(n,)
+                # grad_B = outer(a, grad_output): (k,) x (n,) -> (k, n)
+                grad_b = np.outer(a.data, grad_output)
 
         return grad_a, grad_b
         ### END SOLUTION


### PR DESCRIPTION
## Summary

- Fixes a correctness bug in `MatmulBackward.apply()` in `tinytorch/src/06_autograd/06_autograd.py` where gradient computation was wrong when input `B` is a 1D vector.

## Bug Details

**Root cause**: When `B` is 1D with shape `(k,)`, NumPy's `.T` is a no-op (1D arrays have no second axis to swap). The old code then called `np.matmul(grad_output, b.data)` which either raises a shape error (when `m != k`) or silently computes a dot product returning a scalar (when `m == k`) instead of the correct `(m, k)` gradient matrix.

**Correct math**: For `A(m,k) @ b(k,)` -> `out(m,)`:
- `grad_A = np.outer(grad_output, b)` -- shape `(m, k)` (was broken)
- `grad_b = a.T @ grad_output` -- shape `(k,)` (was broken for 1D `a`)

The symmetric case (1D `a` with 2D `B`) is also fixed using `np.outer(a, grad_output)`.

The 2D+ batched path using `np.swapaxes` is preserved unchanged and correct.

## Test plan

- [ ] Verify `MatmulBackward` with `A(m,k) @ b(k,)` produces `grad_A` of shape `(m, k)` and `grad_b` of shape `(k,)`
- [ ] Verify existing 2D matmul test (`A(2,2) @ B(2,2)`) still passes
- [ ] Verify batched matmul (3D inputs) still passes
- [ ] Run `tinytorch` test suite: `pytest tinytorch/tests/`