### PR TITLE
fix(staffml): reset QuestionVisual failed state on visual.path change

### DIFF
--- a/interviews/staffml/src/__tests__/question-visual.test.tsx
+++ b/interviews/staffml/src/__tests__/question-visual.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * Regression test — QuestionVisual resets its `failed` state when the
+ * visual.path prop changes.
+ *
+ * Bug: after one question's image errored (`onError` set failed=true), the
+ * component stayed in the error branch when the parent re-rendered with a
+ * different question's visual, because failed=true short-circuited before
+ * the new <img> could mount and clear the state.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, fireEvent, screen } from '@testing-library/react';
+import QuestionVisual from '@/components/QuestionVisual';
+
+const visualA = {
+  kind: 'svg' as const,
+  path: 'broken.svg',
+  alt: 'A broken diagram of cache hierarchies',
+  caption: 'Visual A',
+};
+
+const visualB = {
+  kind: 'svg' as const,
+  path: 'working.svg',
+  alt: 'A working diagram of attention heads',
+  caption: 'Visual B',
+};
+
+describe('QuestionVisual', () => {
+  it('shows the error UI after the image errors', () => {
+    render(<QuestionVisual track="cloud" visual={visualA} />);
+    const img = screen.getByTestId('question-visual-img') as HTMLImageElement;
+    fireEvent.error(img);
+    expect(screen.getByText(/Diagram failed to load/i)).toBeInTheDocument();
+  });
+
+  it('clears the error UI when visual.path changes', () => {
+    const { rerender } = render(<QuestionVisual track="cloud" visual={visualA} />);
+    fireEvent.error(screen.getByTestId('question-visual-img'));
+    expect(screen.getByText(/Diagram failed to load/i)).toBeInTheDocument();
+
+    rerender(<QuestionVisual track="cloud" visual={visualB} />);
+    expect(screen.queryByText(/Diagram failed to load/i)).not.toBeInTheDocument();
+    expect(screen.getByTestId('question-visual-img')).toBeInTheDocument();
+  });
+});

--- a/interviews/staffml/src/__tests__/setup.ts
+++ b/interviews/staffml/src/__tests__/setup.ts
@@ -22,3 +22,11 @@ Object.defineProperty(globalThis, 'crypto', {
     randomUUID: () => 'test-session-' + Math.random().toString(36).slice(2, 10),
   },
 });
+
+// jsdom doesn't ship ResizeObserver; react-medium-image-zoom (and friends) need it.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = ResizeObserverStub as unknown as typeof ResizeObserver;

--- a/interviews/staffml/src/components/QuestionVisual.tsx
+++ b/interviews/staffml/src/components/QuestionVisual.tsx
@@ -39,6 +39,11 @@ export interface QuestionVisualProps {
 
 export default function QuestionVisual({ track, visual }: QuestionVisualProps) {
   const [failed, setFailed] = useState(false);
+  const [prevPath, setPrevPath] = useState(visual.path);
+  if (visual.path !== prevPath) {
+    setPrevPath(visual.path);
+    setFailed(false);
+  }
 
   if (visual.kind !== "svg") return null;
 


### PR DESCRIPTION
## Summary
- A question whose diagram failed to load left `QuestionVisual` in its error state across navigation. `failed=true` short-circuited before the next question's `<img>` could mount, so its `onError` could never reset things. Users saw "Diagram failed to load" on questions whose images were fine.
- Fix uses the same `useState` + compare pattern as `vault/TopicDetail.tsx`, which React's docs recommend for resetting state when a prop changes.
- Adds a regression test (renders, errors, re-renders with new path, asserts the error UI is cleared).
- Adds a `ResizeObserver` stub in the vitest `setup.ts` so `react-medium-image-zoom` mounts cleanly under jsdom — without it the new test crashes.

## Test plan
- [x] `npx vitest run` → 39/39 passing (was 37/37)
- [x] `npx tsc --noEmit` → clean
- [ ] Manual verification: open `/practice`, block a diagram URL in DevTools → red error shows, navigate to next question → new diagram loads (instead of staying in error state)