### PR TITLE
fix(tensor): transpose test uses symmetric tensor that can't detect wrong axis swap

### DIFF
--- a/tinytorch/src/01_tensor/01_tensor.py
+++ b/tinytorch/src/01_tensor/01_tensor.py
@@ -1388,10 +1388,19 @@ def test_unit_shape_manipulation():
     vector_t = vector.transpose()
     assert np.array_equal(vector.data, vector_t.data)
 
-    # Test specific dimension transpose
-    tensor_3d = Tensor([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])  # (2, 2, 2)
-    swapped = tensor_3d.transpose(0, 2)  # Swap first and last dimensions
-    assert swapped.shape == (2, 2, 2)  # Same shape but data rearranged
+    # Non-symmetric shape so a wrong axis swap produces the wrong shape and data.
+    tensor_3d = Tensor(np.arange(24).reshape(2, 3, 4))  # (2, 3, 4)
+    swapped = tensor_3d.transpose(0, 2)  # (4, 3, 2)
+    assert swapped.shape == (4, 3, 2), (
+        f"transpose(0, 2) on (2,3,4) should give (4,3,2), got {swapped.shape}"
+    )
+    for i in range(2):
+        for j in range(3):
+            for k in range(4):
+                assert swapped.data[k, j, i] == tensor_3d.data[i, j, k], (
+                    f"Data mismatch at [{k},{j},{i}]: expected {tensor_3d.data[i,j,k]}, "
+                    f"got {swapped.data[k,j,i]}"
+                )
 
     # Test common reshape pattern (flatten multi-dimensional data)
     batch_images = Tensor(rng.random((2, 3, 4)))  # (batch=2, height=3, width=4)


### PR DESCRIPTION
## What breaks

`test_unit_shape_manipulation()` tests `transpose(0, 2)` on a `(2, 2, 2)` tensor and only asserts the output shape:

```python
tensor_3d = Tensor([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])  # (2, 2, 2)
swapped = tensor_3d.transpose(0, 2)
assert swapped.shape == (2, 2, 2)  # ALWAYS TRUE regardless of which axes are swapped
```

Because all three dimensions are equal, every possible axis swap produces the same `(2, 2, 2)` shape. A broken `transpose()` that swaps the wrong pair of axes, or even returns the input unchanged, passes this test.

## Fix

Use a non-symmetric `(2, 3, 4)` tensor where each dimension size is distinct. Now `transpose(0, 2)` must produce `(4, 3, 2)` -- which is only achievable by swapping exactly axis 0 and axis 2. Add a data-value check verifying that element `[i, j, k]` appears at `[k, j, i]` in the result.

## Test plan
- [ ] `pytest tinytorch/tests/01_tensor/` passes
- [ ] A `transpose()` implementation that swaps the wrong axes now fails this test