### PR TITLE
fix(staffml): trap focus inside the AskInterviewer waitlist modal

### DIFF
--- a/interviews/staffml/src/__tests__/waitlist-modal.test.tsx
+++ b/interviews/staffml/src/__tests__/waitlist-modal.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * WaitlistModal a11y: focus management + focus trap.
+ *
+ * Before: the dialog had role="dialog" aria-modal="true" but Tab/Shift+Tab
+ * escaped the modal into background controls behind the backdrop, and the
+ * email input wasn't auto-focused on open — keyboard users landed in the
+ * page body and had to hunt for the input.
+ *
+ * After: focus moves to the email input on open, Tab cycles within the
+ * surface, and focus returns to the previously-focused element on unmount.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { WaitlistModal } from '@/components/AskInterviewer';
+
+describe('WaitlistModal a11y', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('autofocuses the email input on open', () => {
+    render(<WaitlistModal onClose={() => {}} endpoint="" />);
+    vi.runAllTimers();   // setTimeout(0) for focus
+    expect(document.activeElement?.tagName).toBe('INPUT');
+    expect(document.activeElement?.getAttribute('type')).toBe('email');
+  });
+
+  it('restores focus to the previously-focused element on unmount', () => {
+    // Set up an outside trigger that "had focus" before the modal opened.
+    const trigger = document.createElement('button');
+    trigger.textContent = 'Open waitlist';
+    document.body.appendChild(trigger);
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    const { unmount } = render(<WaitlistModal onClose={() => {}} endpoint="" />);
+    vi.runAllTimers();
+    expect(document.activeElement).not.toBe(trigger);   // moved into modal
+
+    unmount();
+    expect(document.activeElement).toBe(trigger);       // restored
+    trigger.remove();
+  });
+
+  it('cycles focus from the last focusable back to the first on Tab', () => {
+    const { container } = render(<WaitlistModal onClose={() => {}} endpoint="" />);
+    vi.runAllTimers();
+    const surface = container.querySelector('[role="dialog"] > div') as HTMLElement;
+    const focusables = surface.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    );
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+
+    last.focus();
+    expect(document.activeElement).toBe(last);
+    fireEvent.keyDown(surface, { key: 'Tab' });
+    expect(document.activeElement).toBe(first);
+  });
+
+  it('cycles focus from the first back to the last on Shift+Tab', () => {
+    const { container } = render(<WaitlistModal onClose={() => {}} endpoint="" />);
+    vi.runAllTimers();
+    const surface = container.querySelector('[role="dialog"] > div') as HTMLElement;
+    const focusables = surface.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    );
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+
+    first.focus();
+    expect(document.activeElement).toBe(first);
+    fireEvent.keyDown(surface, { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(last);
+  });
+
+  it('does not steal focus when Tab is pressed in the middle of the trap', () => {
+    // If focus is not on the boundary, Tab should fall through to the
+    // browser's native handling — we only block at the edges.
+    const { container } = render(<WaitlistModal onClose={() => {}} endpoint="" />);
+    vi.runAllTimers();
+    const surface = container.querySelector('[role="dialog"] > div') as HTMLElement;
+    const focusables = surface.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    );
+    // Focus a middle element.
+    const middle = focusables[Math.floor(focusables.length / 2)];
+    middle.focus();
+    const event = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+    surface.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(false);
+  });
+});

