### PR TITLE
fix(book): render pseudocode algorithms and contain their overflow

### DIFF
--- a/book/quarto/_extensions/mlsysbook-ext/pseudocode/pseudocode.lua
+++ b/book/quarto/_extensions/mlsysbook-ext/pseudocode/pseudocode.lua
@@ -24,34 +24,53 @@ local function ensure_html_deps()
     [[
     <script type="text/javascript">
     (function(d) {
-      d.querySelectorAll(".pseudocode-container").forEach(function(el) {
-        let pseudocodeOptions = {
-          indentSize: el.dataset.indentSize,
-          commentDelimiter: " " + el.dataset.commentDelimiter + " ",
-          lineNumber: el.dataset.lineNumber.toLowerCase() === "true",
-          lineNumberPunc: el.dataset.lineNumberPunc,
-          noEnd: el.dataset.noEnd.toLowerCase() === "true",
-          scopeLines: el.dataset.indentLines.toLowerCase() === "true",
-          titlePrefix: el.dataset.captionPrefix,
-        };
-        pseudocode.renderElement(el.querySelector(".pseudocode"), pseudocodeOptions);
-      });
-    })(document);
-    (function(d) {
-      d.querySelectorAll(".pseudocode-container").forEach(function(el) {
-        let captionSpan = el.querySelector(".ps-root > .ps-algorithm > .ps-line > .ps-keyword")
-        if (captionSpan !== null) {
-          let captionPrefix = el.dataset.captionPrefix + " ";
-          let captionNumber = "";
-          if (el.dataset.pseudocodeNumber) {
-            captionNumber = el.dataset.pseudocodeNumber + " ";
-            if (el.dataset.chapterLevel) {
-              captionNumber = el.dataset.chapterLevel + "." + captionNumber;
+      function renderPseudocode() {
+        d.querySelectorAll(".pseudocode-container").forEach(function(el) {
+          let pseudocodeOptions = {
+            indentSize: el.dataset.indentSize,
+            commentDelimiter: " " + el.dataset.commentDelimiter + " ",
+            lineNumber: el.dataset.lineNumber.toLowerCase() === "true",
+            lineNumberPunc: el.dataset.lineNumberPunc,
+            noEnd: el.dataset.noEnd.toLowerCase() === "true",
+            scopeLines: el.dataset.indentLines.toLowerCase() === "true",
+            titlePrefix: el.dataset.captionPrefix,
+          };
+          pseudocode.renderElement(el.querySelector(".pseudocode"), pseudocodeOptions);
+        });
+        d.querySelectorAll(".pseudocode-container").forEach(function(el) {
+          let captionSpan = el.querySelector(".ps-root > .ps-algorithm > .ps-line > .ps-keyword")
+          if (captionSpan !== null) {
+            let captionPrefix = el.dataset.captionPrefix + " ";
+            let captionNumber = "";
+            if (el.dataset.pseudocodeNumber) {
+              captionNumber = el.dataset.pseudocodeNumber + " ";
+              if (el.dataset.chapterLevel) {
+                captionNumber = el.dataset.chapterLevel + "." + captionNumber;
+              }
             }
+            captionSpan.innerHTML = captionPrefix + captionNumber;
           }
-          captionSpan.innerHTML = captionPrefix + captionNumber;
-        }
-      });
+        });
+      }
+      // pseudocode.js needs a math backend (KaTeX or MathJax) present *at the
+      // moment* renderElement runs. This book renders math with MathJax loaded
+      // via `defer`, so window.MathJax does not exist yet when this after-body
+      // script executes at parse time — calling renderElement now throws
+      // "No math backend found" and the raw LaTeX source stays on the page.
+      // Wait for the math backend to be ready before rendering: KaTeX if it is
+      // present synchronously, otherwise MathJax's startup promise (available
+      // after the deferred MathJax script has run, by window 'load').
+      function whenMathReady(cb) {
+        if (window.katex) { cb(); return; }
+        var mj = window.MathJax;
+        if (mj && mj.startup && mj.startup.promise) { mj.startup.promise.then(cb); return; }
+        window.addEventListener("load", function() {
+          var m = window.MathJax;
+          if (m && m.startup && m.startup.promise) { m.startup.promise.then(cb); }
+          else { cb(); }
+        });
+      }
+      whenMathReady(renderPseudocode);
     })(document);
     </script>
   ]]

--- a/book/quarto/assets/styles/_base-styles.scss
+++ b/book/quarto/assets/styles/_base-styles.scss
@@ -286,6 +286,22 @@ figure.quarto-float-tbl > div[aria-describedby] {
   -webkit-overflow-scrolling: touch;
 }
 
+// Rendered pseudocode/algorithm blocks (pseudocode.js emits `.ps-root` inside
+// `.pseudocode-container.quarto-float`) lay each `\Require`/`\State` line out on
+// a single, non-wrapping line. Long signature lines — e.g. the `\Require` line
+// of `algo-minibatch-sgd` in nn_computation — exceed the body column on narrow
+// viewports and, since the container has no overflow handling of its own, force
+// page-level horizontal scroll. Same failure mode and fix as the wide tables
+// above: scope `overflow-x: auto` to the container so a wide algorithm scrolls
+// inside its own box instead of widening the page. `max-width: 100%` keeps the
+// container exactly column-width so the inner block's intrinsic width can't
+// stretch it.
+.pseudocode-container {
+  max-width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
 // Link styles
 a {
   color: $link-color;


### PR DESCRIPTION
## Summary

Fixes two HTML-output bugs affecting **every algorithm block across both volumes** (first surfaced on `vol1/nn_computation`).

### 1. Algorithms render as raw LaTeX instead of typeset pseudocode
pseudocode.js's init script ran synchronously at parse time, but the book renders math with **MathJax loaded via `defer`** and no KaTeX. So at the moment `renderElement` ran, no math backend existed yet and it threw:

```
Uncaught EvalError: No math backend found. Please setup KaTeX or MathJax.
```

The raw `\begin{algorithm}…` source was left on the page and never retried (MathJax loads moments later and typesets the rest of the page, but the algorithm init had already failed). **Reproduced on the live `_dev` site**, so this is a production bug, not a local artifact.

**Fix:** wait for the math backend to be ready before rendering — KaTeX if present synchronously, otherwise MathJax's `startup.promise` (available after the deferred MathJax script runs).

### 2. Wide algorithms force page-level horizontal scroll
The rendered `.pseudocode-container` had no overflow handling, so a long algorithm line (e.g. the `\Require …` signature) pushed the whole page sideways. Scoped `overflow-x: auto` to the container so it scrolls in its own box — same failure mode and fix as the existing wide-table rule directly above it.

## Verification
Rendered the page and drove headless Chrome against the output:

| | Before |
<img width="788" height="107" alt="Screenshot 2026-06-24 105451" src="https://github.com/user-attachments/assets/325c0982-00b4-40c0-8e29-98a0b406e614" />

| After |
<img width="773" height="671" alt="Screenshot 2026-06-24 105441" src="https://github.com/user-attachments/assets/6a8d9184-84d8-4f71-a216-63d3f2620f78" />

MathJax confirmed working independently (847 `mjx-container` elements rendered), isolating the failure to pseudocode init timing.

## Scope
Both files are shared across all chapters and both volumes, so this repairs every algorithm block — not just the one page.