### PR TITLE
fix(book): wrap long URLs to stop horizontal page overflow

### DIFF
--- a/book/quarto/assets/styles/_base-styles.scss
+++ b/book/quarto/assets/styles/_base-styles.scss
@@ -271,6 +271,18 @@ a {
   color: $link-color;
   text-decoration: none;
 
+  // Long URLs (paper hashes, arXiv ids, DOI suffixes) are single
+  // unbreakable tokens. In narrow containers — bibliography lists,
+  // column-margin notes, footnotes, callouts — they widen the line box
+  // past the column, which then cascades into page-level horizontal
+  // overflow on the training (and other reference-heavy) chapters.
+  // `overflow-wrap: anywhere` (NOT `break-word`) is required: only
+  // `anywhere` shrinks the element's min-content size so flex/grid
+  // ancestors can actually narrow. Regular prose still breaks at word
+  // boundaries first; mid-token splits only kick in when nothing else
+  // fits.
+  overflow-wrap: anywhere;
+
   &:hover {
     color: $link-hover-color;
     text-decoration: underline;
@@ -474,6 +486,13 @@ nav[role="doc-toc"] {
   border-left: 3px solid $accent; // Keep the solid accent line
   padding-left: 1.5rem; // Good spacing from line to text
   margin-left: 0.5rem; // Additional breathing room
+
+  // Long section titles containing un-hyphenatable tokens (identifiers,
+  // arXiv refs, paths) inflate the TOC column's min-content width and
+  // push the page sideways. `overflow-wrap: anywhere` + `min-width: 0`
+  // lets the column actually narrow on the flex/grid parent.
+  min-width: 0;
+  overflow-wrap: anywhere;
 
   // Ensure header elements don't get extra bars
   h2,

--- a/shared/styles/partials/_links.scss
+++ b/shared/styles/partials/_links.scss
@@ -7,6 +7,18 @@ a {
   color: $link-color;
   text-decoration: none;
 
+  // Long URLs (bibliography hashes like
+  // `https://proceedings.neurips.cc/paper/2012/hash/6aca97005c68f1206823815f66102863-Abstract.html`,
+  // arXiv ids, DOI suffixes) are single unbreakable tokens. Inside narrow
+  // containers — the right-side margin / column-margin notes, footnote
+  // lists, callouts — they push the line box past the column width, which
+  // cascades into page-level horizontal overflow. `overflow-wrap: anywhere`
+  // (preferred over `break-word`: `anywhere` also shrinks min-content size,
+  // so the containing block can actually narrow on flex/grid parents). Safe
+  // global default: regular prose still breaks at word boundaries first and
+  // only falls back to mid-token splits when nothing else fits.
+  overflow-wrap: anywhere;
+
   &:hover {
     color: $link-hover-color;
     text-decoration: underline;

--- a/shared/styles/partials/_toc.scss
+++ b/shared/styles/partials/_toc.scss
@@ -13,6 +13,17 @@ nav[role="doc-toc"] {
   padding-left: 1.5rem; // Good spacing from line to text
   margin-left: 0.5rem; // Additional breathing room
 
+  // Long section titles (and headings containing un-hyphenatable strings like
+  // `arXiv:2310.06825` or `RoPE-Scaled`) were pushing TOC anchors past the
+  // right edge of the margin column, which in turn forced the whole page to
+  // scroll horizontally on narrower viewports. `overflow-wrap: anywhere`
+  // (NOT `break-word`) is required because only `anywhere` shrinks the
+  // column's min-content size — without that, the flex/grid parent still
+  // sees the long word's intrinsic width and refuses to shrink the column.
+  // `min-width: 0` lets the column actually take the smaller min-content.
+  min-width: 0;
+  overflow-wrap: anywhere;
+
   // Ensure TOC list is visible (Bootstrap collapse hides it by default)
   ul.collapse {
     display: block !important;
@@ -59,6 +70,11 @@ nav[role="doc-toc"] {
     display: block;
     padding: 0.2rem 0; // Slightly more padding
     transition: all 0.15s ease;
+    // Inherit wrapping behavior from the TOC root so any long, unbreakable
+    // token inside a heading (an identifier, a path, a URL) wraps inside the
+    // anchor box instead of widening the TOC column past the page bounds.
+    overflow-wrap: anywhere;
+    min-width: 0;
     border: none !important;
     border-left: none !important;
     border-right: none !important;


### PR DESCRIPTION
## Summary
On reference-heavy chapters (e.g. **vol1 training**), long unbreakable tokens — paper hashes (`https://proceedings.neurips.cc/paper/2012/hash/6aca97005c68f1206823815f66102863-Abstract.html`), arXiv ids, DOI suffixes — inside body links, column-margin notes, footnotes, callouts, and right-side TOC entries inflated the line box past their column width. That cascaded into **page-level horizontal scroll** on narrower viewports.

Fix: add `overflow-wrap: anywhere` to the global `a` rule and the TOC container so unbreakable tokens wrap inside their column instead of forcing the page wider.

### Where the change goes

- **`book/quarto/assets/styles/_base-styles.scss`** — the volume builds (vol1 + vol2) use this file. It carries duplicated TOC/link rules and does **not** import the shared partials, so the fix has to be applied here directly.
- **`shared/styles/partials/_links.scss`** and **`shared/styles/partials/_toc.scss`** — the corresponding shared partials, for ecosystem sites that do consume them (site, tinytorch, labs, kits, instructors, slides, mlsysim docs). Defensive parity so the same regression doesn't reappear in those builds later.

### Why `anywhere` (not `break-word`)
Only `overflow-wrap: anywhere` shrinks an element's **min-content size**, so flex/grid ancestors can actually narrow the column. `break-word` would still let the long URL define the column's min-content, and the overflow would persist on small viewports. Paired with `min-width: 0` on the TOC container so the column is allowed to take the smaller size. Regular prose still breaks at word boundaries first; mid-token splits only kick in when nothing else fits.

## Test plan
- [ ] Open the vol1 training chapter (`/vol1/contents/vol1/training/training.html`) on a narrow viewport (~375 px).
- [ ] Confirm no horizontal page scroll where the long neurips paper URL appears.
- [ ] Confirm long URLs in margin-notes, footnotes, callouts, and the right-side TOC wrap inside their column.
- [ ] Regular short links and prose look unchanged.
- [ ] Spot-check vol2 (uses the same `_base-styles.scss`).
- [ ] Spot-check an ecosystem Quarto site that consumes the shared partials (e.g. `site/`) for any regression.