--- a/interviews/staffml/src/components/AskInterviewer.tsx
+++ b/interviews/staffml/src/components/AskInterviewer.tsx
@@ -562,13 +562,20 @@ Please answer each as the interviewer.`;
  * yet (404 / network error), falls back to a mailto: link prefilled
  * with the same data so no submission is ever lost.
  */
-function WaitlistModal({ onClose, endpoint }: { onClose: () => void; endpoint: string }) {
+export function WaitlistModal({ onClose, endpoint }: { onClose: () => void; endpoint: string }) {
   const [email, setEmail] = useState("");
   const [wouldPay, setWouldPay] = useState(5);
   const [need, setNeed] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [status, setStatus] = useState<"idle" | "success" | "fallback" | "error">("idle");
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  // Refs for focus management — surfaceRef bounds the focus trap, the email
+  // input gets autofocus on open, and previouslyFocused restores focus to
+  // whatever the user was on when they closed the modal.
+  const surfaceRef = useRef<HTMLDivElement>(null);
+  const emailInputRef = useRef<HTMLInputElement>(null);
+  const previouslyFocused = useRef<HTMLElement | null>(null);
 
   // Escape to close
   useEffect(() => {
@@ -578,6 +585,38 @@ function WaitlistModal({ onClose, endpoint }: { onClose: () => void; endpoint: s
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
   }, [onClose]);
+
+  // Move focus into the modal on open so keyboard users land inside the
+  // dialog instead of behind it. Restore focus to the trigger on unmount.
+  // setTimeout(0) defers the focus past the same-tick mount, matching the
+  // pattern in CommandPalette / KeyboardShortcutsOverlay.
+  useEffect(() => {
+    previouslyFocused.current = document.activeElement as HTMLElement | null;
+    const t = setTimeout(() => emailInputRef.current?.focus(), 0);
+    return () => {
+      clearTimeout(t);
+      previouslyFocused.current?.focus?.();
+    };
+  }, []);
+
+  // Focus trap: cycle Tab/Shift+Tab within the modal surface so keyboard
+  // users can't escape into background controls behind the backdrop.
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key !== "Tab" || !surfaceRef.current) return;
+    const focusables = surfaceRef.current.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    );
+    if (focusables.length === 0) return;
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  };
 
   const submit = async () => {
     if (!email.trim() || submitting) return;
@@ -633,7 +672,9 @@ function WaitlistModal({ onClose, endpoint }: { onClose: () => void; endpoint: s
       onClick={onClose}
     >
       <div
+        ref={surfaceRef}
         onClick={(e) => e.stopPropagation()}
+        onKeyDown={onKeyDown}
         className="w-full max-w-md bg-background border border-border rounded-xl shadow-2xl p-6"
       >
         <div className="flex items-start justify-between mb-4">
@@ -685,6 +726,7 @@ function WaitlistModal({ onClose, endpoint }: { onClose: () => void; endpoint: s
             <label className="block mb-3">
               <span className="block text-[11px] font-bold text-textSecondary mb-1">Email</span>
               <input
+                ref={emailInputRef}
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}


### PR DESCRIPTION
## Summary
The waitlist modal at the bottom of `AskInterviewer` carried `role=\"dialog\" aria-modal=\"true\"` but didn't enforce the contract — Tab and Shift+Tab escaped into background controls behind the backdrop, and the email input wasn't auto-focused on open. Keyboard users landed in the page body and had to hunt for the input.

### Changes
- **Auto-focus the email input on open** via the same `setTimeout(0)` pattern used by `CommandPalette` and `KeyboardShortcutsOverlay`. Keyboard users land in the right place.
- **Focus trap**: `Tab` from the last focusable cycles back to the first, `Shift+Tab` from the first cycles to the last. Middle-of-trap presses fall through to the browser's native handling — we only block at the edges.
- **Focus restoration**: capture `document.activeElement` on mount, restore it on unmount so focus returns to the trigger that opened the modal.
- **Export `WaitlistModal`** as a named export so the regression test can render it directly without spinning up the full `AskInterviewer` parent and triggering its open state.

Mirrors the focus-trap pattern already used in `CommandPalette` (lines 238-252), so the two modals behave identically for keyboard users.

## Test plan
- [x] `npx vitest run` → 62/62 individual cases (was 57 on dev; +5 new for autofocus, restoration, forward cycle, backward cycle, middle-trap fall-through).
- [x] `npx tsc --noEmit` → unchanged from dev baseline (the 2 pre-existing `katex` / `js-quantities` errors are env-local).
- [ ] Manual: open Mock Interview, click \"Join waitlist\" (or whatever triggers `WaitlistModal`), confirm the email input has focus, Tab repeatedly and verify focus stays inside the dialog, close and verify focus returns to the trigger.