### PR TITLE
fix(community): repair profile setup form + dashboard access for email logins

### DIFF
--- a/tinytorch/quarto/community/modules/guard.js
+++ b/tinytorch/quarto/community/modules/guard.js
@@ -1,5 +1,5 @@
-import { SUPABASE_PROJECT_URL, SUPABASE_ANON_KEY, SUPABASE_URL, getBasePath } from './config.js';
-import { clearSession, supabase } from './state.js';
+import { SUPABASE_URL, NETLIFY_URL, getBasePath } from './config.js';
+import { clearSession } from './state.js';
 
 const LOGIN_PAGE = getBasePath() + '/index.html';
 const SETUP_PAGE = getBasePath() + '/profile_setup.html';
@@ -13,65 +13,107 @@ const DASHBOARD_PAGE = getBasePath() + '/dashboard.html';
   const isPublicPage = isOnIndex || path.includes('login') || path.includes('about') || path.includes('contact');
   const isProtected = !isPublicPage;
 
-  // 0. Get Session
-  const storedToken = localStorage.getItem("tinytorch_token");
-  const storedRefresh = localStorage.getItem("tinytorch_refresh_token");
-  
-  if (storedToken && storedRefresh) {
-      try {
-          await supabase.auth.setSession({
-              access_token: storedToken,
-              refresh_token: storedRefresh
-          });
-      } catch (e) {
-          console.warn("Guard: setSession failed", e);
-      }
-  }
-
-  const { data: { session } } = await supabase.auth.getSession();
-  
-  if (!session && isProtected) {
-      console.log("🚧 No session on protected page. Redirecting to login...");
+  const redirectToLogin = () => {
       window.location.href = LOGIN_PAGE + '?action=login&next=' + encodeURIComponent(path);
-      return;
+  };
+
+  // 0. The app authenticates with `tinytorch_token` (set by email login and OAuth alike).
+  //    Use it as the source of truth here too — older email logins never establish a
+  //    Supabase client session, so gating on supabase.auth.getSession() locked them out.
+  let token = localStorage.getItem("tinytorch_token");
+
+  if (!token) {
+      if (isProtected) redirectToLogin();
+      return; // Public page with no token: nothing to guard.
   }
 
-  if (!session) return; // Public page, no session, we are fine.
-
-  // 1. Fetch Profile with Timeout
+  // 1. Validate the token against the profile Edge Function, with one refresh retry.
   let profile = null;
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 5000);
+  let retryCount = 0;
+  const MAX_RETRIES = 1;
 
