### PR TITLE
Refine PDF layout for front matter pages and Chapter 1

### DIFF
--- a/book/quarto/_extensions/mlsysbook-ext/titlepage/before-body.tex
+++ b/book/quarto/_extensions/mlsysbook-ext/titlepage/before-body.tex
@@ -45,7 +45,7 @@ $-- % Copyright page and dedication page
 \copyrightpage
 \dedicationpage
 
-\setcounter{page}{1}
+%\setcounter{page}{1}
 $if(has-frontmatter)$
 \end{frontmatter}
 $endif$

--- a/book/quarto/contents/vol1/introduction/introduction.qmd
+++ b/book/quarto/contents/vol1/introduction/introduction.qmd
@@ -310,12 +310,12 @@ The timeline in @fig-ai-timeline traces how often artificial intelligence is men
   axis line style={thick},
   axis lines*=left,
   axis on top,
-  width=18cm,
-  height=20cm,
+  width=200mm,
+  height=205mm,
   xmin=1950,
   xmax=2023,
   ymin=0.000000,
-  ymax=0.00033,
+  ymax=0.00032,
   xtick={1950,1960,1970,1980,1990,2000,2010,2020},
   extra x ticks={1955,1965,1975,1985,1995,2005,2015},
   extra x tick labels={},
@@ -493,11 +493,12 @@ While impressive in demonstrations, these systems were operationally brittle. Th
 **Mechanism**:
 
 ```{.text}
-Problem: "If the number of customers Tom gets is twice the
-square of 20% of the number of advertisements he runs, and
-the number of advertisements is 45, what is the number of
-customers Tom gets?"
+Problem: "If the number of customers Tom gets is twice the square of 20% 
+of the number of advertisements he runs, and the number of advertisements 
+is 45, what is the number of customers Tom gets?"
+```
 
+```{.text}
 STUDENT would:
 
 1. Parse the English text
@@ -1228,7 +1229,7 @@ class AlexNetEvolutionTable:
 | **Modern Deep Learning (2020+)** | Large-scale transformers       | ImageNet top-5 accuracy       | 90%+ (ViT) [@dosovitskiy2021image]                                   | Hours on distributed systems                                                                                                                                                                                                                                                       |
 | **Modern Deep Learning (2023)**  | Foundation models              | MMLU benchmark                | 86.4% (GPT-4) [@openai2023gpt4]                                      | Not disclosed; illustrative `mlsysim` reference anchor of about `{python} GPT4ScaleEstimate.a100_gpu_days_million_str` (same scale as `{python} GPT4ScaleEstimate.a100_class_gpu_count_str` reference GPUs for `{python} GPT4ScaleEstimate.training_days_str`) [@semianalysisGPT4] |
 
-: **AI Performance Evolution Across Paradigms**: Each paradigm transition correlates with increased computational scale rather than algorithmic sophistication. Performance improved from amateur-level expert systems (2000 Elo) through high-accuracy statistical learning on constrained benchmarks to superhuman foundation models (86.4 percent Massive Multitask Language Understanding (MMLU)), while computational requirements grew from CPU-era feature pipelines to large-scale distributed training. GPT-4 training details are not official disclosures, so the rightmost value is an illustrative scale anchor rather than a benchmark result. {#tbl-ai-evolution-performance tbl-colwidths="[17,15,20,19,29]"}
+: **AI Performance Evolution Across Paradigms**: Each paradigm transition correlates with increased computational scale rather than algorithmic sophistication. Performance improved from amateur-level expert systems (2000 Elo) through high-accuracy statistical learning on constrained benchmarks to superhuman foundation models (86.4 percent Massive Multitask Language Understanding (MMLU)), while computational requirements grew from CPU-era feature pipelines to large-scale distributed training. GPT-4 training details are not official disclosures, so the rightmost value is an illustrative scale anchor rather than a benchmark result. {#tbl-ai-evolution-performance tbl-colwidths="[16,15,18,21,30]"}
 
 The table reveals two additional insights. MMLU\index{MMLU!benchmark} (Massive Multitask Language Understanding), a standard benchmark for broad knowledge across many subjects, anchors the foundation-model row; @sec-benchmarking formalizes how to interpret such benchmarks. For fixed benchmark tasks such as ImageNet, distributed training pushed training time from multi-day AlexNet runs back toward hours; frontier foundation-model runs still take days to months because teams reinvest parallelism into larger scale. The most dramatic improvements occurred at paradigm transitions (expert systems to statistical learning, statistical learning to deep learning) when new approaches unlocked the ability to use more computation effectively. The pattern validates Sutton's observation: progress comes from finding ways to use more compute, not from encoding more human knowledge.
 
@@ -1576,7 +1577,7 @@ The machine learning systems landscape spans roughly `{python} DeploymentSystems
 | **Mobile**   | Smartphone or wearable-class SoC | Shared application memory            | Phone-class neural, GPU, and CPU engines | Battery and thermal cap        |
 | **TinyML**   | Microcontroller node             | Kilobyte-scale memory                | Always-on sensor compute                 | Milliwatt-class battery budget |
 
