### PR TITLE
fix(staffml): announce toasts to assistive tech and label the dismiss button

### DIFF
--- a/interviews/staffml/src/__tests__/toast-a11y.test.tsx
+++ b/interviews/staffml/src/__tests__/toast-a11y.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * Toast accessibility guardrails.
+ *
+ * Toasts (badge unlocks, streak bumps, success messages) used to be invisible
+ * to assistive tech: the container was a plain <div> with no live region, and
+ * the dismiss button was an icon-only <button> with no accessible name. Screen
+ * readers announced nothing on a toast, and "button" with no label on dismiss.
+ *
+ * We now expose the container as a polite live region and give the dismiss
+ * button an aria-label — matching the existing VersionDriftToast pattern.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ToastProvider, useToast } from '@/components/Toast';
+
+// Minimal consumer that fires a toast on click — exercises the public API.
+function Trigger() {
+  const { show } = useToast();
+  return (
+    <button onClick={() => show({ type: 'badge', title: 'Streak unlocked', description: '7-day streak' })}>
+      fire toast
+    </button>
+  );
+}
+
+function renderWithToast() {
+  return render(
+    <ToastProvider>
+      <Trigger />
+    </ToastProvider>,
+  );
+}
+
+describe('Toast a11y', () => {
+  it('exposes the toast container as a labelled polite live region', () => {
+    renderWithToast();
+    const region = screen.getByRole('region', { name: /notifications/i });
+    expect(region).toHaveAttribute('aria-live', 'polite');
+    // aria-atomic=false so only the newly-added toast is announced, not the
+    // whole stack re-read on every change.
+    expect(region).toHaveAttribute('aria-atomic', 'false');
+  });
+
+  it('renders a fired toast with its title and description', () => {
+    renderWithToast();
+    fireEvent.click(screen.getByText('fire toast'));
+    expect(screen.getByText('Streak unlocked')).toBeInTheDocument();
+    expect(screen.getByText('7-day streak')).toBeInTheDocument();
+  });
+
+  it('gives the dismiss button an accessible name', () => {
+    renderWithToast();
+    fireEvent.click(screen.getByText('fire toast'));
+    expect(
+      screen.getByRole('button', { name: /dismiss notification/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/interviews/staffml/src/components/Toast.tsx
+++ b/interviews/staffml/src/components/Toast.tsx
@@ -43,8 +43,19 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   return (
     <ToastContext.Provider value={{ show }}>
       {children}
-      {/* Toast container */}
-      <div className="fixed bottom-4 right-4 z-[100] flex flex-col gap-2 max-w-sm">
+      {/* Toast container.
+          Polite live region so screen readers announce toasts (badge unlocks,
+          streaks, success messages) as they appear. aria-atomic="false" means
+          only the newly-inserted toast is read, not the whole stack re-read on
+          every change. The container is always mounted; toasts are inserted as
+          children, which is the reliable way for additions to be announced. */}
+      <div
+        role="region"
+        aria-label="Notifications"
+        aria-live="polite"
+        aria-atomic="false"
+        className="fixed bottom-4 right-4 z-[100] flex flex-col gap-2 max-w-sm"
+      >
         <AnimatePresence>
           {toasts.map(toast => (
             <motion.div
@@ -70,10 +81,12 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
                 )}
               </div>
               <button
+                type="button"
                 onClick={() => dismiss(toast.id)}
+                aria-label="Dismiss notification"
                 className="text-textTertiary hover:text-textPrimary transition-colors shrink-0"
               >
-                <X className="w-4 h-4" />
+                <X className="w-4 h-4" aria-hidden="true" />
               </button>
             </motion.div>
           ))}


### PR DESCRIPTION
## Problem (accessibility)

Toasts — badge unlocks, streak milestones, "Saved to your browser", "Link copied" — were **invisible to screen readers**:

- The toast container was a plain `<div>` with **no live region**, so nothing was announced when a toast appeared.
- The icon-only dismiss button had **no accessible name** — a screen reader read just *"button"* (and axe flags "Buttons must have discernible text").

Notably the repo's *other* toast, `VersionDriftToast`, already does this correctly with `role="status"` + `aria-live="polite"` — so this is an inconsistency with an in-repo precedent.

## Fix

- Make the always-mounted container a polite live region: `role="region"` + `aria-label="Notifications"` + `aria-live="polite"`, with `aria-atomic="false"` so only the newly-added toast is announced rather than the whole stack being re-read on every change.
- Give the dismiss button `aria-label="Dismiss notification"` (+ `type="button"`), and mark the `X` icon `aria-hidden`.

## Test

Adds `src/__tests__/toast-a11y.test.tsx` asserting the live-region attributes and the dismiss button's accessible name. Full suite green (112), `tsc --noEmit` clean.

## How to verify

1. `npm run dev`, go to `/practice`, click **"Copy question link"** → a toast appears.
2. DevTools → Accessibility pane: container is a "region" named *Notifications* (live = polite); the X button's computed name is *"Dismiss notification"* (was unnamed).
3. With a screen reader (NVDA / VoiceOver): the toast text is spoken on appearance; the dismiss button announces its name.