### PR TITLE
ci(staffml): re-run preview-dev on vault-cli changes so the badge can't stale

### DIFF
--- a/.github/workflows/staffml-preview-dev.yml
+++ b/.github/workflows/staffml-preview-dev.yml
@@ -58,6 +58,12 @@ on:
       - '.github/workflows/staffml-preview-dev.yml'
       - '.github/workflows/staffml-validate-dev.yml'
       - '.github/workflows/staffml-validate-vault.yml'
+      # vault-cli is the CLI that the validate-vault job (called here) lints.
+      # A fix to it — e.g. a ruff import-sort — must also re-run this
+      # badge-driving workflow, or the README badge stays red after the fix
+      # lands. That happened: PR #1879 sorted vault-cli imports and validate-vault
+      # went green, but preview-dev never re-ran, so the badge stayed red.
+      - 'interviews/vault-cli/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Why
The README **StaffML** badge tracks `staffml-preview-dev` (push, dev). Its path filter triggers on `interviews/staffml/**`, `interviews/vault/**`, and the staffml workflow files — but **not** `interviews/vault-cli/**`, even though the badge-driving job lints vault-cli via the `validate-vault` workflow it calls.

So when #1879 sorted vault-cli imports (ruff I001), `validate-vault` went green but `preview-dev` never re-ran — leaving the badge stuck red on the earlier failing run.

## Change
Add `interviews/vault-cli/**` to the preview-dev path filter so a vault-cli fix re-runs the badge-driving workflow. Editing the workflow file is itself a trigger path, so merging this re-runs preview-dev on the already-fixed dev and clears the badge.

CI-config only; no app/book changes.