### PR TITLE
fixes for tinytorch modules 07 and 08 as well as some rewording for lab 01

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2,7 +2,7 @@
     "projectName": "cs249r_book",
     "projectOwner": "harvard-edge",
     "files": [
-        "book/quarto/contents/frontmatter/acknowledgements/acknowledgements.qmd",
+        "/contents/frontmatter/acknowledgements/acknowledgements.qmd",
         "README.md"
     ],
     "contributors": [

--- a/labs/vol1/lab_01_ml_intro.py
+++ b/labs/vol1/lab_01_ml_intro.py
@@ -193,7 +193,7 @@ def _(COLORS, mo):
                     Duration
                 </div>
                 <div style="font-size: 0.85rem; color: {COLORS['TextSec']}; line-height: 1.65;">
-                    <strong>~51 min</strong><br/>
+                    <strong>~45 min</strong><br/>
                     Part A: ~12 min &middot; Part B: ~12 min<br/>
                     Part C: ~12 min &middot; Part D: ~9 min
                 </div>
@@ -289,7 +289,7 @@ def _(mo):
         options={
             "A) ~2x over budget (need a small trim)":                   "2x",
             "B) ~10x over budget (need significant compression)":        "10x",
-            "C) ~100x over budget (fundamentally infeasible)":           "200x",
+            "C) ~100x over budget (fundamentally infeasible)":           "100x",
             "D) It fits with INT8 quantization":                         "fits",
         },
         label="ResNet-50 requires ~49 MB in FP16. The ESP32-S3 has 512 KB of SRAM. "
@@ -611,7 +611,7 @@ Algorithm capacity metrics complete the picture.
 
         ```
         T  =  D_vol/BW  +  O/(R_peak * eta)  +  L_lat
-              --------     ----------------     ------
+              --------     ----------------     -----
               Data term    Compute term         Overhead
         ```
 
@@ -620,7 +620,7 @@ Algorithm capacity metrics complete the picture.
         the speedup is negligible.
 
         **Arithmetic Intensity (AI)** = O / D_vol (FLOPs per byte). Note: AI here refers to arithmetic intensity, not artificial intelligence.
-        Below the Ridge Point (R_peak / BW), the workload is **memory-bound**.
+        If the AI is below the Ridge Point (R_peak / BW), which is the ratio of peak performance to memory bandwidth, the workload is **memory-bound**, and is otherwise **compute-bound**.
         """))
 
         items.append(partB_prediction)
@@ -734,13 +734,16 @@ Algorithm capacity metrics complete the picture.
 **Iron Law -- Live Calculation** (`batch = {_batch}`)
 
 ```
-T  =  D_vol/BW              +  O/(R * eta)                       +  L
-   =  {_mem_gb:.4f} GB / {H100_BW_GBS:,} GB/s  +  {RESNET50_FLOPS*_batch:.2e} / ({H100_TFLOPS_FP16:.0f}T * {_eta})  +  {_t_ovh_ms:.3f} ms
-   =  {_t_data_ms:.4f} ms           +  {_t_comp_ms:.4f} ms                     +  {_t_ovh_ms:.4f} ms
-   =  {_t_total:.4f} ms total  (Bottleneck: {_bottleneck})
+T = D_vol/BW + O/(R * eta) +  L
 
-AI = {_ai:.1f} FLOPs/Byte  {'<<' if _ai < _ridge_point else '>>'} Ridge Point ~{_ridge_point:.0f} FLOPs/Byte
-     => {'MEMORY-BOUND' if _ai < _ridge_point else 'COMPUTE-BOUND'}
+D_vol/Bw    = {_mem_gb:.4f} GB / {H100_BW_GBS:.4f} GB/s = {_t_data_ms:.4f} ms
+O/(R * eta) = {RESNET50_FLOPS*_batch:.2e} / ({H100_TFLOPS_FP16:.0f}T * {_eta}) = {_t_comp_ms:.4f} ms
+L           = {_t_ovh_ms:.4f} ms
+
+T = {_t_data_ms:.4f} + {_t_comp_ms:.4f} ms + {_t_ovh_ms:.4f} = {_t_total:.4f} ms total (Bottleneck: {_bottleneck})
+
+AI = {_ai:.1f} FLOPs/Byte {'<' if _ai < _ridge_point else '>'} Ridge Point ~{_ridge_point:.0f} FLOPs/Byte
+   => {'MEMORY-BOUND' if _ai < _ridge_point else 'COMPUTE-BOUND'}
 ```
 """))
 
