### PR TITLE
style(vault-cli): sort imports in legacy_export.py (ruff I001)

### DIFF
--- a/interviews/vault-cli/src/vault_cli/legacy_export.py
+++ b/interviews/vault-cli/src/vault_cli/legacy_export.py
@@ -18,10 +18,9 @@ from __future__ import annotations
 import json
 from datetime import UTC
 from pathlib import Path
-
-from vault_cli.book_refs import BookRefResolver
 from typing import Any
 
+from vault_cli.book_refs import BookRefResolver
 from vault_cli.loader import LoadedQuestion
 from vault_cli.policy import filter_questions, load_policy
 


### PR DESCRIPTION
Pure import reordering flagged by the pre-push ruff hook. Landed via #1851, whose CI did not run this local hook. No behavior change.