-  try {
-      // Use the API for profile details
-      const res = await fetch(`${SUPABASE_URL}/get-profile-details`, {
-          headers: { 'Authorization': `Bearer ${session.access_token}` },
-          signal: controller.signal
-      });
-      clearTimeout(timeoutId);
-      
-      if (res.ok) {
-          const data = await res.json();
-          profile = data.profile;
-      } else if (res.status === 401 || res.status === 404) {
-          // 401: Token expired, 404: User deleted from DB
-          console.warn(`Guard: Session invalid or account deleted (${res.status}). Purging...`);
-          await clearSession();
-          
-          if (isProtected) {
-              window.location.href = LOGIN_PAGE + '?action=login';
-          } else {
-              // If on a public page, just reload to clear UI state
-              window.location.reload();
-          }
+  do {
+      let res;
+      try {
+          const controller = new AbortController();
+          const timeoutId = setTimeout(() => controller.abort(), 5000);
+          res = await fetch(`${SUPABASE_URL}/get-profile-details`, {
+              headers: { 'Authorization': `Bearer ${token}` },
+              signal: controller.signal
+          });
+          clearTimeout(timeoutId);
+      } catch (e) {
+          // Network error / timeout: fail open rather than bounce the user around.
+          console.warn("Guard: profile fetch failed or timed out", e);
           return;
       }
-  } catch (e) {
-      console.warn("Guard: Profile fetch failed or timed out", e);
-  }
 
-  // 2. The Rules
+      // 401, or 400 with "Invalid Token", means the access token needs refreshing.
+      let needsRefresh = res.status === 401;
+      if (res.status === 400) {
+          try {
+              const errData = await res.clone().json();
+              if (errData?.error?.includes("Invalid Token")) needsRefresh = true;
+          } catch (e) { /* ignore parse error */ }
+      }
+
+      if (needsRefresh && retryCount === 0) {
+          const refreshTokenStr = localStorage.getItem("tinytorch_refresh_token");
+          if (refreshTokenStr) {
+              try {
+                  const refreshRes = await fetch(`${NETLIFY_URL}/api/auth/refresh`, {
+                      method: "POST",
+                      headers: { "Content-Type": "application/json" },
+                      body: JSON.stringify({ refreshToken: refreshTokenStr })
+                  });
+                  if (refreshRes.ok) {
+                      const refreshData = await refreshRes.json();
+                      const session = refreshData.session || refreshData;
+                      if (session?.access_token) {
+                          token = session.access_token;
+                          localStorage.setItem("tinytorch_token", token);
+                          if (session.refresh_token) {
+                              localStorage.setItem("tinytorch_refresh_token", session.refresh_token);
+                          }
+                          retryCount++;
+                          continue; // Retry with refreshed token
+                      }
+                  }
+              } catch (e) {
+                  console.warn("Guard: token refresh failed", e);
+              }
+          }
+          // No refresh token, or refresh failed → the session is dead.
+          await clearSession();
+          if (isProtected) redirectToLogin();
+          return;
+      }
+
+      if (res.status === 404) {
+          // Account deleted server-side.
+          console.warn("Guard: account not found (404). Purging session...");
+          await clearSession();
+          if (isProtected) redirectToLogin();
+          return;
+      }
+
+      if (!res.ok) {
+          // Unknown server error: fail open rather than lock the user out.
+          console.warn("Guard: unexpected profile fetch status", res.status);
+          return;
+      }
+
+      try {
+          const data = await res.json();
+          profile = data.profile;
+      } catch (e) {
+          console.warn("Guard: failed to parse profile response", e);
+          return;
+      }
+      break; // Success
+  } while (retryCount <= MAX_RETRIES);
+
+  // 2. Completeness rules.
   const hasName = profile && profile.display_name;
   const hasInst = profile && profile.institution && (Array.isArray(profile.institution) ? profile.institution.length > 0 : !!profile.institution);
   const hasLoc = profile && profile.location;

--- a/tinytorch/quarto/community/modules/ui.js
+++ b/tinytorch/quarto/community/modules/ui.js
@@ -26,6 +26,12 @@ export function updateNavState() {
     if (navDashboard) navDashboard.style.display = isLoggedIn ? 'flex' : 'none';
     if (navCommunity) navCommunity.style.display = 'flex';
     if (navArena) navArena.style.display = 'flex';
+
+    // Unlock the sidebar Dashboard link once logged in (hide the lock + tooltip).
+    const navDashboardSidebar = document.getElementById('navDashboardSidebar');
+    const navDashboardLock = document.getElementById('navDashboardLock');
+    if (navDashboardLock) navDashboardLock.style.display = isLoggedIn ? 'none' : 'flex';
+    if (navDashboardSidebar) navDashboardSidebar.classList.toggle('nav-item-restricted', !isLoggedIn);
 }
 
 export function renderLayout() {
@@ -86,9 +92,9 @@ export function renderLayout() {
             <a href="${basePath}/arena.html" class="nav-item">
                 <span>Arena</span>
             </a>
-            <a href="${basePath}/dashboard.html" class="nav-item nav-item-restricted">
+            <a href="${basePath}/dashboard.html" class="nav-item nav-item-restricted" id="navDashboardSidebar">
                 <span>Dashboard</span>
-                <span class="lock-container">
+                <span class="lock-container" id="navDashboardLock">
                     <svg class="lock-icon" viewBox="0 0 24 24" fill="currentColor"><path d="M18 10h-1V7c0-2.76-2.24-5-5-5S7 4.24 7 7v3H6c-1.1 0-2 .9-2 2v8c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-8c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3-10H9V7c0-1.66 1.34-3 3-3s3 1.34 3 3v3z"/></svg>
                     <span class="lock-tooltip">Account Required</span>
                 </span>

--- a/tinytorch/quarto/community/profile_setup.html
+++ b/tinytorch/quarto/community/profile_setup.html
@@ -143,23 +143,23 @@
 
         <form id="setupForm">
             <div class="form-group">
-                <label>Display Name *</label>
+                <label for="displayName">Display Name *</label>
                 <input type="text" id="displayName" required placeholder="e.g. Alex">
             </div>
 
             <div class="form-group">
-                <label>Full Name <span class="optional">(Optional)</span></label>
+                <label for="fullName">Full Name <span class="optional">(Optional)</span></label>
                 <input type="text" id="fullName" placeholder="e.g. Alex Smith">
             </div>
 
             <div class="form-group">
-                <label>Institution / Company *</label>
+                <label for="institution">Institution / Company *</label>
                 <input type="text" id="institution" required placeholder="e.g. University of Science" value="Independent">
                 <div style="font-size: 0.75rem; color: #888; margin-top: 4px;">Defaults to "Independent" if you are not affiliated.</div>
             </div>
 
             <div class="form-group">
-                <label>Role *</label>
+                <label for="roleInput">Role *</label>
                 <select id="roleInput" style="width: 100%; padding: 12px; border: 1px solid #ddd; border-radius: 8px; font-size: 1rem; background: white;">
                     <option value="student" selected>Student</option>
                     <option value="educator">Educator</option>
@@ -168,7 +168,7 @@
             </div>
 
             <div class="form-group">
-                <label>Location (City) *</label>
+                <label for="locationInput">Location (City) *</label>
                 <div class="input-wrapper">
                     <input type="text" id="locationInput" required placeholder="Start typing..." autocomplete="off">
                     <div id="suggestions" class="suggestions"></div>
@@ -176,12 +176,12 @@
             </div>
 
             <div class="form-group">
-                <label>Summary / Bio <span class="optional">(Optional)</span></label>
+                <label for="summary">Summary / Bio <span class="optional">(Optional)</span></label>
                 <textarea id="summary" placeholder="A brief summary about yourself and your interests in AI..."></textarea>
             </div>
 
             <div class="form-group">
-                <label>Websites <span class="optional">(Optional, comma-separated)</span></label>
+                <label for="websites">Websites <span class="optional">(Optional, comma-separated)</span></label>
                 <input type="text" id="websites" placeholder="https://github.com/..., https://linkedin.com/...">
             </div>
 
@@ -346,6 +346,8 @@
         };
     })();
 
