### PR TITLE
fix CI: add [tool.nbdev] to pyproject.toml so nbdev finds its config without falling back to settings.ini

### DIFF
--- a/tinytorch/pyproject.toml
+++ b/tinytorch/pyproject.toml
@@ -56,6 +56,19 @@ docs = [
     "ipywidgets>=8.1.8",
 ]
 
+[tool.nbdev]
+lib_name = "tinytorch"
+lib_path = "tinytorch"
+nbs_path = "modules"
+doc_path = "_docs"
+branch = "main"
+recursive = true
+tst_flags = "notest"
+put_version_in_init = false
+custom_sidebar = false
+doc_host = "https://tinytorch.github.io"
+doc_baseurl = "/TinyTorch/"
+
 [project.urls]
 Homepage = "https://mlsysbook.ai/tinytorch"
 Repository = "https://github.com/harvard-edge/cs249r_book"

--- a/tinytorch/tito/commands/dev/export.py
+++ b/tinytorch/tito/commands/dev/export.py
@@ -97,7 +97,7 @@ class DevExportCommand(BaseCommand):
         cwd = Path.cwd()
         is_tinytorch_root = (
             (cwd / "tinytorch" / "__init__.py").exists() or  # Running from repo root
-            (cwd / "src").exists() and (cwd / "settings.ini").exists()  # Already in tinytorch/
+            (cwd / "src").exists() and (cwd / "pyproject.toml").exists()  # Already in tinytorch/
         )
         if not is_tinytorch_root:
             console.print(Panel(
@@ -107,7 +107,7 @@ class DevExportCommand(BaseCommand):
                 "[dim]  ├── src/[/dim]\n"
                 "[dim]  ├── tinytorch/      ← package exports here[/dim]\n"
                 "[dim]  │   └── __init__.py[/dim]\n"
-                "[dim]  └── settings.ini[/dim]",
+                "[dim]  └── pyproject.toml[/dim]",
                 title="Wrong Directory", border_style="red"
             ))
             return 1
@@ -255,8 +255,7 @@ class DevExportCommand(BaseCommand):
     def _run_nbdev_export(self, notebook_paths: list, console) -> int:
         """Run nbdev_export on the given notebooks using Python API directly.
         
-        Uses nbdev.export.nb_export() instead of subprocess to ensure
-        settings.ini is read correctly regardless of environment.
+        Uses nbdev.export.nb_export() directly (more reliable than subprocess).
         """
         from nbdev.export import nb_export
         success_count = 0

--- a/tinytorch/tito/commands/system/update.py
+++ b/tinytorch/tito/commands/system/update.py
@@ -47,7 +47,6 @@ class UpdateCommand(BaseCommand):
     UPDATE_FILES = [
         "requirements.txt",
         "pyproject.toml",
-        "settings.ini",
         "README.md",
         "LICENSE",
     ]


### PR DESCRIPTION
## What was wrong

nbdev walks up from cwd looking for a pyproject.toml with a [tool.nbdev] section. If it finds none, it falls through to a legacy check: if settings.ini exists anywhere in the parent chain it raises a hard error: Found old settings.ini. Migrate to pyproject.toml.

tinytorch/pyproject.toml existed but had no [tool.nbdev] section. Every call to nb_export() hit that fallback, found settings.ini, and raised blocking Stage 1 on every CI run and cascading to fail all downstream stages.

## Why not just delete settings.ini

The first version of this PR deleted settings.ini. That was wrong. The release workflow (tinytorch-publish-live.yml) still writes the version number into settings.ini on every release via sed and commits it. Deleting it would break the next release. The PR was force-pushed to replace that approach with the correct fix.

## What the fix actually does

Adds [tool.nbdev] to pyproject.toml with the canonical fields (lib_path, nbs_path, doc_path, branch, etc.) migrated from settings.ini. nbdev finds the section on its first walk and never reaches the settings.ini check. settings.ini is kept intact so the release workflow continues to work unchanged.

Also removes two stale settings.ini references in export.py (directory detection heuristic and error message) and removes settings.ini from UpdateCommand.UPDATE_FILES since pyproject.toml is now the authoritative nbdev config.

## Test plan

- [ ] CI Stage 1 passes -- no more Found old settings.ini error
- [ ] All downstream CI stages unblocked
- [ ] settings.ini is untouched -- release workflow still works on next version bump
- [ ] tito system update no longer lists settings.ini as a file it manages