### PR TITLE
fix(conv2d): Conv2dBackward return tuple must match saved_tensors length

### DIFF
--- a/tinytorch/src/09_convolutions/09_convolutions.py
+++ b/tinytorch/src/09_convolutions/09_convolutions.py
@@ -567,8 +567,9 @@ class Conv2dBackward(Function):
         else:
             grad_input = grad_input_padded
 
-        # Return gradients as numpy arrays (autograd system handles storage)
-        # Following TinyTorch protocol: return (grad_input, grad_weight, grad_bias)
+        # Tuple length must match saved_tensors: (x, weight) or (x, weight, bias).
+        if self.bias is None:
+            return grad_input, grad_weight
         return grad_input, grad_weight, grad_bias
 
 #| export


### PR DESCRIPTION
## What breaks

`Conv2dBackward.__init__` registers either 2 or 3 tensors in `saved_tensors` depending on whether bias exists:

```python
if bias is not None:
    super().__init__(x, weight, bias)   # 3 saved tensors
else:
    super().__init__(x, weight)         # 2 saved tensors
```

But `apply()` always returned a 3-tuple `(grad_input, grad_weight, grad_bias)`.

The backward walk zips `saved_tensors` with the return tuple. When `bias=None`, zip silently truncates at 2 pairs, so `grad_bias` is produced but never consumed. This is fragile -- any reordering of `saved_tensors` or `apply()` output would silently corrupt weight updates.

## Fix

Return only `(grad_input, grad_weight)` when `bias is None`, so tuple length always equals `len(saved_tensors)`.

## Test plan
- [ ] Run `pytest tinytorch/tests/09_convolutions/` -- all conv tests pass
- [ ] Manually verify bias=False Conv2d still trains (weight grads non-zero)
- [ ] Verify bias=True Conv2d unchanged behavior