### PR TITLE
fix(activations): numerically stable sigmoid + remove overflow warning suppressor

### DIFF
--- a/tinytorch/src/02_activations/02_activations.py
+++ b/tinytorch/src/02_activations/02_activations.py
@@ -92,7 +92,6 @@ If you see import errors, ensure you've run `tito export` after completing Modul
 import numpy as np
 rng = np.random.default_rng(7)
 from typing import Optional
-import warnings
 
 # Import from TinyTorch package (previous modules must be completed and exported)
 from tinytorch.core.tensor import Tensor
@@ -244,8 +243,13 @@ class Sigmoid:
         HINT: Use np.exp(-x.data) for numerical stability
         """
         ### BEGIN SOLUTION
-        # Apply sigmoid: 1 / (1 + exp(-x))
-        result = 1.0 / (1.0 + np.exp(-x.data))
+        # Piece-wise stable form: avoids exp overflow for large |x|.
+        x_data = x.data
+        result = np.where(
+            x_data >= 0,
+            1.0 / (1.0 + np.exp(-x_data)),
+            np.exp(x_data) / (1.0 + np.exp(x_data))
+        )
         return Tensor(result)
         ### END SOLUTION
 
@@ -281,16 +285,10 @@ def test_unit_sigmoid():
     result = sigmoid.forward(x)
     assert np.all(result.data > 0) and np.all(result.data < 1), "All sigmoid outputs should be in (0, 1)"
 
-    # Test specific values
-    # Temporarily suppress overflow warning, expected
-    warnings.filterwarnings('ignore', category=RuntimeWarning)
-    print("Suppressed expected warning about exp overflow...")
-
-    x = Tensor([-1000, 1000])  # Extreme values
+    x = Tensor([-1000, 1000])  # Extreme values -- must not overflow
     result = sigmoid.forward(x)
-    assert np.allclose(result.data[0], 0, atol=TOLERANCE), "sigmoid(-∞) should approach 0"
-    assert np.allclose(result.data[1], 1, atol=TOLERANCE), "sigmoid(+∞) should approach 1"
-    warnings.filterwarnings('default', category=RuntimeWarning)
+    assert np.allclose(result.data[0], 0, atol=TOLERANCE), "sigmoid(-inf) should approach 0"
+    assert np.allclose(result.data[1], 1, atol=TOLERANCE), "sigmoid(+inf) should approach 1"
 
     print("✅ Sigmoid works correctly!")
 


### PR DESCRIPTION
## What breaks

`Sigmoid.forward()` uses the naive form:
```python
result = 1.0 / (1.0 + np.exp(-x.data))
```

For very negative inputs (`x << -87` in float32), `np.exp(-x)` overflows to `inf`. The result `1/(1+inf) = 0.0` is accidentally correct, but NumPy emits a `RuntimeWarning`. The unit test hid this with:
```python
warnings.filterwarnings('ignore', category=RuntimeWarning)
```

This suppressor silences the whole `RuntimeWarning` category for any future code in that block -- meaning a real numerical regression would produce no signal.

## Fix

Use the piece-wise stable sigmoid identity:
```python
result = np.where(
    x_data >= 0,
    1.0 / (1.0 + np.exp(-x_data)),    # exp(-x) in [0,1], safe
    np.exp(x_data) / (1.0 + np.exp(x_data))  # exp(x) in [0,1), safe
)
```

Both branches compute the same mathematical function but stay in the safe exponent range. This is the same trick used by `scipy.special.expit` and PyTorch's `torch.sigmoid`.

With overflow eliminated: remove the `warnings.filterwarnings` calls and the now-unused `import warnings`.

## Test plan
- [ ] `pytest tinytorch/tests/02_activations/` passes with no RuntimeWarning
- [ ] `sigmoid([-1000, 1000])` returns `[~0, ~1]` without any warning
- [ ] `sigmoid([0])` still returns `0.5`