### PR TITLE
fix(staffml): give ChainStrip dots accessible names and a current-step marker

### DIFF
--- a/interviews/staffml/src/__tests__/chain-strip.test.tsx
+++ b/interviews/staffml/src/__tests__/chain-strip.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * ChainStrip a11y guardrails.
+ *
+ * The progress dots used to convey state purely by color/scale/opacity
+ * and `title=` attributes — keyboard / screen-reader users couldn't tell
+ * which step was current or what each step was about. We now render the
+ * dots in an `<ol>` with `aria-current="step"` on the active dot and an
+ * accessible name on each button.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import ChainStrip from '@/components/ChainStrip';
+import type { ChainInfo } from '@/lib/corpus';
+
+const chain: ChainInfo = {
+  chainId: 'kv-cache-tour',
+  position: 1,
+  total: 3,
+  tier: 'primary',
+  questions: [
+    { id: 'q-a', title: 'What is a KV cache?',             level: 'L1', position: 0 },
+    { id: 'q-b', title: 'Why does KV cache memory grow?',  level: 'L2', position: 1 },
+    { id: 'q-c', title: 'Estimate KV cache for Llama 70B', level: 'L3', position: 2 },
+  ],
+};
+
+describe('ChainStrip a11y', () => {
+  it('renders the dots as a semantic ordered list', () => {
+    render(<ChainStrip chain={chain} onNavigate={() => {}} />);
+    const list = screen.getByRole('list', { name: /question chain progress/i });
+    expect(within(list).getAllByRole('listitem')).toHaveLength(3);
+  });
+
+  it('marks only the current step with aria-current', () => {
+    render(<ChainStrip chain={chain} onNavigate={() => {}} />);
+    const list = screen.getByRole('list', { name: /question chain progress/i });
+    const current = within(list).getAllByRole('button').filter(
+      b => b.getAttribute('aria-current') === 'step',
+    );
+    expect(current).toHaveLength(1);
+    expect(current[0].getAttribute('aria-label')).toMatch(/Part 2 of 3/);
+  });
+
+  it('gives each dot an accessible name with part, level, and title', () => {
+    render(<ChainStrip chain={chain} onNavigate={() => {}} />);
+    expect(
+      screen.getByRole('button', { name: /Part 1 of 3.*L1.*What is a KV cache.*completed/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Part 2 of 3.*L2.*Why does KV cache memory grow/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Part 3 of 3.*L3.*Estimate KV cache for Llama 70B/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('only past steps are labelled as completed', () => {
+    render(<ChainStrip chain={chain} onNavigate={() => {}} />);
+    const list = screen.getByRole('list', { name: /question chain progress/i });
+    const completed = within(list).getAllByRole('button').filter(
+      b => /completed/i.test(b.getAttribute('aria-label') || ''),
+    );
+    expect(completed).toHaveLength(1);
+    expect(completed[0].getAttribute('aria-label')).toMatch(/Part 1 of 3/);
+  });
+
+  it('every dot button is type="button" so it cannot accidentally submit a form', () => {
+    render(<ChainStrip chain={chain} onNavigate={() => {}} />);
+    const list = screen.getByRole('list', { name: /question chain progress/i });
+    for (const button of within(list).getAllByRole('button')) {
+      expect((button as HTMLButtonElement).type).toBe('button');
+    }
+  });
+
+  it('clicking a dot still navigates to that question', () => {
+    const onNavigate = vi.fn();
+    render(<ChainStrip chain={chain} onNavigate={onNavigate} />);
+    const part3 = screen.getByRole('button', { name: /Part 3 of 3/i });
+    part3.click();
+    expect(onNavigate).toHaveBeenCalledWith('q-c');
+  });
+});

--- a/interviews/staffml/src/components/ChainStrip.tsx
+++ b/interviews/staffml/src/components/ChainStrip.tsx
@@ -31,34 +31,43 @@ export default function ChainStrip({ chain, onNavigate }: {
             alt path
           </span>
         )}
-        <div className="flex items-center gap-1">
+        <ol
+          aria-label="Question chain progress"
+          className="flex items-center gap-1 list-none p-0 m-0"
+        >
           {chain.questions.map((q, i) => {
             const def = getLevelDef(q.level);
+            const base = `Part ${i + 1} of ${chain.total}: ${q.level} ${def.name} — ${q.title}`;
+            const ariaLabel = i < chain.position ? `${base} (completed)` : base;
             return (
-              <button
-                key={q.id}
-                onClick={() => onNavigate(q.id)}
-                title={`${q.level} ${def.name}: ${q.title}`}
-                className="group"
-              >
-                <div
-                  className={clsx(
-                    "w-3 h-3 rounded-full border-2 transition-all",
-                    i === chain.position
-                      ? "scale-125"
-                      : i < chain.position
-                      ? "opacity-60"
-                      : "opacity-30"
-                  )}
-                  style={{
-                    borderColor: def.color,
-                    backgroundColor: i <= chain.position ? def.color : "transparent",
-                  }}
-                />
-              </button>
+              <li key={q.id}>
+                <button
+                  type="button"
+                  onClick={() => onNavigate(q.id)}
+                  aria-current={i === chain.position ? "step" : undefined}
+                  aria-label={ariaLabel}
+                  title={`${q.level} ${def.name}: ${q.title}`}
+                  className="group"
+                >
+                  <div
+                    className={clsx(
+                      "w-3 h-3 rounded-full border-2 transition-all",
+                      i === chain.position
+                        ? "scale-125"
+                        : i < chain.position
+                        ? "opacity-60"
+                        : "opacity-30"
+                    )}
+                    style={{
+                      borderColor: def.color,
+                      backgroundColor: i <= chain.position ? def.color : "transparent",
+                    }}
+                  />
+                </button>
+              </li>
             );
           })}
-        </div>
+        </ol>
       </div>
 
       {/* Previous/next question previews. Showing both directions makes the


### PR DESCRIPTION
## Summary
The progress dots in `ChainStrip` conveyed state purely by color, scale, and opacity (`scale-125` for current, `opacity-60` for past, `opacity-30` for future), and the only accessible name on each `<button>` was a `title=` — which screen readers announce inconsistently. Keyboard and screen-reader users couldn't tell which step was current or what each step was about.

### Changes
- Wrap the dots in `<ol aria-label="Question chain progress">` with each dot in an `<li>` so AT announces this as an ordered list of N items rather than a loose bag of buttons.
- Mark the current dot with `aria-current="step"`.
- Give each dot an `aria-label` of the form `Part X of Y: <level> <name> — <title>` (with `" (completed)"` appended for past steps), so the accessible name doesn't depend on `title=`.
- Add `type="button"` to the dots so they can't accidentally submit a form if the strip is ever rendered inside one.

### Visual impact
Zero. The list resets default `list-style` / padding / margin so the dot row still renders identically.

## Test plan
- [x] `npx vitest run` → 43/43 passing (was 37/37 on dev — 6 new tests for list semantics, single `aria-current`, accessible-name format, completed-suffix on past steps only, `type="button"` on every dot, and that `onNavigate` is still wired to clicks)
- [x] `npx tsc --noEmit` → clean
- [ ] Manual a11y: open a chained question, Tab into the dot row, listen — screen reader should announce the list, then each dot with its part/level/title, with the current dot identified as the current step
- [ ] Manual visual: dot row should look identical to before