### PR TITLE
fix(book): contain wide tables in their own scroll instead of widening the page

### DIFF
--- a/book/quarto/assets/styles/_base-styles.scss
+++ b/book/quarto/assets/styles/_base-styles.scss
@@ -266,6 +266,26 @@ figure figcaption {
   }
 }
 
+// Multi-column tables in reference-heavy chapters (e.g. vol1 training's
+// `tbl-optimization-roadmap`, `tbl-flashattention-benchmarks`) can have
+// text-heavy cells that exceed the body column width on narrow viewports
+// and force page-level horizontal scroll. Quarto wraps each table in a
+// `<div aria-describedby="…">` inside `<figure class="quarto-float-tbl">`
+// but does not make that wrapper scrollable, so the overflow propagates
+// up to the document. Scope `overflow-x: auto` to that wrapper so a wide
+// table scrolls inside its own box instead of widening the page.
+//
+// `max-width: 100%` is required because the inner table's intrinsic width
+// would otherwise stretch the wrapper itself. Together they keep the
+// wrapper exactly column-width and push the overflow into the table's
+// own scroll context.
+.quarto-float-tbl > div[aria-describedby],
+figure.quarto-float-tbl > div[aria-describedby] {
+  max-width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
 // Link styles
 a {
   color: $link-color;


### PR DESCRIPTION
## Summary
Multi-column tables in reference-heavy chapters (e.g. **vol1 training**'s `tbl-optimization-roadmap`, `tbl-flashattention-benchmarks`) have text-heavy cells that exceed the body column width on narrow viewports and force **page-level horizontal scroll**. Quarto wraps each table in a `<div aria-describedby="…">` inside `<figure class="quarto-float-tbl">`, but that wrapper isn't scrollable — the table's intrinsic width leaks out to the document and the whole page scrolls sideways.

Scope `overflow-x: auto` + `max-width: 100%` to the per-table wrapper so a wide table scrolls **inside its own box**. The page width stays bound to the viewport.

### Where the change goes
- **`book/quarto/assets/styles/_base-styles.scss`** — both vol1 and vol2 import this; the fix covers every table in the book.

### Notes
- Selector-based (`figure.quarto-float-tbl > div[aria-describedby]`) — applies to every table, not just `tbl-optimization-roadmap`, so the same regression can't reappear in another chapter later.
- Wide desktop layouts are unchanged: `overflow-x: auto` shows a scrollbar only when content actually overflows.
- Adds `-webkit-overflow-scrolling: touch` so iOS gets momentum scroll inside the table.

## Test plan
- [ ] Open vol1 training (`/vol1/contents/vol1/training/training.html`) on a narrow viewport (~375 px).
- [ ] Confirm the page itself no longer scrolls horizontally.
- [ ] Scroll to Table 6 (Optimization Technique Roadmap) — table scrolls inside its own box; page width stays at 100 vw.
- [ ] Same check for `tbl-flashattention-benchmarks` and any other wide multi-column table.
- [ ] Desktop viewport: no visible scrollbar appears on tables that fit (no regression).
- [ ] Spot-check vol2 for parity.