### PR TITLE
fix(staffml): mount the command palette and shortcuts overlay

### DIFF
--- a/interviews/staffml/src/app/layout.tsx
+++ b/interviews/staffml/src/app/layout.tsx
@@ -6,6 +6,8 @@ import AnnouncementBar from "@/components/AnnouncementBar";
 import MaybeFooter from "@/components/MaybeFooter";
 import Providers from "@/components/Providers";
 import VersionDriftToast from "@/components/VersionDriftToast";
+import CommandPalette from "@/components/CommandPalette";
+import KeyboardShortcutsOverlay from "@/components/KeyboardShortcutsOverlay";
 import { QUESTION_COUNT_DISPLAY } from "@/lib/corpus";
 
 export const metadata: Metadata = {
@@ -100,6 +102,12 @@ export default function RootLayout({
           <main className="flex-1 flex flex-col">{children}</main>
           <MaybeFooter />
           <VersionDriftToast />
+          {/* Global overlays: command palette (Cmd/Ctrl+K, navbar search icon)
+              and the keyboard-shortcuts cheat sheet (?). Mounted once here so
+              they're reachable from every route. CommandPalette must live
+              inside Providers — it reads the vault via useVault(). */}
+          <CommandPalette />
+          <KeyboardShortcutsOverlay />
         </Providers>
       </body>
     </html>

--- a/interviews/staffml/tests/command-palette.spec.ts
+++ b/interviews/staffml/tests/command-palette.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * Smoke test for the globally-mounted command palette + shortcuts overlay.
+ *
+ * Regression guard for the mount bug: CommandPalette and
+ * KeyboardShortcutsOverlay were authored (with tests + docblocks claiming
+ * they live in app/layout.tsx) but the mount line was never added, so the
+ * navbar search icon, Cmd/Ctrl+K, and `?` were all no-ops on every route.
+ *
+ * Checks the three entry points that were dead:
+ *   1. Ctrl+K opens the palette and focuses its input; Esc closes it.
+ *   2. The navbar search icon dispatches staffml:open-palette → same palette.
+ *   3. `?` opens the keyboard-shortcuts overlay.
+ */
+import { test, expect } from "@playwright/test";
+
+test.describe("Command palette — global mount", () => {
+  test("Ctrl+K opens the palette and Esc closes it", async ({ page }) => {
+    await page.goto("/");
+
+    // Closed by default — the component renders null when not open.
+    const palette = page.getByRole("dialog", { name: /command palette/i });
+    await expect(palette).toHaveCount(0);
+
+    await page.keyboard.press("Control+k");
+    await expect(palette).toBeVisible();
+
+    // Input is focused on open.
+    await expect(
+      palette.getByPlaceholder(/search pages, topics, or questions/i),
+    ).toBeFocused();
+
+    // Pages section is available with an empty query.
+    await expect(palette.getByRole("option", { name: /Practice/i }).first()).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(palette).toHaveCount(0);
+  });
+
+  test("navbar search icon opens the same palette", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("button", { name: /search \(cmd\+k\)/i }).click();
+    await expect(page.getByRole("dialog", { name: /command palette/i })).toBeVisible();
+  });
+
+  test("? opens the keyboard-shortcuts overlay", async ({ page }) => {
+    await page.goto("/");
+    await page.keyboard.press("?");
+    await expect(
+      page.getByRole("dialog", { name: /keyboard shortcuts/i }),
+    ).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(
+      page.getByRole("dialog", { name: /keyboard shortcuts/i }),
+    ).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Problem

`CommandPalette` and `KeyboardShortcutsOverlay` were added in the client-UX overhaul (`cefa8bfe63`) — complete with unit tests and docblocks stating they are *"mounted in `app/layout.tsx`"* — but the mount line was never actually added. `git log -S CommandPalette -- src/app/layout.tsx` returns nothing: they have been dead since introduction.

As a result, on **every** route:
- the navbar search icon dispatches `staffml:open-palette` into the void (no listener mounted),
- **Cmd/Ctrl+K** does nothing,
- **`?`** does nothing.

## Fix

Render both overlays once in `RootLayout`, inside `<Providers>` so the palette can read the vault via `useVault()` (it would throw outside `CorpusProvider`).

## Test

Adds a Playwright smoke test (`tests/command-palette.spec.ts`) covering the three previously-dead entry points: Ctrl+K, the navbar search icon, and `?`. `tsc --noEmit` is clean.

## How to verify

1. `npm run dev`, open any page.
2. Click the navbar search icon **or** press **Ctrl/Cmd+K** → palette opens.
3. Press **`?`** → keyboard-shortcuts overlay opens. **Esc** closes either.