### PR TITLE
fix(staffml): pin bootstrap-icons CSS with SRI + crossorigin

### DIFF
--- a/interviews/staffml/src/components/EcosystemBar.tsx
+++ b/interviews/staffml/src/components/EcosystemBar.tsx
@@ -242,13 +242,30 @@ export default function EcosystemBar() {
   const dropdownHoverBg = isDark ? '#3a3a3a' : '#f8f9fa';
   const dividerColor = isDark ? '#454d55' : '#dee2e6';
 
-  // Load Bootstrap Icons font
+  // Load Bootstrap Icons font.
+  // SRI integrity pins the CSS bytes — if jsDelivr ever serves modified
+  // content, the browser rejects the stylesheet rather than applying it.
+  // crossorigin="anonymous" is required for integrity to be enforced on
+  // cross-origin resources. If the bootstrap-icons version is ever bumped,
+  // recompute the hash:
+  //   curl -sL <url> | openssl dgst -sha384 -binary | openssl base64 -A
   useEffect(() => {
     if (document.getElementById("bi-css")) return;
     const link = document.createElement("link");
     link.id = "bi-css";
     link.rel = "stylesheet";
     link.href = "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css";
+    link.integrity = "sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+";
+    link.crossOrigin = "anonymous";
+    // Surface SRI/network failures in devtools — without this the browser
+    // silently blocks the stylesheet and the only symptom is missing icons.
+    link.onerror = () => {
+      console.error(
+        "[EcosystemBar] Failed to load Bootstrap Icons CSS from jsDelivr.",
+        "If you just bumped the version, recompute the SRI hash with:",
+        "curl -sL", link.href, "| openssl dgst -sha384 -binary | openssl base64 -A",
+      );
+    };
     document.head.appendChild(link);
   }, []);
 


### PR DESCRIPTION
## Summary
`EcosystemBar` injected the bootstrap-icons stylesheet from jsDelivr with no `integrity` attribute. If jsDelivr was ever compromised or its CDN served modified bytes, the browser would apply the foreign CSS on every StaffML pageview.

### Changes
- Add `integrity=\"sha384-…\"` pinning the v1.11.3 bytes. Hash computed from the actual CDN file:
  ```
  curl -sL https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css \
    | openssl dgst -sha384 -binary | openssl base64 -A
  ```
- Add `crossOrigin=\"anonymous\"` — required for SRI to be enforced on cross-origin resources.
- Add an `onerror` handler that logs to console (with the recompute recipe) when the stylesheet is rejected. Without it the only symptom of a stale hash (e.g. after a version bump) would be silently missing icons across the bar.
- Comment includes the recompute recipe so future version bumps update the hash deterministically.

## Test plan
- [x] `npx tsc --noEmit` → unchanged (the 2 pre-existing errors on `dev` about `katex` / `js-quantities` are local-env-only; those packages are declared in `package.json` but missing from local `node_modules` until `npm install` runs)
- [x] All 57 individual vitest cases still pass. The 4 test files that fail to import on `dev` fail with the same stash-in / stash-out behavior — unrelated to this PR.
- [ ] Manual: load the site, confirm icons (envelope, github, etc.) still render. If the hash is wrong they'd vanish.
- [ ] Manual: temporarily corrupt the hash, reload, confirm the new `console.error` fires with the recompute recipe.