### PR TITLE
fix(layers): Dropout uses global unseeded np.random instead of module rng

### DIFF
--- a/tinytorch/src/03_layers/03_layers.py
+++ b/tinytorch/src/03_layers/03_layers.py
@@ -701,7 +701,7 @@ class Dropout(Layer):
         """
         ### BEGIN SOLUTION
         keep_prob = 1.0 - self.p
-        binary_mask = (np.random.random(shape) < keep_prob).astype(np.float32)
+        binary_mask = (rng.random(shape) < keep_prob).astype(np.float32)
         scale = 1.0 / keep_prob
         return Tensor(binary_mask * scale)
         ### END SOLUTION


### PR DESCRIPTION
## What breaks

`03_layers.py` seeds a module-level RNG for reproducibility:
```python
rng = np.random.default_rng(7)
```

`Dropout._create_mask()` ignores this and calls `np.random.random(shape)`, which draws from the global unseeded state. Dropout masks are therefore different on every run even when the user expects deterministic behavior from the module seed. Any unit test that checks a specific Dropout output value will be flaky.

## Fix

```python
# before
binary_mask = (np.random.random(shape) < keep_prob).astype(np.float32)

# after
binary_mask = (rng.random(shape) < keep_prob).astype(np.float32)
```

One line change -- Dropout now participates in the same reproducible stream as every other random operation in the module.

## Test plan
- [ ] `pytest tinytorch/tests/03_layers/` passes
- [ ] Run twice with same seed -- Dropout produces identical masks both times