### PR TITLE
fix(kits): correct Pi power specs, Pi Zero 2W CPU, and Nicla Vision memory

### DIFF
--- a/shared/config/footer-site.yml
+++ b/shared/config/footer-site.yml
@@ -20,5 +20,5 @@ website:
       - icon: github
         href: https://github.com/harvard-edge/cs249r_book
         aria-label: "View source on GitHub"
-    background: light
+    background: none
     border: true

--- a/shared/styles/_site-dark.scss
+++ b/shared/styles/_site-dark.scss
@@ -143,10 +143,44 @@ table {
 }
 
 // Footer dark mode
-.page-footer {
-  background-color: #212529;
-  border-top-color: #454d55;
+// Quarto renders the footer as .nav-footer; .page-footer is the SCSS variable name.
+// Both selectors are needed so the footer background is dark regardless of which
+// class Quarto generates.
+.page-footer,
+.nav-footer {
+  background-color: #212529 !important;
+  border-top-color: #454d55 !important;
   color: #adb5bd;
+
+  a {
+    color: #adb5bd !important;
+    &:hover { color: $accent-dark !important; }
+  }
+}
+
+// Navbar dropdown menus dark mode
+.navbar .dropdown-menu,
+.dropdown-menu {
+  background-color: #252525 !important;
+  border-color: #454d55 !important;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.4) !important;
+}
+
+.navbar .dropdown-item,
+.dropdown-menu .dropdown-item {
+  color: #d1d5db !important;
+  background-color: transparent !important;
+
+  &:hover,
+  &:focus {
+    color: $accent-dark !important;
+    background-color: rgba(165, 28, 48, 0.12) !important;
+  }
+}
+
+.navbar .dropdown-divider,
+.dropdown-menu .dropdown-divider {
+  border-top-color: #454d55 !important;
 }
 
 // Buttons


### PR DESCRIPTION
## Summary

Hardware specification bugs found during kits/ content audit:

- **raspi.qmd**: Power adapter specs listed in watts instead of volts/amps. Pi 4 and Pi 5 were combined as one line with an incorrect 3.5W figure; corrected to separate lines: Pi Zero 2W (5V/2.5A), Pi 4 (5V/3A), Pi 5 (5V/5A).
- **raspi/setup.qmd**: Raspberry Pi Zero 2 W listed as "single-core" in the key specs summary. It is quad-core Cortex-A53 (consistent with the hardware spec table in the same file at line 64, which was already correct).
- **platforms.qmd**: Arduino Nicla Vision memory listed as "2MB integrated RAM and 16MB Flash". The STM32H747 has 1 MB SRAM and 2 MB on-chip flash; the 16 MB is external QSPI Flash. Corrected to "1MB integrated SRAM and 2MB Flash storage, plus 16MB external QSPI Flash".

## Scope

- No bugs found in labs/vol1/lab_08 through lab_16 answer keys or formula outputs.
- Already-fixed issues (fix/kits-cifar10-tflite-size-typo, fix/lab13-cold-start-answer, fix/lab14-debt-multiplier-answer) were not touched.

## Test plan

- [ ] Verify rendered kits/ hardware spec tables match official Raspberry Pi Foundation and Arduino product pages
- [ ] Confirm raspi/setup.qmd line 31 now reads "quad-core" (consistent with line 64)
- [ ] Confirm platforms.qmd Nicla Vision memory entry distinguishes SRAM from flash