-: **Four Deployment Paradigms**: Representative memory, compute, and power envelopes for cloud, edge, mobile, and TinyML systems, exposing the multi-order-of-magnitude span that prevents simple model reuse across tiers. Exact hardware twins and peak-rate calculations appear in the hardware chapters. {#tbl-introduction-deployment-paradigms tbl-colwidths="[17,25,22,21,15]"}
+: **Four Deployment Paradigms**: Representative memory, compute, and power envelopes for cloud, edge, mobile, and TinyML systems, exposing the multi-order-of-magnitude span that prevents simple model reuse across tiers. Exact hardware twins and peak-rate calculations appear in the hardware chapters. {#tbl-introduction-deployment-paradigms tbl-colwidths="[12,24,22,23,17]"}
 
 **Observation**: The gap between the Cloud and TinyML paradigms is roughly `{python} DeploymentSystems.mem_span_math` in memory and `{python} DeploymentSystems.compute_span_math` in compute power. This divergence is precisely why we cannot simply "shrink" a cloud model to run at the edge; each tier requires a fundamental redesign of the D·A·M axes.
 
@@ -3008,7 +3009,9 @@ These pillars also provide the organizational backbone for this textbook. Each p
 
 ## Book Organization {#sec-introduction-book-organization-0b64}
 
-The five pillars map directly onto this textbook's four-part structure, which progresses from foundational concepts through model development to production deployment. The organizing principle is *context before theory*: the landscape and vocabulary are established (Part I) before building models (Part II), optimizing those models (Part III), and deploying them reliably (Part IV). @Tbl-book-structure outlines this organization.
+The five pillars map directly onto this textbook's four-part structure, which progresses from foundational concepts through model development to production deployment. The organizing principle is *context before theory*: the landscape and vocabulary are established (Part I) before building models (Part II), optimizing those models (Part III), and deploying them reliably (Part IV). @Tbl-book-structure outlines this organization.`
+
+Part I establishes the constraint vocabulary before model machinery appears. @Sec-introduction develops the engineering revolution in AI and the frameworks that organize this discipline. @Sec-ml-systems explores the deployment spectrum from Cloud to TinyML, examining how physical constraints (power envelopes, memory hierarchies, and latency budgets) govern each tier. @Sec-ml-workflow presents the end-to-end process from problem formulation through deployment, providing the conceptual map that guides subsequent learning. @Sec-data-engineering addresses data collection, processing, and management, establishing that data infrastructure precedes and enables model development.
 
 | **Part**           | **Theme**                      | **Key Chapters**                                                                             |
 |:-------------------|:-------------------------------|:---------------------------------------------------------------------------------------------|
@@ -3018,8 +3021,6 @@ The five pillars map directly onto this textbook's four-part structure, which pr
 | **IV: Deploy**     | Production: Real-world systems | @sec-model-serving, @sec-ml-operations, @sec-responsible-engineering, @sec-conclusion        |
 
 : **Book Organization**: The four parts follow a pedagogical progression from context (Foundations) through theory (Build) to practice (Optimize, Deploy). Each part builds on the vocabulary and frameworks of its predecessors, so Part III's optimization techniques assume familiarity with Part II's model architectures, and Part IV's deployment practices assume mastery of Parts II and III. {#tbl-book-structure tbl-colwidths="[18,30,52]"}
-
-Part I establishes the constraint vocabulary before model machinery appears. @Sec-introduction develops the engineering revolution in AI and the frameworks that organize this discipline. @Sec-ml-systems explores the deployment spectrum from Cloud to TinyML, examining how physical constraints (power envelopes, memory hierarchies, and latency budgets) govern each tier. @Sec-ml-workflow presents the end-to-end process from problem formulation through deployment, providing the conceptual map that guides subsequent learning. @Sec-data-engineering addresses data collection, processing, and management, establishing that data infrastructure precedes and enables model development.
 
 Part II turns that vocabulary into model construction skills. @Sec-neural-computation provides algorithmic foundations, while @sec-network-architectures extends these to specific network designs. Both chapters reference the five Lighthouse Models introduced earlier (ResNet-50, GPT-2/Llama, MobileNetV2, DLRM, and Keyword Spotting) to anchor abstract concepts in concrete workloads. @Sec-ml-frameworks examines the software infrastructure from TensorFlow and PyTorch to specialized tools. @Sec-model-training develops training systems for complex models and large datasets.
 

--- a/book/quarto/tex/frontmatter-vol1.tex
+++ b/book/quarto/tex/frontmatter-vol1.tex
@@ -68,6 +68,7 @@
 \renewcommand{\halftitle}{%
   \thispagestyle{empty}%
   \begingroup%
+  \addtocounter{page}{-1}%
   \fontsize{12pt}{14.4pt}\selectfont\bfseries\noindent%
   Introduction to Machine Learning Systems
   \vfill%
@@ -321,5 +322,5 @@ only matters if you give it away.%
 \DedicationText
 
 \endgroup
-\clearpage
+\cleardoublepage
 }

--- a/book/quarto/tex/header-includes.tex
+++ b/book/quarto/tex/header-includes.tex
@@ -709,8 +709,8 @@ align=right,font={\fontsize{40pt}{40}\selectfont}]
 % Switch to Arabic page numbering on first numbered part
 \if@firstnumberedpart%
   \cleardoublepage%
-  \setcounter{lastRomanPage}{\value{page}}%
-  \pagenumbering{arabic}%
+  %\setcounter{lastRomanPage}{\value{page}}%
+  %\pagenumbering{arabic}%
   \@firstnumberedpartfalse%
   \@firstnumberedfalse%  % Also mark chapters as not first (prevents double switch)
 \fi
@@ -755,11 +755,21 @@ minimum width=40mm,font={%
 \makeatother
 
 
+\makeatletter
+\newif\if@firstdivision
+\@firstdivisiontrue
+
 % DIVISIONS: Clean geometric styling with subtle tech elements
 % Used for frontmatter, main_content, and backmatter divisions
 \newcommand{\division}[1]{%
 \FloatBarrier%  % Flush all pending floats before division break
-\clearpage
+\cleardoublepage
+  %
+  \if@firstdivision
+    \pagenumbering{arabic}% starts arabic numbering from 1
+    \@firstdivisionfalse
+  \fi
+  %
 \thispagestyle{empty}
 \begin{tikzpicture}[remember picture,overlay]
 
@@ -815,6 +825,8 @@ align=center,font={\fontsize{40pt}{40}\selectfont}]
 \end{tikzpicture}
 \clearpage
 }
+
+\makeatother
 
 % LAB DIVISIONS: Circuit-style neural network design for lab sections
 % Used specifically for lab platform sections (arduino, xiao, grove, etc.)
@@ -1099,8 +1111,9 @@ align=right,font={\fontsize{40pt}{40}\selectfont}]
   \else
     \if@firstnumbered%
       \cleardoublepage%