@@ -1011,7 +1014,7 @@ Since {RESNET50_FLOPS/(RESNET50_SIZE_MB/1024*1e9):.0f} << {_ridge_point:.0f}, th
         _pred = partC_prediction.value
         _actual_ratio = RESNET50_SIZE_MB * 1024 / ESP32_RAM_KB
 
-        if _pred == "200x":
+        if _pred == "100x":
             _rev = (f"**Correct.** The ratio is ~{_actual_ratio:.0f}x. "
                     "This is not a compression problem -- it is a feasibility violation. "
                     "You need a fundamentally different model architecture for TinyML.")
@@ -1118,7 +1121,7 @@ Since {RESNET50_FLOPS/(RESNET50_SIZE_MB/1024*1e9):.0f} << {_ridge_point:.0f}, th
         ))
         _fig.update_layout(
             barmode="group", height=380,
-            yaxis=dict(title="Magnitude (units vary)", type=_scale, gridcolor="#f1f5f9"),
+            yaxis=dict(title="Magnitude (units vary)", type=_scale, exponentformat="power" if _scale == "Log scale" else "none", gridcolor="#f1f5f9"),
             xaxis=dict(gridcolor="#f1f5f9"),
             legend=dict(orientation="h", y=1.1, x=0),
             margin=dict(l=50, r=20, t=60, b=40),
@@ -1223,8 +1226,8 @@ Since {RESNET50_FLOPS/(RESNET50_SIZE_MB/1024*1e9):.0f} << {_ridge_point:.0f}, th
             _rkind = "success"
         elif _pred == "100x":
             _rev = (f"**The gap is ~{_actual/100:.0f}x larger than your prediction.** "
-                    f"Actual: ~{_actual:,.0f}x. Each tier drops ~100x, "
-                    "compounding across three steps.")
+                    f"Actual: ~{_actual:,.0f}x, which is compounded across the drop from "
+                    f"Cloud to Edge and Edge to TinyML.")
             _rkind = "warn"
         elif _pred == "10000x":
             _rev = (f"**Close but ~100x too low.** Actual: ~{_actual:,.0f}x.")
@@ -1317,7 +1320,6 @@ Since {RESNET50_FLOPS/(RESNET50_SIZE_MB/1024*1e9):.0f} << {_ridge_point:.0f}, th
                         <strong>Read:</strong> the Introduction chapter for the D-A-M framework,
                         the Iron Law section (Ch. 1) for the full Iron Law derivation,
                         the Deployment Spectrum section (Ch. 1) for the hardware tier table.
-                        <br/><strong>Build:</strong> TinyTorch Module 01 -- implement the D-A-M diagnostic framework and Iron Law calculator from scratch.
                     </div>
                 </div>
             </div>

