### PR TITLE
fix(staffml): drop misleading role=button from MetaTooltip and stop nesting it inside a real button

### DIFF
--- a/interviews/staffml/src/__tests__/meta-tooltip.test.tsx
+++ b/interviews/staffml/src/__tests__/meta-tooltip.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * MetaTooltip a11y guardrails.
+ *
+ * Previously the trigger declared role="button" with no handler — screen
+ * readers announced "button" but Enter/Space did nothing. We keep the
+ * trigger focusable (tabIndex={0}) so keyboard users see the tooltip on
+ * focus, but no longer claim it's a button.
+ *
+ * Also locks in the `withTooltip={false}` opt-out on LevelBadge for the
+ * "rendered inside a <button>" case at vault/TopicDetail.tsx, which
+ * otherwise produces nested interactive elements (invalid HTML +
+ * double tab stop).
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import MetaTooltip from '@/components/MetaTooltip';
+import LevelBadge from '@/components/LevelBadge';
+
+describe('MetaTooltip', () => {
+  it('does not declare role="button" on the trigger', () => {
+    render(
+      <MetaTooltip title="L4" body="Analyze">
+        <span>L4</span>
+      </MetaTooltip>,
+    );
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('keeps the trigger keyboard-focusable so the tooltip appears on focus', () => {
+    const { container } = render(
+      <MetaTooltip title="L4" body="Analyze">
+        <span>L4</span>
+      </MetaTooltip>,
+    );
+    const trigger = container.firstElementChild as HTMLElement;
+    expect(trigger.tabIndex).toBe(0);
+  });
+
+  it('links the trigger to the tooltip via aria-describedby', () => {
+    const { container } = render(
+      <MetaTooltip title="L4" body="Analyze">
+        <span>L4</span>
+      </MetaTooltip>,
+    );
+    const trigger = container.firstElementChild as HTMLElement;
+    const describedBy = trigger.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    const tip = document.getElementById(describedBy!);
+    expect(tip).not.toBeNull();
+    expect(tip!.getAttribute('role')).toBe('tooltip');
+  });
+});
+
+describe('LevelBadge', () => {
+  it('renders a MetaTooltip by default (standalone use)', () => {
+    const { container } = render(<LevelBadge level="L3" />);
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.getAttribute('aria-describedby')).toBeTruthy();
+  });
+
+  it('omits the tooltip wrapper when withTooltip={false} (nested-in-button use)', () => {
+    const { container } = render(<LevelBadge level="L3" withTooltip={false} />);
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.getAttribute('aria-describedby')).toBeNull();
+    expect(root.hasAttribute('tabindex')).toBe(false);
+  });
+});

--- a/interviews/staffml/src/components/MetaTooltip.tsx
+++ b/interviews/staffml/src/components/MetaTooltip.tsx
@@ -8,12 +8,19 @@
  * narrow containers; uses max-width to bound that.
  *
  * Accessibility:
- *   - The trigger gets `tabIndex={0}` and `role="button"` if it's not
- *     already a button
+ *   - The trigger gets `tabIndex={0}` so keyboard users can focus it and
+ *     the tooltip appears (via `group-focus-within`). No `role` is set —
+ *     the trigger is informational, not a button. Adding `role="button"`
+ *     without a handler misled screen readers into announcing an
+ *     interactive control whose Enter/Space did nothing.
  *   - The tooltip body is hidden visually until hover/focus but always in
  *     the DOM, with `role="tooltip"` and an aria-describedby link
  *   - Also sets a native `title=` attribute as a fallback for screen
  *     readers that don't support live tooltip semantics
+ *   - When the badge is already nested inside an interactive parent
+ *     (e.g. a `<button>`), pass `withTooltip={false}` on the wrapping
+ *     LevelBadge so MetaTooltip isn't rendered at all — avoids nested
+ *     interactives and a double tab stop.
  *
  * Usage:
  *   <MetaTooltip title="L4 — Analyze (Senior)" body="Can you compare trade-offs and diagnose?">
@@ -44,7 +51,6 @@ export default function MetaTooltip({
     <span
       className={clsx("group relative inline-flex", className)}
       tabIndex={0}
-      role="button"
       aria-describedby={id}
       title={fallbackTitle}
     >

--- a/interviews/staffml/src/components/vault/TopicDetail.tsx
+++ b/interviews/staffml/src/components/vault/TopicDetail.tsx
@@ -183,7 +183,7 @@ export default function TopicDetail({ topic, areaName, style, onClose, selectedT
                     return (
                       <button key={level} onClick={() => setDrillLevel(level)}
                         className="w-full flex items-center gap-3 px-4 py-2.5 rounded-xl border border-borderSubtle bg-surface hover:bg-surfaceElevated hover:border-borderHighlight transition-all group">
-                        <LevelBadge level={level} />
+                        <LevelBadge level={level} withTooltip={false} />
                         <span className="flex-1 text-left text-[13px] font-medium text-textSecondary">{levelDef?.name}</span>
                         <span className="text-[13px] font-mono font-bold text-textPrimary">{count}</span>
                         <ChevronRight className="w-4 h-4 text-textMuted group-hover:text-textSecondary shrink-0 transition-colors" />


### PR DESCRIPTION
## Summary
Two related a11y issues in `MetaTooltip` / `LevelBadge`:

1. **`role=\"button\"` with no handler.** `MetaTooltip`'s trigger declared `role=\"button\"` with no `onClick` / `onKeyDown` — screen readers announced \"button\" but Enter/Space did nothing.
2. **Nested interactive elements.** `LevelBadge` wraps its badge in `MetaTooltip` by default, and `vault/TopicDetail` renders `LevelBadge` inside a real `<button>` for the drill-by-difficulty rows. The result was `<button><span role=\"button\" tabIndex={0}>…</span></button>` — invalid HTML and a double tab stop for one logical control.

### Changes
- `MetaTooltip.tsx`: drop `role=\"button\"`. Keep `tabIndex={0}` so keyboard users can still focus the trigger and the tooltip appears via `group-focus-within`. Keep `aria-describedby` linking to the `role=\"tooltip\"` body.
- `vault/TopicDetail.tsx`: pass `withTooltip={false}` on the nested `LevelBadge` (the `withTooltip` prop already exists on `LevelBadge` for exactly this case).
- New regression test asserts no `role=\"button\"`, trigger stays focusable, `aria-describedby` still resolves to a `role=\"tooltip\"` body, and `LevelBadge` with `withTooltip={false}` skips the wrapper.

## Test plan
- [x] `npx vitest run` → 42/42 passing (was 37/37 on dev — the 5 new tests cover the above)
- [x] `npx tsc --noEmit` → clean
- [ ] Manual a11y: tab through the drill-by-difficulty list at `/?topic=...` — each row should be one tab stop (the parent `<button>`), not two
- [ ] Manual a11y: hover a `LevelBadge` outside any button (e.g. on the practice page header) — tooltip still appears; screen reader announces the tooltip text via `aria-describedby` instead of \"button\"
