### PR TITLE
fix(quantization): constant-tensor zero_point clamp silently corrupts values outside [-127,127]

### DIFF
--- a/tinytorch/src/15_quantization/15_quantization.py
+++ b/tinytorch/src/15_quantization/15_quantization.py
@@ -486,14 +486,23 @@ def quantize_int8(tensor: Tensor) -> Tuple[Tensor, float, int]:
     min_val = float(np.min(data))
     max_val = float(np.max(data))
 
-    # Step 2: Handle edge case (constant tensor).
-    # All elements have the same value, so there is no range to map.
-    # We still need dequantize(quantize(c)) ≈ c, so we encode every element
-    # as q=0 and set zero_point so that (0 - zero_point) * scale = c.
-    # With scale=1.0 that means zero_point = -round(c), clamped to INT8 range.
+    # Step 2: Constant tensor -- all elements equal c, no range to map.
+    # Encode every element as q=0; choose scale and zero_point so that
+    # (0 - zero_point) * scale = c. For |c| > 127 we can't use scale=1.0
+    # because zero_point = -c would exceed the INT8 range and be clamped,
+    # corrupting dequantization. Instead set zero_point to +-1 and compute
+    # scale = |c| so the identity holds without any clamping.
     if abs(max_val - min_val) < EPSILON:
-        scale = 1.0
-        zero_point = int(np.clip(np.round(-min_val), INT8_MIN_VALUE, INT8_MAX_VALUE))
+        c = min_val
+        if abs(c) < EPSILON:
+            scale = 1.0
+            zero_point = 0
+        elif abs(c) <= INT8_MAX_VALUE:
+            scale = 1.0
+            zero_point = int(np.round(-c))
+        else:
+            zero_point = -1 if c > 0 else 1
+            scale = -c / (-zero_point)
         quantized_data = np.zeros_like(data, dtype=np.int8)
         return Tensor(quantized_data), scale, zero_point
 


### PR DESCRIPTION
## What breaks

`quantize_int8()` handles constant tensors (all elements equal to `c`) with:

```python
scale = 1.0
zero_point = int(np.clip(np.round(-c), INT8_MIN_VALUE, INT8_MAX_VALUE))
```

The dequantization identity is `(q - zero_point) * scale = original_value`. With `q=0` for all elements, this requires `zero_point = -c`. But `np.clip` silently caps `zero_point` at `[-128, 127]`, so for any `|c| > 127`:

```
c = 500 => zero_point = clip(-500, -128, 127) = -128
dequantize: (0 - (-128)) * 1.0 = 128  ≠  500
```

No error, no warning -- just silently wrong values.

## Fix

Three cases based on `|c|`:
- `c == 0`: `scale=1.0, zero_point=0`
- `|c| <= 127`: `scale=1.0, zero_point=-round(c)` (original logic, always in range)
- `|c| > 127`: set `zero_point = -1` (positive c) or `+1` (negative c), compute `scale = |c|` so that `(0 - zero_point) * scale = c` exactly -- no clamping needed

## Test plan
- [ ] `pytest tinytorch/tests/15_quantization/` passes
- [ ] `dequantize(quantize(Tensor([[500.0, 500.0]])))` returns values close to 500.0
- [ ] `dequantize(quantize(Tensor([[2.0, 2.0]])))` still returns values close to 2.0