### PR TITLE
feat(captions): upgrade MiniMax example to M3 default

### DIFF
--- a/book/tools/scripts/content/manage_captions.py
+++ b/book/tools/scripts/content/manage_captions.py
@@ -4104,8 +4104,8 @@ Examples:
   # Cloud LLM providers (no local Ollama required):
   python improve_figure_captions.py -d contents/vol1/ -p openai -m gpt-4o-mini
   python improve_figure_captions.py -d contents/vol1/ -p groq -m llama-3.3-70b-versatile
-  python improve_figure_captions.py -d contents/vol1/ -p minimax -m MiniMax-M2.7
-  python improve_figure_captions.py -d contents/vol1/ --provider minimax --model MiniMax-M2.7 --api-key sk-...
+  python improve_figure_captions.py -d contents/vol1/ -p minimax -m MiniMax-M3
+  python improve_figure_captions.py -d contents/vol1/ --provider minimax --model MiniMax-M3 --api-key sk-...
 """
     )
 


### PR DESCRIPTION
## Summary
Upgrade the `manage_captions.py` docstring example to reference the latest MiniMax model (`MiniMax-M3`) instead of `MiniMax-M2.7`, so first-time users land on the current flagship model.

## Changes
- Update the `--provider minimax` usage example in the script's epilog to use `MiniMax-M3` (was `MiniMax-M2.7`)
- No code logic changes; the model name is user-supplied via `--model` and the example was the only place the model ID was pinned

## Why
MiniMax released M3, the new default flagship: 512K context window, up to 128K output tokens, and image input support on the OpenAI-compatible endpoint. The previous example pinned M2.7 (added in #1239), which is still available but is no longer the recommended starting point. M2.7 / M2.7-highspeed remain valid `--model` values for anyone who prefers them.

## Testing
- Verified the docstring example renders correctly (`python book/tools/scripts/content/manage_captions.py --help`)
- No other MiniMax / minimax provider references in the file were affected