### PR TITLE
fix(staffml): make mobile ecosystem nav menu scroll internally

### DIFF
--- a/interviews/staffml/src/components/EcosystemBar.tsx
+++ b/interviews/staffml/src/components/EcosystemBar.tsx
@@ -565,7 +565,29 @@ export default function EcosystemBar() {
 
       {/* Mobile expanded */}
       {mobileOpen && (
-        <div className="nav-lg:hidden" style={{ borderTop: `1px solid ${borderColor}`, backgroundColor: bgColor, padding: '12px 16px' }}>
+        <div
+          className="nav-lg:hidden"
+          style={{
+            borderTop: `1px solid ${borderColor}`,
+            backgroundColor: bgColor,
+            padding: '12px 16px',
+            // Cap the menu at the remaining viewport height so it scrolls
+            // internally instead of pushing the whole sticky bar past the
+            // viewport. Without this, the menu's overflow content sits
+            // below the fold and the next touch-drag scrolls the PAGE
+            // (because the menu isn't its own scroll container) — items
+            // only became reachable after the bar released at the body
+            // bottom. 60 = the header row's minHeight; `dvh` (not `vh`)
+            // tracks the dynamic mobile viewport as the URL bar shows /
+            // hides so we don't clip the bottom on iOS Safari.
+            maxHeight: 'calc(100dvh - 60px)',
+            overflowY: 'auto',
+            // Prevent scroll-chaining: once the menu reaches its end, a
+            // continued swipe shouldn't start scrolling the page behind.
+            overscrollBehavior: 'contain',
+            WebkitOverflowScrolling: 'touch',
+          }}
+        >
           {LEFT_MENUS.map((menu) => (
             <div key={menu.id} style={{ marginBottom: 12 }}>
               <div style={{ fontSize: 10, fontWeight: 600, color: '#adb5bd', textTransform: 'uppercase' as const, letterSpacing: 1, marginBottom: 4 }}>


### PR DESCRIPTION
## Summary
- Mobile hamburger menu on the `EcosystemBar` lived inside a `position: sticky` parent with `overflow-y: visible`. Once the menu was taller than the viewport, the overflow items sat below the fold and a swipe scrolled the **page** instead of the menu — items only became reachable once the sticky bar released at the body bottom.
- Cap the expanded menu at `calc(100dvh - 60px)` with `overflow-y: auto` and `overscroll-behavior: contain` so the menu owns its own scroll and stops chaining swipes to the page.
- `dvh` (not `vh`) so the bottom of the menu doesn't get clipped on iOS Safari when the URL bar collapses.

Scoped to `interviews/staffml/src/components/EcosystemBar.tsx`. No behavior change for desktop (`nav-lg:hidden` gate is unchanged).

## Test plan
- [ ] Open the StaffML site on a phone (or DevTools mobile emulator) at a viewport short enough that the open hamburger menu exceeds it.
- [ ] Tap the hamburger on the top MLSysBook ecosystem bar.
- [ ] Swipe up/down inside the menu — the **menu** scrolls; the page behind it stays put.
- [ ] Reaching the bottom of the menu does not start scrolling the page (no overscroll-chain).
- [ ] Tall-viewport / desktop behavior is unchanged.