+    // Decorative only: keep failures here from blocking the setup form below.
+    try {
     const container = document.getElementById('canvas-container');
     const scene = new THREE.Scene();
     const initialBgColor = new THREE.Color(0xf0f4f8);
@@ -375,50 +377,10 @@
     const skyMesh = new THREE.Mesh(skyGeo, skyMat);
     scene.add(skyMesh);
 
-    const width = 60;
-    const depth = 80;
-    const widthSegments = 80;
-    const depthSegments = 100;
-    const geometry = new THREE.PlaneGeometry(width, depth, widthSegments, depthSegments);
-    geometry.rotateX(-Math.PI / 2);
-
-    const terrainMat = new THREE.ShaderMaterial({
-        vertexShader: document.getElementById('terrain-vs').textContent,
-        fragmentShader: document.getElementById('terrain-fs').textContent,
-        uniforms: {
-            uTime: { value: 0 },
-            uNoiseScale: { value: 0.15 },
-            uHeightScale: { value: 4.0 }
-        },
-        wireframe: true,
-        transparent: true
-    });
-
-    const terrain = new THREE.Mesh(geometry, terrainMat);
-    scene.add(terrain);
-
-    // Solid base layer
-    const solidMat = new THREE.ShaderMaterial({
-        vertexShader: document.getElementById('terrain-vs').textContent,
-        fragmentShader: document.getElementById('terrain-fs').textContent,
-        uniforms: {
-            uTime: { value: 0 },
-            uNoiseScale: { value: 0.15 },
-            uHeightScale: { value: 4.0 }
-        },
-        polygonOffset: true,
-        polygonOffsetFactor: 1,
-        polygonOffsetUnits: 1
-    });
-    const terrainSolid = new THREE.Mesh(geometry, solidMat);
-    scene.add(terrainSolid);
-
     function animate() {
         requestAnimationFrame(animate);
         const time = performance.now() * 0.001;
         skyMesh.material.uniforms.uTime.value = time;
-        terrain.material.uniforms.uTime.value = time;
-        terrainSolid.material.uniforms.uTime.value = time;
         renderer.render(scene, camera);
     }
     animate();
@@ -428,6 +390,9 @@
         camera.updateProjectionMatrix();
         renderer.setSize(window.innerWidth, window.innerHeight);
     });
