### PR TITLE
fix(tensor): reshape -1 silently truncates when size is not divisible

### DIFF
--- a/tinytorch/src/01_tensor/01_tensor.py
+++ b/tinytorch/src/01_tensor/01_tensor.py
@@ -651,6 +651,13 @@ class Tensor:
             for i, dim in enumerate(new_shape):
                 if i != unknown_idx:
                     known_size *= dim
+            if self.size % known_size != 0:
+                raise ValueError(
+                    f"Cannot infer -1 dimension: {self.size} elements is not "
+                    f"divisible by the known dimensions product {known_size}\n"
+                    f"  ❌ {self.size} % {known_size} = {self.size % known_size}\n"
+                    f"  💡 The -1 dimension must be a whole number"
+                )
             unknown_dim = self.size // known_size
             new_shape = list(new_shape)
             new_shape[unknown_idx] = unknown_dim


### PR DESCRIPTION
## What breaks

`Tensor.reshape(-1, n)` infers the unknown dimension with `self.size // known_size` (integer division). When `self.size` is not divisible by `known_size`, floor division silently produces a wrong truncated value.

Example:
```python
Tensor([1,2,3,4,5,6,7]).reshape(-1, 3)
# known_size = 3, self.size = 7
# unknown_dim = 7 // 3 = 2  (silently truncated!)
# new_shape = (2, 3)
# np.prod((2,3)) = 6 != 7 → raises generic "element count mismatch"
```

The element-count guard does eventually catch it, but with a confusing message that doesn't explain *why* the -1 inference failed. PyTorch raises immediately:
```
RuntimeError: shape '[-1, 3]' is invalid for input of size 7
```

## Fix

Check `self.size % known_size != 0` before the division and raise a clear `ValueError` explaining that the total size is not divisible by the known dimensions product.

## Test plan
- [ ] `pytest tinytorch/tests/01_tensor/` passes
- [ ] `Tensor(np.ones(7)).reshape(-1, 3)` raises `ValueError` with clear message
- [ ] `Tensor(np.ones(6)).reshape(-1, 3)` still works, returns shape `(2, 3)`