### PR TITLE
fix(module): syntax errors in student notebook silently pass tito module complete

### DIFF
--- a/tinytorch/tito/commands/module/workflow.py
+++ b/tinytorch/tito/commands/module/workflow.py
@@ -595,6 +595,12 @@ class ModuleWorkflowCommand(BaseCommand):
             self.console.print("[bold cyan] Step 2/4: Exporting to TinyTorch Package[/bold cyan]")
             self.console.print()
 
+            syntax_error = self._check_notebook_syntax(module_name)
+            if syntax_error:
+                self.console.print(f"[red]   ❌ Syntax error in your notebook -- fix it before exporting[/red]")
+                self.console.print(f"      [dim red]{syntax_error}[/dim red]")
+                return 1
+
             export_result = self.export_module(module_name)
             if export_result != 0:
                 self.console.print(f"[red]   ❌ Export failed for {module_name}[/red]")
@@ -783,6 +789,8 @@ class ModuleWorkflowCommand(BaseCommand):
 
         # Export to package
         if not skip_export:
+            if self._check_notebook_syntax(module_name):
+                return 1
             export_result = self.export_module(module_name)
             if export_result != 0:
                 return 1
@@ -941,6 +949,46 @@ class ModuleWorkflowCommand(BaseCommand):
             'tests': tests_run,
             'returncode': result.returncode
         }
+
+    def _check_notebook_syntax(self, module_name: str) -> Optional[str]:
+        """Compile every code cell in the student's notebook and return the first SyntaxError.
+
+        Unit tests run against src/ (instructor source), so a syntax error the
+        student introduced in their notebook goes undetected until export silently
+        writes broken code into tinytorch/core/ and the next module fails on import.
+        This check catches the error at the notebook level before export runs.
+
+        Returns an error string on failure, None on success.
+        """
+        import ast
+        short_name = module_name.split("_", 1)[1] if "_" in module_name else module_name
+        notebook_path = Path.cwd() / "modules" / module_name / f"{short_name}.ipynb"
+
+        if not notebook_path.exists():
+            return None
+
+        try:
+            import json
+            nb = json.loads(notebook_path.read_text(encoding="utf-8"))
+        except Exception as e:
+            return f"Could not read notebook: {e}"
+
+        cells = nb.get("cells", [])
+        for i, cell in enumerate(cells):
+            if cell.get("cell_type") != "code":
+                continue
+            source = "".join(cell.get("source", []))
+            if not source.strip():
+                continue
+            try:
+                compile(source, f"{short_name}.ipynb cell {i+1}", "exec")
+            except SyntaxError as e:
+                return (
+                    f"SyntaxError in {short_name}.ipynb cell {i+1}, "
+                    f"line {e.lineno}: {e.msg}\n"
+                    f"  {(e.text or '').rstrip()}"
+                )
+        return None
 
     def _run_integration_tests(self, module_name: str, verbose: bool) -> Dict[str, int]:
         """Run progressive integration tests using pytest."""


### PR DESCRIPTION
## Bug report

Reported by @Chufeng-Jiang in discussion #1827.

A student had a syntax error in their Module 01 notebook (missing closing parenthesis in an `isinstance` call). Running `tito module complete 01` reported all tests passing. The error only surfaced when Module 02 tests tried to import from the broken `tinytorch/core/tensor.py` that the export had written.

## Root cause

`_run_inline_unit_tests()` runs the instructor's source file at `src/01_tensor/01_tensor.py`, not the student's notebook at `modules/01_tensor/tensor.ipynb`. A syntax error in the student's notebook is invisible to this test phase -- the instructor source always runs clean. The broken notebook then gets exported into `tinytorch/core/tensor.py` without any parse check.

## Fix

Add `_check_notebook_syntax()`: reads the student's notebook, compiles every code cell with Python's `compile()`, and returns the first `SyntaxError` found with the cell number and line. Called in both `complete_module` and `_complete_module_quiet` immediately before the export step, so the student sees:

```
❌ Syntax error in your notebook -- fix it before exporting
   SyntaxError in tensor.ipynb cell 12, line 3: '(' was never closed
     if len(shape) == 1 and isinstance(shape[0], (tuple, list):
```

instead of a confusing failure in the next module.

## Test plan

- [ ] Student notebook with a syntax error: `tito module complete 01` reports the error with cell + line number and exits 1
- [ ] Valid notebook: behaviour unchanged, export proceeds normally
- [ ] `tito module complete --all` (quiet path) also blocked on syntax errors

Co-authored-by: Chufeng Jiang <cjiang@gradcenter.cuny.edu>