+    } catch (bgErr) {
+        console.warn('Profile setup: 3D background failed to initialize (non-critical):', bgErr);
+    }
 
 
     // --- AUTH & PROFILE LOGIC ---


### PR DESCRIPTION
Fixes the profile-setup bug reported in discussion #1745 and issue #1813, plus a related dashboard-access bug surfaced while testing.

## 1. Profile setup form did nothing on submit

`profile_setup.html` referenced THREE.js shader `<script>` elements `terrain-vs` / `terrain-fs` that **are not defined anywhere in the page** (only `sky-vs` / `sky-fs` exist). At module load:

```js
vertexShader: document.getElementById('terrain-vs').textContent, // null.textContent → TypeError
```

This threw `Uncaught TypeError: Cannot read properties of null (reading 'textContent')` **before** the form's `submit` handler was attached further down the same module. With no handler, clicking **Complete Setup** triggered a native form submission → the page reloaded with empty fields and nothing was ever saved. Confirmed live on `mlsysbook.ai` (`profile_setup.html:386`).

**Fix**
- Remove the dead terrain mesh/material code (the referenced shaders never existed; the sky shader is unaffected).
- Wrap the decorative 3D background in `try/catch` so a background failure can never again block the form/auth handlers.
- Add `for` attributes to every label — resolves the *"No label associated with the form field"* accessibility error noted in the report.

## 2. Email/password logins were redirected to login when opening the dashboard

Email login stores a `tinytorch_token` but, when the login response contains no `refresh_token`, never calls `supabase.auth.setSession(...)` — so no Supabase client session is created. `guard.js` gated access on `supabase.auth.getSession()`, which is empty in that case, and bounced logged-in users to login. Meanwhile the rest of the app (dashboard's `fetchUserProgress`, `profile.js`, `auth.js`) authenticates via `tinytorch_token`, so the nav showed the user as logged in. Verified: `{ token: true, refresh: false, sbKeys: [] }`.

**Fix**
- `guard.js`: authenticate via `tinytorch_token` + the `get-profile-details` Edge Function (with one refresh retry), consistent with the rest of the app. Fail open on network/timeout; clear session + send to login only when the token is truly dead or the account is gone (404).
- `ui.js`: clear the sidebar Dashboard lock icon/tooltip once logged in (`updateNavState` previously only toggled the top-right icon).

## Follow-up (out of scope, backend)
The root reason for `refresh: false` is that the Netlify `/api/auth/login` endpoint did not return a `refresh_token`, so no refreshable session is stored. This PR makes the dashboard work while the access token is valid; once it expires with no refresh token the guard correctly sends the user back to login. Returning a `refresh_token` from the login endpoint lives in the `tinytorch.netlify.app` backend (separate repo).

## Testing
- Reproduced the original `terrain-vs` TypeError on the live site and confirmed it's gone after the change.
- Verified locally (served at `http://localhost:8000/community/`): submitting the setup form now persists and advances; logging in with email/password and clicking **Dashboard** now loads instead of redirecting to login; the sidebar lock clears when logged in.