### PR TITLE
fix(staffml): derive PaperCitationCard year from buildDate, not `new Date()`

### DIFF
--- a/interviews/staffml/src/__tests__/paper-citation-card.test.tsx
+++ b/interviews/staffml/src/__tests__/paper-citation-card.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * PaperCitationCard year stability.
+ *
+ * Previously the BibTeX year came from `new Date().getFullYear()`, which
+ * is the *render-time* year on the client. With Next's static export the
+ * HTML is generated at build time and hydrates on the client whenever the
+ * user visits — server (build) and client (hydrate) could disagree on the
+ * year (e.g. around midnight UTC on Dec 31 / Jan 1, or just any time the
+ * site is viewed in a year after the build year). That's a hydration
+ * mismatch AND, more fundamentally, the wrong anchor for a citation.
+ * The year now comes from the required `buildDate` prop (UTC).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render } from '@testing-library/react';
+import PaperCitationCard from '@/components/PaperCitationCard';
+
+const baseProps = {
+  paperUrl: 'https://example.com/paper.pdf',
+  releaseId: '0.1.0',
+  releaseHash: 'abcdef1234567890abcdef1234567890',
+};
+
+function getCiteText(container: HTMLElement): string {
+  return container.querySelector('pre')?.textContent ?? '';
+}
+
+describe('PaperCitationCard BibTeX year', () => {
+  it('derives the year from buildDate, not from the current clock', () => {
+    // Force "now" to a different year than buildDate. If the code ever
+    // regresses to `new Date().getFullYear()` this test will catch it.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2099-07-04T00:00:00Z'));
+    try {
+      const { container } = render(
+        <PaperCitationCard {...baseProps} buildDate="2024-06-15T00:00:00Z" />,
+      );
+      const cite = getCiteText(container);
+      expect(cite).toContain('@misc{staffml2024');
+      expect(cite).toContain('year = {2024}');
+      expect(cite).not.toContain('2099');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('updates the year when buildDate changes', () => {
+    const { container, rerender } = render(
+      <PaperCitationCard {...baseProps} buildDate="2024-06-15T00:00:00Z" />,
+    );
+    expect(getCiteText(container)).toContain('@misc{staffml2024');
+
+    rerender(<PaperCitationCard {...baseProps} buildDate="2027-03-01T00:00:00Z" />);
+    expect(getCiteText(container)).toContain('@misc{staffml2027');
+    expect(getCiteText(container)).toContain('year = {2027}');
+  });
+
+  it('uses UTC so the year is stable regardless of viewer timezone', () => {
+    // 2025-01-01T01:00:00Z is Jan 1 2025 in UTC but Dec 31 2024 in PT
+    // (UTC-8). The citation year must be 2025 (the UTC year, matching
+    // the build server) and not depend on where the viewer is sitting.
+    const { container } = render(
+      <PaperCitationCard {...baseProps} buildDate="2025-01-01T01:00:00Z" />,
+    );
+    expect(getCiteText(container)).toContain('@misc{staffml2025');
+  });
+});

--- a/interviews/staffml/src/components/PaperCitationCard.tsx
+++ b/interviews/staffml/src/components/PaperCitationCard.tsx
@@ -16,7 +16,8 @@ export interface PaperCitationCardProps {
   paperUrl: string;
   releaseId: string;
   releaseHash: string;    // full hex digest; first 7 chars are shown above the fold.
-  buildDate?: string;     // ISO 8601; rendered as a human-readable date next to the version.
+  buildDate: string;      // ISO 8601 (e.g. "2026-04-22T12:34:56Z"); required because
+                          // the citation year is derived from it for stable hydration.
   doi?: string;           // optional — register via Zenodo per ARCHITECTURE.md §15 #2
   className?: string;
 }
@@ -24,13 +25,21 @@ export interface PaperCitationCardProps {
 function bibtex({
   releaseId,
   releaseHash,
+  buildDate,
   doi,
 }: {
   releaseId: string;
   releaseHash: string;
+  buildDate: string;
   doi?: string;
 }): string {
-  const year = new Date().getFullYear();
+  // Year MUST come from buildDate (a stable prop), not `new Date()`. With
+  // Next's static export the HTML is generated at build time but hydrates
+  // on the client whenever the user visits — `new Date().getFullYear()`
+  // would mismatch around midnight UTC on Dec 31 / Jan 1, or any time the
+  // site is viewed in a year after the build year. The build-time date is
+  // the right anchor for a citation anyway.
+  const year = new Date(buildDate).getUTCFullYear();
   const version = `v${releaseId}`;
   const hashLine = `  note = {Release hash: ${releaseHash.slice(0, 16)}},\n`;
   const doiLine = doi ? `  doi = {${doi}},\n` : "";
@@ -53,11 +62,11 @@ export default function PaperCitationCard({
   className,
 }: PaperCitationCardProps) {
   const [copied, setCopied] = useState(false);
-  const cite = bibtex({ releaseId, releaseHash, doi });
+  const cite = bibtex({ releaseId, releaseHash, buildDate, doi });
   const shortHash = releaseHash.slice(0, 7);
-  const buildDateLabel = buildDate
-    ? new Date(buildDate).toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" })
-    : null;
+  const buildDateLabel = new Date(buildDate).toLocaleDateString("en-US", {
+    year: "numeric", month: "long", day: "numeric",
+  });
 
   const handleCopy = async () => {
     try {


### PR DESCRIPTION
## Summary
The BibTeX entry in `PaperCitationCard` took its year from `new Date().getFullYear()` — the *render-time* year on the client. With Next's static export the HTML is generated at build time and hydrates on the client whenever the user visits, so server (build) and client (hydrate) could disagree on the year:

- around midnight UTC on Dec 31 / Jan 1, OR
- any time the site is viewed in a year after the build year (i.e. always, eventually).

Hydration mismatch warning either way, and the wrong anchor for a citation regardless — the year in a software citation should be the release year, not the year the reader happened to view the page.

### Changes
- **Make `buildDate` required** on `PaperCitationCardProps`. The only call site at [`app/about/page.tsx`](src/app/about/page.tsx#L70) already passes it from `BUILD_DATE` in `lib/stats`, so this is a type-level alignment with the existing real-world usage.
- **Derive the BibTeX year** via `new Date(buildDate).getUTCFullYear()` so the year matches the build server's UTC reference regardless of viewer timezone.
- `buildDateLabel` simplifies: no `buildDate ? ... : null` ternary, just the formatted string. The `&&` short-circuit at the render site is now redundant but harmless — left as defense-in-depth.

### Out of scope
The displayed `buildDateLabel` still uses `toLocaleDateString` with no timezone option, which CAN mismatch on a build like `2026-04-22T03:00:00Z` viewed in PT (renders \"April 22, 2026\" on the build server, \"April 21, 2026\" on a PT client). That's a separate, smaller hydration concern with a UX trade-off (UTC vs viewer's local date) — happy to file a follow-up if it's worth fixing.

## Test plan
- [x] `npx vitest run` → 60/60 individual cases (was 57 on dev; +3 new for the year derivation, including a clock-mock test that catches future regressions to `new Date()`).
- [x] `npx tsc --noEmit` → unchanged from dev baseline (the 2 pre-existing `katex` / `js-quantities` errors are env-local).
- [ ] Manual: open `/about`, expand \"Cite this release\", confirm the BibTeX year matches `BUILD_DATE`'s UTC year.