### PR TITLE
fix(staffml): pause Nav due-count poll on hidden tabs + sync across tabs

### DIFF
--- a/interviews/staffml/src/__tests__/use-visibility-poll.test.tsx
+++ b/interviews/staffml/src/__tests__/use-visibility-poll.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * Tests for useVisibilityPoll — the Page Visibility-aware setInterval
+ * wrapper extracted from Nav's SR-due-count poll.
+ *
+ * Pins the four behaviors that make this hook useful versus a plain
+ * setInterval:
+ *   1. Fires immediately on mount (so the UI isn't blank for one interval).
+ *   2. Fires repeatedly at the requested cadence while visible.
+ *   3. Stops firing when the tab goes hidden.
+ *   4. Catches up with an immediate call when the tab comes back, then
+ *      resumes the cadence.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useVisibilityPoll } from '@/lib/hooks/useVisibilityPoll';
+
+function setVisibility(state: 'visible' | 'hidden') {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => state,
+  });
+  document.dispatchEvent(new Event('visibilitychange'));
+}
+
+describe('useVisibilityPoll', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setVisibility('visible');
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fires immediately on mount when visible', () => {
+    const cb = vi.fn();
+    renderHook(() => useVisibilityPoll(cb, 1000));
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires repeatedly at the requested cadence while visible', () => {
+    const cb = vi.fn();
+    renderHook(() => useVisibilityPoll(cb, 1000));
+    expect(cb).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(3000);
+    expect(cb).toHaveBeenCalledTimes(4);   // mount + 3 ticks
+  });
+
+  it('stops firing when the tab is hidden', () => {
+    const cb = vi.fn();
+    renderHook(() => useVisibilityPoll(cb, 1000));
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    setVisibility('hidden');
+    vi.advanceTimersByTime(10_000);
+    expect(cb).toHaveBeenCalledTimes(1);   // nothing fired while hidden
+  });
+
+  it('catches up immediately on resume and then resumes the cadence', () => {
+    const cb = vi.fn();
+    renderHook(() => useVisibilityPoll(cb, 1000));
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    setVisibility('hidden');
+    vi.advanceTimersByTime(5000);
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    setVisibility('visible');
+    expect(cb).toHaveBeenCalledTimes(2);   // immediate catch-up
+    vi.advanceTimersByTime(2000);
+    expect(cb).toHaveBeenCalledTimes(4);   // + 2 ticks
+  });
+
+  it('does not start the interval if mounted while already hidden', () => {
+    setVisibility('hidden');
+    const cb = vi.fn();
+    renderHook(() => useVisibilityPoll(cb, 1000));
+    vi.advanceTimersByTime(10_000);
+    expect(cb).not.toHaveBeenCalled();
+
+    setVisibility('visible');
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('isolates throws from the callback so mount setup completes and polling continues', () => {
+    // Reviewer caught a subtle bug in an earlier iteration: if the
+    // callback throws on the mount-time synchronous tick, the throw
+    // propagates out of the effect body BEFORE React receives the
+    // cleanup function. Any setInterval/listeners armed before the
+    // throw leak forever. The hook now wraps every tick in try/catch
+    // internally so the worst case is per-tick console errors, not a
+    // leak. We also assert that the visibilitychange listener was
+    // attached (it sits AFTER start() in the effect body, so a throw
+    // there would skip it).
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    let throwOnce = true;
+    const cb = vi.fn(() => {
+      if (throwOnce) { throwOnce = false; throw new Error('boom'); }
+    });
+
+    const { unmount } = renderHook(() => useVisibilityPoll(cb, 1000));
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalled();
+
+    // Listener wired up despite the throw — toggling visibility works.
+    setVisibility('hidden');
+    vi.advanceTimersByTime(3000);
+    expect(cb).toHaveBeenCalledTimes(1);   // paused
+    setVisibility('visible');
+    expect(cb).toHaveBeenCalledTimes(2);   // resume tick (no throw this time)
+
+    vi.advanceTimersByTime(2000);
+    expect(cb).toHaveBeenCalledTimes(4);   // interval kept ticking
+
+    unmount();
+    consoleError.mockRestore();
+  });
+
+  it('cleans up the interval and listener on unmount', () => {
+    const cb = vi.fn();
+    const { unmount } = renderHook(() => useVisibilityPoll(cb, 1000));
+    expect(cb).toHaveBeenCalledTimes(1);
+    unmount();
+    vi.advanceTimersByTime(10_000);
+    expect(cb).toHaveBeenCalledTimes(1);   // nothing fired post-unmount
+  });
+
+  it('always calls the latest callback closure, not the one captured on first render', () => {
+    // Sanity-check the ref pattern: changing the callback between renders
+    // must take effect without tearing down and re-arming the interval.
+    let value = 0;
+    const seen: number[] = [];
+    const { rerender } = renderHook(
+      ({ v }: { v: number }) => useVisibilityPoll(() => seen.push(v), 1000),
+      { initialProps: { v: 0 } },
+    );
+    expect(seen).toEqual([0]);
+
+    value = 1;
+    rerender({ v: 1 });
+    vi.advanceTimersByTime(1000);
+    expect(seen).toEqual([0, 1]);
+    void value;
+  });
+});

