### PR TITLE
fix(staffml): guard localStorage access in ThemeProvider against strict-storage browsers

### DIFF
--- a/interviews/staffml/src/__tests__/theme-provider-storage.test.tsx
+++ b/interviews/staffml/src/__tests__/theme-provider-storage.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * ThemeProvider storage-guard regression.
+ *
+ * getInitialTheme() reads localStorage to reconcile the stored theme on mount.
+ * In strict-storage browsers (Safari "Block all cookies", sandboxed iframes)
+ * localStorage.getItem itself throws. The writer (toggleTheme) already guarded
+ * its setItem calls, but the reader did not — so the mount effect threw and the
+ * theme never reconciled. The read is now wrapped in try/catch, falling back to
+ * the ecosystem default ("light").
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ThemeProvider, { useTheme } from '@/components/ThemeProvider';
+
+function ThemeReadout() {
+  const { theme } = useTheme();
+  return <span data-testid="theme">{theme}</span>;
+}
+
+const originalGetItem = window.localStorage.getItem;
+
+afterEach(() => {
+  window.localStorage.getItem = originalGetItem;
+});
+
+describe('ThemeProvider storage guard', () => {
+  it('falls back to the default theme without throwing when localStorage.getItem throws', () => {
+    window.localStorage.getItem = () => {
+      throw new DOMException('The operation is insecure.', 'SecurityError');
+    };
+
+    expect(() =>
+      render(
+        <ThemeProvider>
+          <ThemeReadout />
+        </ThemeProvider>,
+      ),
+    ).not.toThrow();
+
+    expect(screen.getByTestId('theme')).toHaveTextContent('light');
+  });
+
+  it('reconciles to a stored theme when storage is readable', () => {
+    window.localStorage.setItem('staffml_theme', 'dark');
+
+    render(
+      <ThemeProvider>
+        <ThemeReadout />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByTestId('theme')).toHaveTextContent('dark');
+  });
+});

--- a/interviews/staffml/src/components/ThemeProvider.tsx
+++ b/interviews/staffml/src/components/ThemeProvider.tsx
@@ -25,12 +25,33 @@ export function useTheme() {
 // and shared/config/site-head.html.
 const QUARTO_KEY = "quarto-color-scheme";
 
+// localStorage access can throw — not just on the method call, but on the
+// property access itself — in strict-storage browsers (Safari "Block all
+// cookies") and sandboxed iframes without allow-same-origin. Funnel every
+// access through these guards so a future caller can't reintroduce an
+// unguarded read/write that aborts a mount effect.
+function safeGet(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch (_) {
+    return null;
+  }
+}
+
+function safeSet(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch (_) {
+    /* storage unavailable; in-memory state still updates. */
+  }
+}
+
 function getInitialTheme(): Theme {
   if (typeof window === "undefined") return "light";
-  const stored = localStorage.getItem("staffml_theme") as Theme | null;
+  const stored = safeGet("staffml_theme");
   if (stored === "light" || stored === "dark") return stored;
   // Secondary source: pick up the choice last set on a sibling subsite.
-  const fromQuarto = localStorage.getItem(QUARTO_KEY) as Theme | null;
+  const fromQuarto = safeGet(QUARTO_KEY);
   if (fromQuarto === "light" || fromQuarto === "dark") return fromQuarto;
   // Light is the ecosystem-wide default (matches the book, labs, kits,
   // slides, etc.). OS preference is intentionally NOT honored here — users
@@ -54,14 +75,10 @@ export default function ThemeProvider({ children }: { children: React.ReactNode 
     setTheme((prev) => {
       const next = prev === "dark" ? "light" : "dark";
       document.documentElement.dataset.theme = next;
-      try {
-        localStorage.setItem("staffml_theme", next);
-        // Mirror to the ecosystem-shared key so Quarto subsites (book,
-        // labs, kits, slides, ...) inherit the choice on next nav.
-        localStorage.setItem(QUARTO_KEY, next);
-      } catch (_) {
-        /* localStorage unavailable; in-memory state still updates. */
-      }
+      safeSet("staffml_theme", next);
+      // Mirror to the ecosystem-shared key so Quarto subsites (book,
+      // labs, kits, slides, ...) inherit the choice on next nav.
+      safeSet(QUARTO_KEY, next);
       return next;
     });
   }, []);


### PR DESCRIPTION
## Problem

`ThemeProvider.getInitialTheme()` read `localStorage` without a `try/catch`, while the matching writer (`toggleTheme`) was already guarded. In browsers that block storage — Safari with **"Block all cookies"**, or sandboxed iframes without `allow-same-origin` — even accessing `window.localStorage` throws a `SecurityError` (not just the `.getItem()` call). That throw happened inside the mount `useEffect`, aborting it **before** `setTheme` ran, so the theme never reconciled and stayed stuck at the SSR default.

## Fix

Funnel all storage access through shared `safeGet` / `safeSet` helpers, so reads and writes share a single guard and a future caller can't reintroduce an unguarded access that breaks a mount effect. Runtime validation of the stored value (`=== "light" | "dark"`) is preserved, so a garbage value can't poison the theme.

## Test

Adds `theme-provider-storage.test.tsx`:
- mounts `ThemeProvider` with a throwing `getItem` → no throw, falls back to `light`
- confirms normal reconciliation to a stored `dark` theme still works

No behavior change for users with working storage.