### PR TITLE
fix(staffml): keep command-palette active row in view during keyboard nav

### DIFF
--- a/interviews/staffml/src/__tests__/command-palette-scroll.test.tsx
+++ b/interviews/staffml/src/__tests__/command-palette-scroll.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * CommandPalette keyboard-scroll guardrail.
+ *
+ * The result list is scrollable (max-h-[60vh]). Arrowing down past the fold
+ * used to move the highlighted row out of view because nothing scrolled the
+ * active row back into the viewport. We now call scrollIntoView on the active
+ * row whenever activeIdx changes, with `block: "nearest"` so an already-visible
+ * row never causes a jump.
+ *
+ * jsdom doesn't implement Element.prototype.scrollIntoView, so we spy on it.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import CommandPalette from '@/components/CommandPalette';
+
+// ─── Mock the data + routing deps so the palette renders standalone ──
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+vi.mock('@/lib/taxonomy', () => ({ searchTopics: () => [] }));
+vi.mock('@/lib/corpus', () => ({ searchQuestions: () => [] }));
+vi.mock('@/lib/corpus-provider', () => ({
+  useVault: () => ({ apiBase: null }),
+  vaultSearch: async () => [],
+}));
+
+function openPalette() {
+  // The navbar dispatches this event to open the palette by click.
+  act(() => {
+    window.dispatchEvent(new Event('staffml:open-palette'));
+  });
+}
+
+describe('CommandPalette active-row scrolling', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('scrolls the active row into view when navigating with ArrowDown', () => {
+    const scrollSpy = vi
+      .spyOn(Element.prototype, 'scrollIntoView')
+      .mockImplementation(() => {});
+
+    render(<CommandPalette />);
+    openPalette();
+
+    // With an empty query the static Pages list is shown — enough rows to navigate.
+    const input = screen.getByLabelText(/command palette query/i);
+
+    scrollSpy.mockClear();
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+    // The newly-active row (index 1) should have been scrolled into view.
+    const calledRows = scrollSpy.mock.instances as Element[];
+    expect(scrollSpy).toHaveBeenCalled();
+    expect(calledRows.some(el => el.id === 'cmdk-row-1')).toBe(true);
+    // And it must use block:"nearest" so visible rows never jump.
+    expect(scrollSpy).toHaveBeenCalledWith({ block: 'nearest' });
+  });
+
+  it('scrolls back up to the active row on ArrowUp', () => {
+    const scrollSpy = vi
+      .spyOn(Element.prototype, 'scrollIntoView')
+      .mockImplementation(() => {});
+
+    render(<CommandPalette />);
+    openPalette();
+    const input = screen.getByLabelText(/command palette query/i);
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    scrollSpy.mockClear();
+    fireEvent.keyDown(input, { key: 'ArrowUp' });
+
+    const calledRows = scrollSpy.mock.instances as Element[];
+    expect(calledRows.some(el => el.id === 'cmdk-row-1')).toBe(true);
+  });
+});

--- a/interviews/staffml/src/__tests__/setup.ts
+++ b/interviews/staffml/src/__tests__/setup.ts
@@ -30,3 +30,9 @@ class ResizeObserverStub {
   disconnect() {}
 }
 globalThis.ResizeObserver = ResizeObserverStub as unknown as typeof ResizeObserver;
+
+// jsdom doesn't implement scrollIntoView; components that keep an active row in
+// view (e.g. CommandPalette) call it, and tests spy on it.
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = function () {};
+}

--- a/interviews/staffml/src/components/CommandPalette.tsx
+++ b/interviews/staffml/src/components/CommandPalette.tsx
@@ -22,6 +22,7 @@
  *   role="listbox" on the result list, role="option" on items
  *   aria-selected on the active row
  *   focus on the input on open, restore on close
+ *   active row scrolled into view as you arrow through results
  */
 
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -199,6 +200,18 @@ export default function CommandPalette() {
   useEffect(() => {
     setActiveIdx(0);
   }, [query, searchQuery]);
+
+  // Keep the active row visible during keyboard navigation. The result list is
+  // scrollable (max-h-[60vh]); arrowing past the fold would otherwise move the
+  // highlight out of view. `block: "nearest"` is a no-op when the row is already
+  // fully visible, so hovering a visible row — which also sets activeIdx via
+  // onMouseEnter — never triggers a scroll jump.
+  useEffect(() => {
+    if (!open) return;
+    document
+      .getElementById(`cmdk-row-${activeIdx}`)
+      ?.scrollIntoView({ block: "nearest" });
+  }, [activeIdx, open]);
 
   // ─── Commit a result ─────────────────────────────────
   const commit = (r: Result) => {


### PR DESCRIPTION
## Problem (accessibility)

The Cmd+K command-palette result list is scrollable (`max-h-[60vh]`). Arrowing past the fold updated `aria-activedescendant` and the highlight class, but nothing scrolled the active row back into the viewport — so **keyboard-only users lost the highlight off-screen** on longer result sets (e.g. a question search returning Pages + Topics + 12 questions).

## Fix

Scroll the active row into view whenever `activeIdx` changes, using `block: "nearest"` so an already-visible row — e.g. one set active via `onMouseEnter` hover — never triggers a scroll jump.

```tsx
useEffect(() => {
  if (!open) return;
  document.getElementById(`cmdk-row-${activeIdx}`)?.scrollIntoView({ block: "nearest" });
}, [activeIdx, open]);
```

## Test

Adds `command-palette-scroll.test.tsx` covering ArrowDown/ArrowUp navigation, plus a jsdom `scrollIntoView` stub in the shared test setup (jsdom doesn't implement it). Full suite: 113 passing. `tsc --noEmit` clean.

## Note

Best reviewed/merged **after** #1856 — the command palette is currently not mounted in `app/layout.tsx`, so this keyboard behavior is only reachable once that mount lands. The two changes touch different files and do not conflict.