### PR TITLE
fix(ci): stage mlsysbook-labs wheel for the WASM browser smoke test

### DIFF
--- a/.github/workflows/labs-validate-dev.yml
+++ b/.github/workflows/labs-validate-dev.yml
@@ -179,6 +179,12 @@ jobs:
           echo "✅ Wheel built:"
           ls -la dist/*.whl
 
+      - name: 📦 Build mlsysbook-labs helper wheel
+        run: |
+          python3 -m build --wheel labs --outdir labs/dist
+          echo "✅ Lab helper wheel built:"
+          ls -la labs/dist/*.whl
+
       - name: 📦 Setup Node.js for Pyodide test
         uses: actions/setup-node@v6
         with:
@@ -226,9 +232,12 @@ jobs:
           SMOKE_LABS="labs/vol1/lab_00_introduction.py labs/vol1/lab_01_ml_intro.py labs/vol2/lab_01_introduction.py labs/vol2/lab_05_dist_train.py"
           FAILED=""
 
-          # Setup wheel directory so relative paths work
+          # Setup wheel directory so relative paths work. Labs bootstrap with
+          # BOTH the mlsysim engine wheel and the mlsysbook-labs helper wheel,
+          # so both must be served or micropip 404s and Pyodide raises BadZipFile.
           mkdir -p /tmp/wasm-smoke/wheels
           cp mlsysim/dist/*.whl /tmp/wasm-smoke/wheels/
+          cp labs/dist/mlsysbook_labs-*.whl /tmp/wasm-smoke/wheels/
 
           for lab in $SMOKE_LABS; do
             name=$(basename "$lab" .py)


### PR DESCRIPTION
## What

The `🔮 Labs · ✅ Validate (Dev)` workflow has been failing at the **Browser smoke test (real Chromium + Pyodide)** step. All four smoke labs boot, then fail with:

```
❌ browser smoke failed:
  lab_00_introduction:  - [python] BadZipFile: File is not a zip file
  lab_01_introduction:  - [python] BadZipFile: File is not a zip file
  lab_01_ml_intro:      - [python] BadZipFile: File is not a zip file
  lab_05_dist_train:    - [python] BadZipFile: File is not a zip file
```

## Root cause

The labs bootstrap with **two** micropip installs:

```python
await micropip.install("../../wheels/mlsysim-0.1.2-py3-none-any.whl", ...)
await micropip.install("../../wheels/mlsysbook_labs-0.1.0-py3-none-any.whl", ...)
```

The WASM smoke job in `labs-validate-dev.yml` only built and served the **mlsysim** engine wheel. When the exported lab boots in headless Chromium, micropip 404s on `mlsysbook_labs-0.1.0-py3-none-any.whl`, gets an HTML error page instead of a zip, and Pyodide raises `BadZipFile`.

The Node-Pyodide step still passes because it installs only the mlsysim wheel directly via `file://` and never runs the lab's own bootstrap — only the real-browser step exercises both wheels, which is exactly the gap it exists to catch.

It surfaced now (last green: 2026-06-07) because the canonical-lab-track work added the `mlsysbook_labs` micropip line to the smoke labs after that run.

## Fix

Build the `mlsysbook-labs` helper wheel and copy it next to the engine wheel in the smoke wheels dir, mirroring what `labs/tools/build_site.sh` already does for the production/preview builds.

## Scope / risk

- **CI-only.** Production and preview (`labs/tools/build_site.sh`) already build both wheels, so the live labs site is unaffected.
- Verified locally that `python -m build --wheel labs` and `python -m build --wheel mlsysim` produce `mlsysbook_labs-0.1.0-py3-none-any.whl` and `mlsysim-0.1.2-py3-none-any.whl` — the exact filenames the labs request.