### PR TITLE
fix(autograd): tracked_mul passes raw scalar to MulBackward, causing .data crash on backward

### DIFF
--- a/tinytorch/src/06_autograd/06_autograd.py
+++ b/tinytorch/src/06_autograd/06_autograd.py
@@ -2510,21 +2510,19 @@ def enable_autograd(quiet=False):
         """
         _ensure_grad_attrs(self)
 
-        # Convert scalar to Tensor if needed for consistency
         if not isinstance(other, Tensor):
             other_tensor = Tensor(other)
         else:
             other_tensor = other
         _ensure_grad_attrs(other_tensor)
 
-        # Call original operation
         result = _original_mul(self, other)
         _ensure_grad_attrs(result)
 
-        # Track gradient if needed
+        # Pass other_tensor (always a Tensor) so MulBackward can call .data on it.
         if _get_requires_grad(self) or _get_requires_grad(other_tensor):
             result.requires_grad = True
-            result._grad_fn = MulBackward(self, other)
+            result._grad_fn = MulBackward(self, other_tensor)
 
         return result
 


### PR DESCRIPTION
## What breaks

`tracked_mul()` wraps a scalar operand into `other_tensor = Tensor(other)` correctly, but then builds the grad function with the original scalar:

```python
result._grad_fn = MulBackward(self, other)   # BUG: raw scalar, not other_tensor
```

`MulBackward.apply()` does `a, b = self.saved_tensors` and then `b.data` to compute the gradient. Calling `.data` on a Python `int` or `float` raises `AttributeError`. Any scalar multiplication inside a `requires_grad=True` computation graph crashes during `backward()`.

## Fix

```python
result._grad_fn = MulBackward(self, other_tensor)  # always a Tensor
```

`other_tensor` is already constructed and initialized with `_ensure_grad_attrs`. The forward value is unaffected -- `_original_mul` still receives the original `other`.

## Test plan
- [ ] `pytest tinytorch/tests/06_autograd/` passes
- [ ] Scalar mul backward: `x = Tensor([2.0], requires_grad=True); (x * 3.0).backward()` -- `x.grad` should be `[3.0]`