-      \setcounter{lastRomanPage}{\value{page}}%
+      %\setcounter{lastRomanPage}{\value{page}}%
       \pagenumbering{arabic}%
+      \setcounter{page}{3}%
       \@firstnumberedfalse%
     \else
       \setcounter{page}{\value{page}}%
@@ -1114,8 +1127,9 @@ align=right,font={\fontsize{40pt}{40}\selectfont}]
 \newcommand{\unnumbered@chapter}[1]{%
   \if@firstunnumbered%
     \clearpage
-    \setcounter{lastRomanPage}{\value{page}}%
+    %\setcounter{lastRomanPage}{\value{page}}%
     \pagenumbering{roman}%
+    \setcounter{page}{15}%
     \@firstunnumberedfalse%
   \fi
   \setcounter{sidenote}{1}
@@ -1219,9 +1233,13 @@ align=right,font={\fontsize{40pt}{40}\selectfont}]
 % a closing rule. Non-callout longtables are untouched: the \else branch runs
 % the original, fully patched by the counter hooks above.
 \makeatletter
+\@ifundefined{mfx@inCalloutTablesPatched}{%
+  \gdef\mfx@inCalloutTablesPatched{}%
+
 \newif\ifmfxInCallout
 \let\mfx@orig@longtable\longtable
 \let\mfx@orig@endlongtable\endlongtable
+\let\mfx@orig@caption\caption
 \long\def\mfx@tbl@gobble#1\endlastfoot{}
 % Start the tabular lazily at the first \toprule. Pandoc emits \caption BEFORE
 % \toprule, so deferring the tabular lets the caption typeset ABOVE the table
@@ -1250,15 +1268,21 @@ align=right,font={\fontsize{40pt}{40}\selectfont}]
   % \nopagebreak: it still keeps the caption off a page bottom, but it now lets
   % the foldbox break right before the caption when fewer than N lines remain,
   % so a tall in-callout table no longer shoves the whole callout (large gap).
