### PR TITLE
add unit and E2E integration tests for community progress syncing

### DIFF
--- a/tinytorch/quarto/community/modules/auth.js
+++ b/tinytorch/quarto/community/modules/auth.js
@@ -112,10 +112,10 @@ export async function verifySession() {
     const { data: { session: sbSession } } = await supabase.auth.getSession();
     
     // If Supabase client is empty but we have tokens (from Direct Email login), restore it.
-    if (!sbSession && refreshTokenStr) {
+    if (!sbSession && token) {
         const { error } = await supabase.auth.setSession({
             access_token: token,
-            refresh_token: refreshTokenStr
+            refresh_token: refreshTokenStr || "dummy_refresh_token"
         });
         if (error) {
             console.warn("Auto-sync setSession failed:", error);
@@ -332,10 +332,10 @@ export async function handleAuth(e) {
             localStorage.setItem("tinytorch_user", JSON.stringify(data.user));
 
             // Sync Supabase Client so it doesn't trigger SIGNED_OUT
-            if (data.refresh_token) {
+            if (data.access_token) {
                 const { error: sessionError } = await supabase.auth.setSession({
                     access_token: data.access_token,
-                    refresh_token: data.refresh_token
+                    refresh_token: data.refresh_token || "dummy_refresh_token"
                 });
                 if (sessionError) {
                     console.error("Supabase setSession error during login:", sessionError);

--- a/tinytorch/quarto/community/modules/auth.js
+++ b/tinytorch/quarto/community/modules/auth.js
@@ -112,7 +112,7 @@ export async function verifySession() {
     const { data: { session: sbSession } } = await supabase.auth.getSession();
     
     // If Supabase client is empty but we have tokens (from Direct Email login), restore it.
-    if (!sbSession && token) {
+    if (!sbSession) {
         const { error } = await supabase.auth.setSession({
             access_token: token,
             refresh_token: refreshTokenStr || "dummy_refresh_token"

--- a/tinytorch/quarto/community/modules/guard.js
+++ b/tinytorch/quarto/community/modules/guard.js
@@ -15,9 +15,9 @@ const DASHBOARD_PAGE = getBasePath() + '/dashboard.html';
 
   // 0. Get Session
   const storedToken = localStorage.getItem("tinytorch_token");
-  const storedRefresh = localStorage.getItem("tinytorch_refresh_token");
+  const storedRefresh = localStorage.getItem("tinytorch_refresh_token") || "dummy_refresh_token";
   
-  if (storedToken && storedRefresh) {
+  if (storedToken) {
       try {
           await supabase.auth.setSession({
               access_token: storedToken,

--- a/tinytorch/tests/cli/README.md
+++ b/tinytorch/tests/cli/README.md
@@ -59,22 +59,49 @@ Ensures help text is consistent and complete:
   - All registered commands documented
   - Checkpoint command specifically validated
 
+### 4. `test_community_flow.py` - Community Flow Unit Tests
+Validates the community syncing client-side code and payload schema:
+- **TestCommunitySyncFlow**: Core validation
+  - Validates JSON payload schema (percentages, milestone formats, user email).
+  - Verifies successful urllib offline mocking for status 200.
+  - Verifies token expiry handling (401 Unauthorized) and subsequent refresh logic.
+
+### 5. `test_live_submission.py` - Live E2E Integration Tests
+Runs E2E integration tests against the remote production Supabase backend:
+- **TestLiveCommunitySync**: End-to-End backend syncing
+  - Performs programmatic login using user credentials and Supabase Anon Key.
+  - Seeds CLI progress mock data.
+  - Submits progress to the Edge Function `/upload-progress`.
+  - Queries `/get-profile-details` to verify that completion progress successfully persists.
+
 ## Running the Tests
 
 Run all CLI tests:
 ```bash
-pytest tests/cli/ -v
+TINYTORCH_SKIP_EXPORT_CHECK=1 pytest tests/cli/ -v
 ```
 
 Run specific test file:
 ```bash
-pytest tests/cli/test_cli_registry.py -v
+TINYTORCH_SKIP_EXPORT_CHECK=1 pytest tests/cli/test_cli_registry.py -v
 ```
 
 Run with output:
 ```bash
-pytest tests/cli/ -v -s
+TINYTORCH_SKIP_EXPORT_CHECK=1 pytest tests/cli/ -v -s
 ```
+
+### Running Live Community Sync Integration Tests
+The live integration tests connect directly to the remote Supabase database and require credentials. They automatically skip if credentials are not configured:
+1. Create a `local.env` file in the project root:
+   ```env
+   TINYTORCH_TEST_EMAIL=your_student_email@domain.com
+   TINYTORCH_TEST_PASSWORD=your_password
+   ```
+2. Run pytest targeting the live submission file:
+   ```bash
+   TINYTORCH_SKIP_EXPORT_CHECK=1 pytest tests/cli/test_live_submission.py -v
+   ```
 
 ## What These Tests Catch
 

--- a/tinytorch/tests/cli/test_community_flow.py
+++ b/tinytorch/tests/cli/test_community_flow.py
@@ -1,0 +1,148 @@
+"""
+Tests for the TinyTorch community submission and progress syncing flow.
+
+These tests validate:
+1. Retrieval of authentication status and tokens.
+2. Creation and structure of the progress payload.
+3. Execution of progress syncing POST requests with mock servers.
+"""
+
+import os
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+from pathlib import Path
+import sys
+
+# Ensure tito is importable
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from tito.core.config import CLIConfig
+from tito.core.submission import SubmissionHandler
+from tito.core import auth
+
+
+class TestCommunitySyncFlow:
+    """Test suite for validating submission and syncing features."""
+
+    @pytest.fixture
+    def mock_env_paths(self, tmp_path):
+        """Creates a temporary .tito directory with progress and milestone mock data."""
+        tito_dir = tmp_path / ".tito"
+        tito_dir.mkdir(parents=True, exist_ok=True)
+
+        progress_file = tito_dir / "progress.json"
+        progress_data = {
+            "started_modules": [],
+            "completed_modules": ["01", "02"],
+            "last_worked": "02",
+            "last_completed": "02",
+            "last_updated": "2026-06-16T22:32:26"
+        }
+        progress_file.write_text(json.dumps(progress_data))
+
+        milestones_file = tito_dir / "milestones.json"
+        milestone_data = {
+            "unlocked_milestones": ["01"],
+            "completed_milestones": ["01"],
+            "unlock_dates": {"01": "2026-06-16T22:32:26"},
+            "completion_dates": {"01": "2026-06-16T22:32:26"},
+            "total_unlocked": 1
+        }
+        milestones_file.write_text(json.dumps(milestone_data))
+
+        config = CLIConfig(
+            project_root=tmp_path,
+            assignments_dir=tmp_path / "assignments",
+            modules_dir=tmp_path / "src",
+            tinytorch_dir=tmp_path / "tinytorch",
+            bin_dir=tmp_path / "bin"
+        )
+        return config, progress_file, milestones_file
+
+    def test_assemble_payload(self, mock_env_paths):
+        """Verify the JSON payload matches the Supabase Edge Function schema."""
+        config, _, _ = mock_env_paths
+        console = MagicMock()
+        handler = SubmissionHandler(config, console)
+
+        with patch("tito.core.auth.get_user_email", return_value="test_student@example.com"):
+            payload = handler.assemble_payload(total_modules=20)
+
+        # Assert correct schema mapping
+        assert payload["user_id"] == "test_student@example.com"
+        assert payload["version"] == "1.0"
+        assert payload["module_progress"]["completed_count"] == 2
+        assert payload["module_progress"]["completed_modules"] == ["01", "02"]
+        assert payload["module_progress"]["completion_percentage"] == 10.0
+        assert payload["milestone_progress"]["unlocked_count"] == 1
+        
+        milestones = payload["milestone_progress"]["unlocked_milestones"]
+        assert len(milestones) == 1
+        assert milestones[0]["id"] == "01"
+        assert milestones[0]["completed"] is True
+
+    @patch("urllib.request.urlopen")
+    @patch("tito.core.auth.get_token")
+    @patch("tito.core.auth.get_user_email")
+    def test_sync_progress_success(self, mock_email, mock_token, mock_urlopen, mock_env_paths):
+        """Test successful progress synchronization (HTTP 200)."""
+        config, _, _ = mock_env_paths
+        mock_email.return_value = "test_student@example.com"
+        mock_token.return_value = "mock_jwt_access_token"
+
+        # Mock urllib response
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.read.return_value = json.dumps({"synced_modules": 2}).encode("utf-8")
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        console = MagicMock()
+        handler = SubmissionHandler(config, console)
+        success = handler.sync_progress(total_modules=20)
+
+        assert success is True
+        mock_urlopen.assert_called_once()
+        
+        # Verify request contents
+        request_obj = mock_urlopen.call_args[0][0]
+        assert request_obj.method == "POST"
+        assert request_obj.headers["Authorization"] == "Bearer mock_jwt_access_token"
+        assert request_obj.headers["Content-type"] == "application/json"
+        
+        # Verify printed messages
+        console.print.assert_any_call("✅ [bold green]Sync Successful![/bold green]")
+
+    @patch("urllib.request.urlopen")
+    @patch("tito.core.auth.get_token")
+    @patch("tito.core.auth.get_user_email")
+    def test_sync_progress_unauthorized_token_refresh(self, mock_email, mock_token, mock_urlopen, mock_env_paths):
+        """Verify that an expired token triggers token refresh logic."""
+        config, _, _ = mock_env_paths
+        mock_email.return_value = "test_student@example.com"
+        mock_token.return_value = "expired_token"
+
+        import urllib.error
+        # Raise HTTP 401 Unauthorized for the first call
+        http_error = urllib.error.HTTPError(
+            url="http://mock-url",
+            code=401,
+            msg="Unauthorized",
+            hdrs=None,
+            fp=MagicMock()
+        )
+        http_error.read = MagicMock(return_value=b'{"error": "Invalid token"}')
+
+        # Second call response (after refresh token)
+        retry_response = MagicMock()
+        retry_response.__enter__.return_value.status = 200
+        retry_response.__enter__.return_value.read.return_value = b'{"synced_modules": 2}'
+
+        mock_urlopen.side_effect = [http_error, retry_response]
+
+        console = MagicMock()
+        handler = SubmissionHandler(config, console)
+
+        with patch("tito.core.auth.refresh_token", return_value="new_fresh_token") as mock_refresh:
+            handler.sync_progress(total_modules=20)
+            mock_refresh.assert_called_once_with(console)

--- a/tinytorch/tests/cli/test_community_flow.py
+++ b/tinytorch/tests/cli/test_community_flow.py
@@ -7,7 +7,6 @@ These tests validate:
 3. Execution of progress syncing POST requests with mock servers.
 """
 
-import os
 import json
 import pytest
 from unittest.mock import MagicMock, patch
@@ -19,7 +18,6 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from tito.core.config import CLIConfig
 from tito.core.submission import SubmissionHandler
-from tito.core import auth
 
 
 class TestCommunitySyncFlow:

--- a/tinytorch/tests/cli/test_live_submission.py
+++ b/tinytorch/tests/cli/test_live_submission.py
@@ -1,0 +1,185 @@
+"""
+Live E2E integration test for TinyTorch progress submission to Supabase.
+
+This test runs ONLY if TINYTORCH_TEST_EMAIL and TINYTORCH_TEST_PASSWORD are set
+in the environment or in a local.env file.
+
+It automates the entire flow:
+1. Programmatic login to Supabase auth API using email/password + active Anon Key.
+2. Temporary credentials file setup.
+3. Seeding dummy progress data.
+4. Sending the sync payload to the Supabase Edge Function.
+5. Verifying a successful response from the server.
+"""
+
+import os
+import json
+import urllib.request
+import urllib.error
+import pytest
+from unittest.mock import patch
+from pathlib import Path
+import sys
+
+# Ensure tito is importable
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from tito.core.config import CLIConfig
+from tito.core.submission import SubmissionHandler
+from tito.core import auth
+
+# Helper to load local.env if present
+def load_local_env():
+    env_path = Path(__file__).parent.parent.parent / "local.env"
+    if env_path.exists():
+        for line in env_path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith('#') or '=' not in line:
+                continue
+            key, val = line.split('=', 1)
+            os.environ[key.strip()] = val.strip()
+
+load_local_env()
+
+TEST_EMAIL = os.environ.get("TINYTORCH_TEST_EMAIL")
+TEST_PASSWORD = os.environ.get("TINYTORCH_TEST_PASSWORD")
+
+# Dynamic retrieval of Supabase Anon Key and Project URL from config.js
+def get_supabase_keys():
+    config_js = Path(__file__).parent.parent.parent / "quarto" / "community" / "modules" / "config.js"
+    if not config_js.exists():
+        return None, None
+    
+    content = config_js.read_text()
+    import re
+    url_match = re.search(r'SUPABASE_PROJECT_URL\s*=\s*["\']([^"\']+)["\']', content)
+    key_match = re.search(r'SUPABASE_ANON_KEY\s*=\s*["\']([^"\']+)["\']', content)
+    
+    return (
+        url_match.group(1) if url_match else None,
+        key_match.group(1) if key_match else None
+    )
+
+@pytest.mark.skipif(not TEST_EMAIL or not TEST_PASSWORD, reason="Requires TINYTORCH_TEST_EMAIL and TINYTORCH_TEST_PASSWORD in local.env or environment")
+class TestLiveCommunitySync:
+    """Live E2E test verifying progress syncing with Supabase Auth & Edge functions."""
+
+    @pytest.fixture(autouse=True)
+    def setup_sandbox_paths(self, tmp_path):
+        """Creates clean .tito folder and backs up / restores existing credentials."""
+        # Seeding mock data in clean directory
+        self.tito_dir = tmp_path / ".tito"
+        self.tito_dir.mkdir(parents=True, exist_ok=True)
+        
+        self.progress_file = self.tito_dir / "progress.json"
+        self.progress_file.write_text(json.dumps({
+            "completed_modules": ["01"],
+            "last_worked": "01",
+            "last_completed": "01",
+            "last_updated": "2026-06-16T22:32:26"
+        }))
+        
+        self.milestones_file = self.tito_dir / "milestones.json"
+        self.milestones_file.write_text(json.dumps({
+            "unlocked_milestones": [],
+            "completed_milestones": [],
+            "unlock_dates": {},
+            "completion_dates": {},
+            "total_unlocked": 0
+        }))
+        
+        self.config = CLIConfig(
+            project_root=tmp_path,
+            assignments_dir=tmp_path / "assignments",
+            modules_dir=tmp_path / "src",
+            tinytorch_dir=tmp_path / "tinytorch",
+            bin_dir=tmp_path / "bin"
+        )
+        
+        # Override credentials storage directory to temporary path
+        self.orig_creds_dir = auth.CREDENTIALS_DIR
+        auth.CREDENTIALS_DIR = str(tmp_path / "creds")
+        
+        yield
+        
+        # Restore credentials path
+        auth.CREDENTIALS_DIR = self.orig_creds_dir
+
+    def test_live_auth_and_sync(self):
+        """Performs programmatic login, writes credentials, and syncs progress to Supabase."""
+        project_url, anon_key = get_supabase_keys()
+        assert project_url and anon_key, "Could not extract Supabase Project URL or Anon Key from config.js"
+        
+        # Step 1: Login programmatically using Supabase password grant type
+        auth_url = f"{project_url}/auth/v1/token?grant_type=password"
+        headers = {
+            "apikey": anon_key,
+            "Content-Type": "application/json"
+        }
+        body = {
+            "email": TEST_EMAIL,
+            "password": TEST_PASSWORD
+        }
+        
+        req = urllib.request.Request(
+            auth_url,
+            data=json.dumps(body).encode('utf-8'),
+            headers=headers,
+            method="POST"
+        )
+        
+        try:
+            with urllib.request.urlopen(req, timeout=10) as response:
+                data = json.loads(response.read().decode('utf-8'))
+        except urllib.error.HTTPError as e:
+            pytest.fail(f"Supabase Authentication failed (HTTP {e.code}): {e.read().decode('utf-8')}")
+        except Exception as e:
+            pytest.fail(f"Failed to reach Supabase Auth API: {e}")
+            
+        assert "access_token" in data, "No access_token returned from Supabase Auth"
+        
+        # Step 2: Store credentials locally in the temp credentials path
+        auth.save_credentials({
+            "access_token": data["access_token"],
+            "refresh_token": data.get("refresh_token", ""),
+            "user_email": data["user"]["email"]
+        })
+        
+        assert auth.is_logged_in() is True
+        assert auth.get_user_email() == TEST_EMAIL
+        
+        # Step 3: Run the submission handler to sync progress
+        from rich.console import Console
+        console = Console(record=True)
+        handler = SubmissionHandler(self.config, console)
+        
+        sync_success = handler.sync_progress(total_modules=20)
+        
+        # Assert syncing returns success from the Edge Function
+        assert sync_success is True
+        console_output = console.export_text()
+        assert "Sync Successful!" in console_output
+
+        # Step 4: Verify persistence via /get-profile-details
+        details_url = f"{project_url}/functions/v1/get-profile-details"
+        details_req = urllib.request.Request(
+            details_url,
+            headers={
+                "Authorization": f"Bearer {data['access_token']}",
+                "Content-Type": "application/json"
+            },
+            method="GET"
+        )
+        try:
+            with urllib.request.urlopen(details_req, timeout=10) as details_response:
+                details_data = json.loads(details_response.read().decode('utf-8'))
+        except Exception as e:
+            pytest.fail(f"Failed to fetch profile details from get-profile-details: {e}")
+
+        completed_modules = details_data.get("completed_modules", [])
+        assert (1 in completed_modules or "01" in completed_modules), (
+            "Backend Sync Bug: The module progress was uploaded successfully (Edge Function returned 200), "
+            "but did not persist in the database's completed_modules list. "
+            "This indicates that user_stats row is missing or not updated. "
+            f"Returned completed_modules: {completed_modules}"
+        )

--- a/tinytorch/tests/cli/test_live_submission.py
+++ b/tinytorch/tests/cli/test_live_submission.py
@@ -17,7 +17,6 @@ import json
 import urllib.request
 import urllib.error
 import pytest
-from unittest.mock import patch
 from pathlib import Path
 import sys
 


### PR DESCRIPTION
    ## Summary

    This PR adds unit and end-to-end integration tests to verify
  the TinyTorch CLI progress syncing flow, resolves a login
  redirect loop on the community portal website caused by a
  missing refresh token, and resolves subsequent CodeQL code
  quality findings.

    ## Area

    - [ ] Book (textbook content, figures, exercises)
    - [x] TinyTorch (modules, tests, milestones)
    - [ ] StaffML (interview questions, challenges)
    - [ ] Kits (hardware labs)
    - [x] Infrastructure (CI/CD, scripts, config)

    ## Changes

    ### CLI Progress Syncing Tests:
    - Added `tests/cli/test_community_flow.py` to validate CLI
  configuration parser, payload assembly, and token refresh logic
  under offline mocked conditions.
    - Added `tests/cli/test_live_submission.py` to perform E2E
  verification including programmatic Supabase login, progress
  upload, and verification of profile details persistence.
    - Updated `tests/cli/README.md` to document the new test
  suites and explain how developers can configure a local `.env`
  file to run integration tests.

    ### Website Auth Loop Fix:
    - Modified guard.js to restore sessions on page load
  using a dummy refresh token fallback (`"dummy_refresh_token"`)
  if `storedRefresh` is missing in local storage.
    - Modified auth.js to restore sessions in
  `verifySession` and `handleAuth` even when the Netlify
  authentication proxy fails to return a `refresh_token`.

    ### Code Quality (CodeQL) Cleanups:
    - Removed unused imports (`os`, `auth`, `patch`) from the new
  Python test files.
    - Simplified redundant conditional `if (!sbSession && token)`
  to `if (!sbSession)` in `auth.js`.

    > [!IMPORTANT]
    > **REMINDER**: The TinyTorch community site must be
  rebuilt/compiled using `quarto render` to ensure the compiled
  assets in `quarto/_build/community/modules/` are updated with
  these changes.

    ## Testing

    - [x] Rendered the book locally (`quarto render`)
    - [x] Ran tests (`pytest tests/`)
    - [ ] Ran `tito module test NN` for affected module(s)
    - [x] Manual verification (describe below)

    ### Manual Verification details:
    - Verified that CLI unit tests pass successfully offline.
    - Started the local server via `./run-community.sh` and
  verified the browser login flow at
  `http://localhost:8000/community/index.html`. Logging in using
  the test credentials correctly redirected to `profile_setup.
  html` and remained authenticated. Successfully completed the
  profile update without encountering any loop, landing on
  `dashboard.html`.

    ## Related Issues
    - Related to community site student progress sync issues.