--- a/site/about/contributors.json
+++ b/site/about/contributors.json
@@ -1,10 +1,10 @@
 {
-  "generated": "2026-06-09T17:49:05.663250+00:00",
+  "generated": "2026-06-08T01:41:49.050804+00:00",
   "repo": "harvard-edge/cs249r_book",
   "stats": {
-    "forks": 2982,
-    "issues": 21,
-    "stars": 24761,
+    "forks": 2974,
+    "issues": 20,
+    "stars": 24731,
     "watchers": 177
   },
   "total": 97,
@@ -13,7 +13,7 @@
       "login": "profvjreddi",
       "name": "Vijay Janapa Reddi",
       "avatar_url": "https://avatars.githubusercontent.com/u/6807956?v=4",
-      "contributions": 15005,
+      "contributions": 14877,
       "html_url": "https://github.com/profvjreddi"
     },
     {

--- a/tinytorch/src/07_optimizers/07_optimizers.py
+++ b/tinytorch/src/07_optimizers/07_optimizers.py
@@ -5,7 +5,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.17.1
+#       jupytext_version: 1.19.2
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python
@@ -81,7 +81,7 @@ DEFAULT_EPS = 1e-8  # Small epsilon for numerical stability in Adam
 DEFAULT_WEIGHT_DECAY_ADAMW = 0.01  # Default weight decay for AdamW
 
 # %% [markdown]
-"""
+r"""
 ## 💡 Introduction: What are Optimizers?
 
 Optimizers are the engines that drive neural network learning. They take gradients computed from your loss function and use them to update model parameters toward better solutions. Think of optimization as navigating a complex landscape where you're trying to find the lowest valley (minimum loss).
@@ -92,13 +92,14 @@ Imagine you're hiking in dense fog, trying to reach the bottom of a valley. You 
 
 ```
 Loss Landscape (2D visualization):
-       🏔️
-      /  \\
-   🚶 /    \\
-    /      \\
-   /   🎯   \\  ← Global minimum (goal)
-  /          \\
- 🏔️          🏔️
+
+   🏔️         🏔️
+   |         /
+    \       |
+     |     /
+      \   |
+       \ /
+        🎯  ← Global minimum (goal)
 
 Challenge: Navigate to 🎯 using only local slope information!
 ```
@@ -133,7 +134,7 @@ But sophisticated optimizers do much more than basic gradient descent!
 """
 
 # %% [markdown]
-"""
+r"""
 ## 📐 Foundations: Mathematical Background
 
 ### Understanding Momentum: The Physics of Optimization
@@ -141,16 +142,11 @@ But sophisticated optimizers do much more than basic gradient descent!
 Momentum in optimization works like momentum in physics. A ball rolling down a hill doesn't immediately change direction when it hits a small bump - it has momentum that carries it forward.
 
 ```
-Without Momentum (SGD):           With Momentum:
-     ↓                                ↘️
-  ←  •  →  ← oscillation           →  •  → smooth path
-     ↑                                ↙️
-
 Narrow valley problem:            Momentum solution:
-|\\     /|                        |\\     /|
-| \\ • / | ← ping-pong             | \\ •→/ | ← smoother
-|  \\ /  |   motion                |  \\ /  |   descent
-|   ●   |                        |   ●   |
+|\•➡️ ⬅️ •/|                        |\•      /|
+| \     / | ← ping-pong            | \↘️    / | ← smoother
+|  \   /  |   motion               |  \•➡️•/  |   descent
+|    ●    |                        |     ●    |
 ```
 
 **SGD with Momentum Formula:**
@@ -168,23 +164,10 @@ the gradient, which is needed for its bias-correction and adaptive scaling steps
 ### Adam: Adaptive Learning for Each Parameter
 
 Adam solves a key problem: different parameters need different learning rates. Imagine adjusting the focus and zoom on a camera - you need fine control for focus but coarse control for zoom.
-
-```
-Parameter Landscape (2 dimensions):
-
-   param2
-     ^
-     |
-   😞|    steep gradient
-     |    (needs small steps)
-     |
-  ---+--●--→ param1
-     |     \\
-     |      \\ gentle gradient
-     |       \\ (needs big steps)
+- A steep gradient would require small steps, as if it were carefully climbing down the mountain.
+- A gentle gradient would require large steps, since going fast doesn't have as large of an effect.
 
 Adam Solution: Automatic step size per parameter!
-```
 
 **Adam's Two-Memory System:**
 
@@ -473,7 +456,7 @@ if __name__ == "__main__":
     test_unit_optimizer_base()
 
 # %% [markdown]
-"""
+r"""
 ## 🏗️ SGD - Stochastic Gradient Descent
 
 SGD is the foundation of neural network perf. It implements the simple but powerful idea: "move in the direction opposite to the gradient."
@@ -483,22 +466,24 @@ SGD is the foundation of neural network perf. It implements the simple but power
 Gradients point uphill (toward higher loss). To minimize loss, we go downhill:
 
 ```
-Loss Surface (side view):
+Loss Surface (side view, imagine plane):
 
     Loss
-     ^
+     ↑
      |
-  📈 |     current position
-     |    /
-     |   • ← you are here
-     |  / \\
-     | /   \\ gradient points uphill
-     |/     \\
-     ●-------\\--→ parameters
-      \\        \\
-       \\        ↘️ SGD steps downhill
-        \\        (opposite to gradient)
-         \\⭐ ← goal (minimum loss)
+     |  current position
+     |    |
+     |   /|
+     |  / |\
+     | /  |\\ gradient points uphill
+     |/   | \\
+     ●----|--\\--→ parameter
+    / \\  •   \\ ↘️ SGD steps downhill (opposite to gradient)
+   /   \\         
+  /     \\   ⭐ ← goal (minimum loss)     
+ ↙       \\
+ other
+parameter
 ```
 
 ### The Oscillation Problem
@@ -506,16 +491,21 @@ Loss Surface (side view):
 Pure SGD can get trapped oscillating in narrow valleys:
 
 ```
-Narrow valley (top view):
-  \\     /
-   \\   /   ← steep sides
-    \\ /
-  4← • →2  ← SGD bounces back and forth
-    / \\
-   1   3   instead of going down the valley
-  /     \\
- ●       \\
- goal     \\
+Narrow valley (side view, two different gradients shown as planes):
+   
+    first position
+          |
+     -----+---------- 
+     \\ / |     \\ /
+      \\  •→ ←•  \\
+      /\\     |  /\\
+     /  \\ ⭐ | /  \\
+    /    \\|  |/    \\
+    -------+--+-------  
+           |  |
+           | second position
+           |
+          goal (minimum loss)
 ```
 
 ### Momentum Solution
@@ -524,14 +514,20 @@ Momentum remembers the direction you were going and continues in that direction:
 
 ```
 With momentum:
-  \\     /
-   \\   /
-    \\ /
-     •  ← smooth path down the valley
-    / ↓
-   /   ↓
-  ●    ↓  momentum carries us through oscillations
- goal
+
+starting position
+          |
+     -----|---------- 
+     \\ / •↘     \\ /
+      \\    ↙•    \\
+      /\\ •↘     / \\
+     /  \\ ⭐   /   \\
+    /    \\|   /     \\
+    -------+----------  
+           | 
+           | 
+           |
+          goal (minimum loss)
 ```
 
 **Implementation:** SGD keeps a "velocity" buffer that accumulates momentum.
@@ -780,13 +776,13 @@ Consider a neural network with both first layer weights and output weights:
 ```
 Parameter Sensitivity Landscape:
 
-  output_weight                 first_layer_weight
-       ↑                              ↑
-       |                              |
-    😱 |  steep cliff                 |  🐌 gentle slope
-       |  (needs tiny steps)          |  (needs big steps)
-       |                              |
-    ━━━●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━●━━━→
+    first_layer_weight              output_weight
+           ↑                               ↑
+           |                               |
+           |  🐌 gentle slope              |  ⛰️ steep cliff
+           |  (needs big steps)            |  (needs tiny steps)
+           |                               |
+        ━━━●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━●━━━→
 
 Same learning rate = disaster!
 • Small LR: output weights learn fast, first layer crawls
@@ -1212,14 +1208,14 @@ update step size.
 ### Visual Comparison
 
 ```
-Adam weight decay:               AdamW weight decay:
+Adam weight decay:                  AdamW weight decay:
 
-gradient ──┐                    gradient ──→ adaptive ──→ param
+gradient ──┐                        gradient ──→ adaptive ──→ param
            ├─→ adaptive ──→ param                  update
 weight ────┘   scaling
 decay
-                                weight ─────────→ param
-                                decay           shrinkage
+                                    weight ─────────→ param
+                                    decay           shrinkage
 
 Coupled (inconsistent)          Decoupled (consistent)
 ```

--- a/tinytorch/src/08_training/08_training.py
+++ b/tinytorch/src/08_training/08_training.py
@@ -479,19 +479,19 @@ one at a time, testing as you go.
 
 ```
 Trainer Components:
-┌────────────────────────────────────────────────┐
-│  Trainer                                       │
-│  ├── __init__       → Store components, state  │
-│  ├── train_epoch    → Forward/backward loop    │
-│  ├── evaluate       → Forward only, metrics    │
-│  ├── save_checkpoint → Serialize to disk       │
-│  └── load_checkpoint → Restore from disk       │
-│                                                │
-│  Private helpers (provided):                   │
-│  ├── _get_model_state / _set_model_state       │
-│  ├── _get_optimizer_state / _set_optimizer_state│
-│  └── _get_scheduler_state / _set_scheduler_state│
-└────────────────────────────────────────────────┘
+┌───────────────────────────────────────────────────┐
+│  Trainer                                          │
+│  ├── __init__       → Store components, state     │
+│  ├── train_epoch    → Forward/backward loop       │
+│  ├── evaluate       → Forward only, metrics       │
+│  ├── save_checkpoint → Serialize to disk          │
+│  └── load_checkpoint → Restore from disk          │
+│                                                   │
+│  Private helpers (provided):                      │
+│  ├── _get_model_state / _set_model_state          │
+│  ├── _get_optimizer_state / _set_optimizer_state  │
+│  └── _get_scheduler_state / _set_scheduler_state  │
+└───────────────────────────────────────────────────┘
 ```
 
 You will implement the five public methods. The private serialization helpers
@@ -570,24 +570,24 @@ Think of it as assembling the instruments before the orchestra plays.
 
 ```
 Trainer State After __init__:
-┌─────────────────────────────────────┐
-│  Components:                        │
-│    model       → Neural network     │
-│    optimizer   → Parameter updater  │
-│    loss_fn     → Error measure      │
-│    scheduler   → LR adjuster (opt)  │
-│    grad_clip_norm → Stability (opt) │
-│                                     │
-│  State:                             │
-│    epoch = 0                        │
-│    step = 0                         │
-│    training_mode = True             │
-│                                     │
-│  History:                           │
-│    train_loss = []                  │
-│    eval_loss = []                   │
-│    learning_rates = []              │
-└─────────────────────────────────────┘
+┌──────────────────────────────────────┐
+│  Components:                         │
+│    model       → Neural network      │
+│    optimizer   → Parameter updater   │
+│    loss_fn     → Error measure       │
+│    scheduler   → LR adjuster (opt)   │
+│    grad_clip_norm → Stability (opt)  │
+│                                      │
+│  State:                              │
+│    epoch = 0                         │
+│    step = 0                          │
+│    training_mode = True              │
+│                                      │
+│  History:                            │
+│    train_loss = []                   │
+│    eval_loss = []                    │
+│    learning_rates = []               │
+└──────────────────────────────────────┘
 ```
 """
 
@@ -718,15 +718,15 @@ the forward-backward-update cycle that drives learning.
 
 ```
 Training Loop Flow:
-┌─────────────────────────────────────────────┐
-│  for each batch in dataloader:              │
-│    outputs = model.forward(inputs)     →    │
-│    loss = loss_fn(outputs, targets)    →    │
-│    loss.backward(grad)                →    │
-│    optimizer.step()                   →    │
-│    optimizer.zero_grad()                    │
-│  scheduler.get_lr(epoch)                    │
-└─────────────────────────────────────────────┘
+┌────────────────────────────────────────────┐
+│  for each batch in dataloader:             │
+│    outputs = model.forward(inputs)         │
+│    loss = loss_fn(outputs, targets)        │
+│    loss.backward(grad)                     │
+│    optimizer.step()                        │
+│    optimizer.zero_grad()                   │
+│  scheduler.get_lr(epoch)                   │
+└────────────────────────────────────────────┘
 ```
 
 With gradient accumulation, the update step happens every N batches instead
@@ -1242,16 +1242,16 @@ essential for long training runs that may be interrupted.
 
 ```
 Checkpoint Contents:
-┌───────────────────────────────────┐
-│  checkpoint.pkl                   │
-│  ├── epoch: 42                    │
-│  ├── step: 1680                   │
-│  ├── model_state: {weights...}    │
-│  ├── optimizer_state: {lr, mom..} │
-│  ├── scheduler_state: {lr range}  │
-│  ├── history: {losses, lrs...}    │
-│  └── training_mode: True          │
-└───────────────────────────────────┘
+┌────────────────────────────────────┐
+│  checkpoint.pkl                    │
+│  ├── epoch: 42                     │
+│  ├── step: 1680                    │
+│  ├── model_state: {weights...}     │
+│  ├── optimizer_state: {lr, mom..}  │
+│  ├── scheduler_state: {lr range}   │
+│  ├── history: {losses, lrs...}     │
+│  └── training_mode: True           │
+└────────────────────────────────────┘
 ```
 """
 
@@ -1609,6 +1609,9 @@ def demonstrate_complete_training_pipeline():
     print("   • Checkpointing for training persistence")
     print("   • Evaluation mode for model assessment")
 
+if __name__ == "__main__":
+    demonstrate_complete_training_pipeline()
+
 # %% [markdown]
 """
 ## 📊 Systems Analysis: Training Performance and Memory
@@ -1714,7 +1717,6 @@ def analyze_training_memory():
     print("- Adam: 4× parameter memory (params + grads + 2 moment buffers)")
     print("- Gradient accumulation reduces memory but increases training time")
 
-# %%
 def analyze_checkpoint_overhead():
     """📊 Analyze checkpoint size and overhead."""
     print("\n📊 Analyzing Checkpoint Overhead...")


### PR DESCRIPTION
Tested through `tito module test NN` for modules 07 and 08.
_Note_: It fails FAILED tests/integration/test_training_flow.py::TestTrainingReducesLoss::test_mlp_loss_decreases, however the commits here aren't meant to fix this, and they shouldn't be altering/causing it in any way.

I manually checked to make sure the new diagrams and wording is accurate.

Changes for tinytorch
* Fixed diagram representations for easier understanding
* Fixed alignment/consistency issues

Changes for labs
* Fixed duration so that it adds up in the correct spot
* Fixed equation representation
* Fixed graph so that logarithm y-axis so that y-axis is easier to understand