-  \def\caption##1{\par\addvspace{8\p@}\needspace{\mfx@tbl@needlines\baselineskip}%
-    \global\mlsys@longtable@numberedtrue
-    \global\mfx@tbl@nexttable=\c@table
-    \global\advance\mfx@tbl@nexttable by 1%
-    \c@table=\numexpr\mfx@tbl@nexttable-1\relax
+\def\caption##1{%
+  \par\addvspace{8\p@}%
+  \needspace{\mfx@tbl@needlines\baselineskip}%
+  \global\mlsys@longtable@numberedtrue
+  \global\mfx@tbl@nexttable=\c@table
+  \global\advance\mfx@tbl@nexttable by 1%
+  \c@table=\numexpr\mfx@tbl@nexttable-1\relax
+  {%
+    \let\caption\mfx@orig@caption
     \captionof{table}{##1}%
-    \c@table=\mfx@tbl@nexttable
-    \global\c@table=\mfx@tbl@nexttable
-    \par\nobreak\vskip 3\p@\nobreak}%
+  }%
+  \c@table=\mfx@tbl@nexttable
+  \global\c@table=\mfx@tbl@nexttable
+  \par\nobreak\vskip 3\p@\nobreak
+  }%
   \let\label\mlsys@orig@label
   \let\tabularnewline\relax
   \let\endfirsthead\mfx@tbl@gobble
@@ -1275,6 +1299,7 @@ align=right,font={\fontsize{40pt}{40}\selectfont}]
   \expandafter\mfx@orig@longtable\fi}
 \def\endlongtable{\ifmfxInCallout\expandafter\mfx@tbl@end\else
   \expandafter\mfx@orig@endlongtable\fi}
+}{}
 \makeatother
 
 % =============================================================================
@@ -2237,7 +2262,7 @@ align=right,font={\fontsize{40pt}{40}\selectfont}]
 % Set \MarginDebugfalse for production builds; \MarginDebugtrue to show guides.
 % ─────────────────────────────────────────────────────────────────────────────
 \newif\ifMarginDebug
