### PR TITLE
fix(autograd): SumBackward multi-axis gradient restores wrong shape

### DIFF
--- a/tinytorch/src/06_autograd/06_autograd.py
+++ b/tinytorch/src/06_autograd/06_autograd.py
@@ -1389,10 +1389,12 @@ class SumBackward(Function):
         tensor, = self.saved_tensors
 
         if isinstance(tensor, Tensor) and tensor.requires_grad:
-            # For axis-reduced sums, expand grad_output back along the summed
-            # axis before broadcasting, so each row/column gets its own gradient.
+            # Expand dims one at a time in sorted order so each insertion is
+            # relative to the correct growing shape (safe for tuple axes).
             if self.axis is not None and not self.keepdims:
-                grad_output = np.expand_dims(grad_output, axis=self.axis)
+                axes = (self.axis,) if isinstance(self.axis, int) else tuple(sorted(self.axis))
+                for ax in axes:
+                    grad_output = np.expand_dims(grad_output, axis=ax)
             return np.ones_like(tensor.data) * grad_output,
         return None,
         ### END SOLUTION


### PR DESCRIPTION
## What breaks

`SumBackward.apply()` calls `np.expand_dims(grad_output, axis=self.axis)` with a tuple when the user reduces over multiple axes (e.g. `.mean(axis=(1, 2))`).

NumPy evaluates all axes in the tuple **relative to the current (already-reduced) shape**. For non-contiguous or higher-rank tuple axes this can silently restore the wrong shape. The subsequent `np.ones_like(tensor.data) * grad_output` then broadcasts the gradient incorrectly -- every operation that reduces over multiple spatial axes (common in CNNs: `mean(axis=(2,3))`) produces wrong gradients. The network trains in the wrong direction with no error or exception.

## Fix

Insert one dimension at a time in ascending axis order:
```python
axes = (self.axis,) if isinstance(self.axis, int) else tuple(sorted(self.axis))
for ax in axes:
    grad_output = np.expand_dims(grad_output, axis=ax)
```

After each insertion the array is one rank higher, so the next axis index is still correct relative to the growing shape. Matches PyTorch's convention.

## Test plan
- [ ] `pytest tinytorch/tests/06_autograd/` passes
- [ ] `pytest tinytorch/tests/integration/test_gradients.py` passes
- [ ] Verify: `t = Tensor(np.ones((2,3,4)), requires_grad=True); t.mean(axis=(1,2)).backward()` -- `t.grad.shape` should be `(2,3,4)`