--- a/interviews/staffml/src/components/Nav.tsx
+++ b/interviews/staffml/src/components/Nav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { ECOSYSTEM_BASE } from "../lib/env";
@@ -14,6 +14,7 @@ import StreakBadge from "@/components/StreakBadge";
 import { buildSiteIssueUrl } from "@/lib/issue-url";
 import { getDueCount } from "@/lib/progress";
 import { useTheme } from "@/components/ThemeProvider";
+import { useVisibilityPoll } from "@/lib/hooks/useVisibilityPoll";
 
 const primaryLinks = [
   { href: "/", label: "Vault", icon: Library },
@@ -42,14 +43,31 @@ export default function Nav() {
   const { theme, toggleTheme } = useTheme();
   const toolsRef = useRef<HTMLDivElement>(null);
 
-  // Check for due SR cards periodically
-  useEffect(() => {
-    try { setDueCount(getDueCount()); } catch {}
-    const interval = setInterval(() => {
-      try { setDueCount(getDueCount()); } catch {}
-    }, 30000);
-    return () => clearInterval(interval);
+  // Single source of truth for refreshing the due-count badge — used by
+  // both the periodic poll below AND the cross-tab storage listener.
+  // Errors are logged (not swallowed) so a corrupted-localStorage failure
+  // shows up in devtools instead of presenting as a frozen badge.
+  const refresh = useCallback(() => {
+    try {
+      setDueCount(getDueCount());
+    } catch (e) {
+      console.error("[Nav] getDueCount failed", e);
+    }
   }, []);
+
+  // Check for due SR cards every 30s while the tab is visible. The hook
+  // pauses on hidden and re-reads immediately on resume — see its docs.
+  useVisibilityPoll(refresh, 30_000);
+
+  // Cross-tab freshness: the poll above only catches up on visibility
+  // transitions, so if two tabs are visible at the same time (split
+  // screen, multiple monitors) a write in one tab is invisible to the
+  // other until its next 30s tick. The `storage` event fires in OTHER
+  // tabs the instant one tab writes to localStorage, so re-read on it.
+  useEffect(() => {
+    window.addEventListener("storage", refresh);
+    return () => window.removeEventListener("storage", refresh);
+  }, [refresh]);
 
   // Close tools dropdown on outside click
   useEffect(() => {

--- a/interviews/staffml/src/lib/hooks/useVisibilityPoll.ts
+++ b/interviews/staffml/src/lib/hooks/useVisibilityPoll.ts
@@ -1,0 +1,74 @@
+/**
+ * useVisibilityPoll — run a callback on a fixed interval, but only when
+ * the document is visible. When the tab is hidden the interval is cleared;
+ * when it becomes visible again the callback fires immediately so the UI
+ * catches up on time-based changes (e.g. cards becoming due while the tab
+ * was backgrounded) and the regular interval resumes.
+ *
+ * The original use case (Nav.tsx's SR due-count badge) was polling every
+ * 30s indefinitely, even on backgrounded tabs — cheap per call but wasted
+ * battery on mobile.
+ *
+ * NOT a cross-tab sync primitive. If two tabs are visible at the same
+ * time (split screen, multiple monitors, popped-out window), a write in
+ * one tab is invisible to the other until its next interval tick. Callers
+ * that need instant cross-tab freshness should pair this hook with a
+ * `storage` event listener — see Nav.tsx for an example.
+ *
+ * The callback is held in a ref so a fresh closure on every render is
+ * picked up without tearing down and re-arming the interval. Only
+ * `intervalMs` is a real dependency. The callback fires once immediately
+ * on mount (when visible), which is a deviation from a bare setInterval.
+ *
+ * Usage:
+ *   useVisibilityPoll(() => setDueCount(getDueCount()), 30_000);
+ */
+"use client";
+
+import { useEffect, useRef } from "react";
+
+export function useVisibilityPoll(callback: () => void, intervalMs: number): void {
+  const cbRef = useRef(callback);
+  // Refresh the ref after every render so the interval always calls the
+  // latest closure (the caller may close over fresh state).
+  useEffect(() => { cbRef.current = callback; });
+
+  useEffect(() => {
+    let interval: ReturnType<typeof setInterval> | null = null;
+    // Throw-isolate the callback. If it ever throws (corrupted localStorage,
+    // null deref in dev) the exception is logged and the next tick still
+    // runs — without this guard, a throw inside start()'s synchronous tick
+    // during MOUNT propagates out of the effect body before React receives
+    // the cleanup, leaving the already-armed setInterval orphaned and
+    // re-throwing every intervalMs with no way to cancel.
+    const tick = () => {
+      try { cbRef.current(); }
+      catch (e) { console.error("[useVisibilityPoll] callback threw", e); }
+    };
+
+    const start = () => {
+      if (interval !== null) return;
+      tick();
+      interval = setInterval(tick, intervalMs);
+    };
+    const stop = () => {
+      if (interval !== null) {
+        clearInterval(interval);
+        interval = null;
+      }
+    };
+
+    if (document.visibilityState === "visible") start();
+
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") start();
+      else stop();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      stop();
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, [intervalMs]);
+}


### PR DESCRIPTION
## Summary
Nav was polling `getDueCount` every 30s indefinitely via a bare `setInterval`, even on backgrounded tabs. Cheap per call (it reads localStorage), but the unnecessary wakeups burn battery on mobile and add no value when no one is looking. There was also no cross-tab sync: a card completed in one tab wouldn't update the badge in another tab until that other tab's next 30s tick.

### Changes
- **New hook** `src/lib/hooks/useVisibilityPoll.ts`: pauses the interval on `visibilitychange→hidden`, re-arms on `→visible` with an immediate catch-up tick. Callback is held in a ref so a fresh closure on every render is picked up without re-arming.
- **Throw-isolation inside the hook**: each tick is wrapped in `try/catch` with `console.error`. Without this, a throwing callback on the mount-time synchronous tick propagates out of the effect body *before* React receives the cleanup — the already-armed `setInterval` would orphan and re-throw every interval forever.
- **Cross-tab freshness in Nav**: the hook is explicit in its docs that it is **not** a cross-tab sync primitive (only catches up on visibility transitions, not on two-tabs-both-visible). So Nav adds a separate `storage` event listener that fires in *other* tabs the instant one writes to localStorage.
- **Replace `Nav`'s empty `catch {}` with `console.error(...)`** so a real failure (corrupted localStorage, JSON parse error) surfaces in devtools instead of presenting as a frozen badge. Refresh logic hoisted into one `useCallback` shared by both the poll and the storage handler.

## Test plan
- [x] `npx vitest run` → 65/65 individual cases (was 57 on dev; +8 new for the hook).
- [x] `npx tsc --noEmit` → unchanged from dev baseline (the 2 pre-existing `katex` / `js-quantities` errors are env-local: those packages are declared in `package.json` but missing from `node_modules` until `npm install` runs).
- [ ] Manual: open Nav in two browser windows, complete an SR card in window A, observe the due-count badge in window B drop within ~1 tick (the `storage` event fires immediately; the visibility poll would otherwise wait up to 30s).
- [ ] Manual: open DevTools → Application → throttle background tab to confirm no `setInterval` wakeups while the tab is hidden.