-\MarginDebugfalse   % <<< set to \MarginDebugtrue to show margin alignment guides
+\MarginDebugfalse% <<< set to \MarginDebugtrue to show margin alignment guides
 \ifMarginDebug
   \usepackage{showframe}
   \renewcommand*\ShowFrameLinethickness{0.2pt}


### PR DESCRIPTION
### Summary of the first commit

This commit updates the Volume I front-matter and main-matter page sequence to match the MIT Press publisher requirements.

The page order has been adjusted as follows:

* half-title page — p. i
* blank page — p. ii
* full title page — p. iii
* copyright page — p. iv
* dedication page — p. v
* blank page — p. vi
* Table of Contents starts on p. vii
* Welcome page starts on p. xv
* the remaining front-matter pages continue with Roman page numbering
* Main Matter division page starts with Arabic numbering on p. 1
* blank page — p. 2
* Chapter 1 starts on p. 3
* the remaining chapters continue with Arabic page numbering

The following files were updated to support this layout.

#### `quarto/_extensions/mlsysbook-ext/titlepage/before-body.tex`

The command

```tex
\setcounter{page}{1}
```

was disabled to prevent the page counter from being reset before the Table of Contents.

#### `quarto/tex/frontmatter-vol1.tex`

The command

```tex
\addtocounter{page}{-1}
```

was added inside

```tex
\renewcommand{\halftitle}{...}
```

so that the half-title page starts correctly on page i.

The final `\clearpage` at the end of the dedication page was also changed to `\cleardoublepage` in order to insert the required blank page before the Table of Contents and ensure that the Table of Contents starts on an odd-numbered page, p. vii.

#### `quarto/tex/header-includes.tex`

The command

```tex
\newcommand{\unnumbered@chapter}[1]{...}
```

was adjusted so that the first unnumbered chapter after the Table of Contents, the Welcome chapter, starts on p. xv.

The command

```tex
\setcounter{lastRomanPage}{\value{page}}
```

was disabled because it is no longer needed. When

```tex
\pagenumbering{roman}
```

is used, LaTeX automatically resets the page counter to 1.

The command

```tex
\setcounter{page}{15}
```

was added so that the Welcome chapter starts on Roman page xv. Since the Table of Contents starts on p. vii and occupies seven pages, it ends on p. xiv, so the next page should correctly be p. xv.

The same logic was also applied to

```tex
\newcommand{\numbered@chapter}[1]{...}
```

because

```tex
\pagenumbering{arabic}
```

automatically resets the page counter to 1.

The Main Matter division page needs to start on a right-hand page, so the page break inside

```tex
\newcommand{\division}[1]{...}
```

was changed from `\clearpage` to `\cleardoublepage`:

```tex
\newcommand{\division}[1]{%
  \FloatBarrier% Flush all pending floats before division break
  \cleardoublepage
```

The Main Matter page is also the first page that should use Arabic page numbering. For this reason, I added a conditional flag so that the first call to `\division` switches the document to Arabic numbering by using:

```tex
\pagenumbering{arabic}
```

Since `\pagenumbering{arabic}` automatically resets the page counter, this makes the Main Matter division page start as page 1.

On subsequent calls to `\division`, for example for later division pages, the condition is no longer true, so the Arabic page numbering simply continues without being reset.

```tex
\makeatletter
\newif\if@firstdivision
\@firstdivisiontrue

% DIVISIONS: Clean geometric styling with subtle tech elements
% Used for frontmatter, main_content, and backmatter divisions
\newcommand{\division}[1]{%
  \FloatBarrier% Flush all pending floats before division break
  \cleardoublepage
  %
  \if@firstdivision
    \pagenumbering{arabic}% starts Arabic numbering from 1
    \@firstdivisionfalse
  \fi
  %
```


Finally, inside

```tex
\newcommand{\numberedpart}[1]{...}
```

the command

```tex
\pagenumbering{arabic}
```

was disabled for the first numbered part. This prevents the page counter from being reset when Part I starts. The Arabic page numbering should begin with the Main Matter division page and then continue through Part I and the following chapters without being restarted.
