### PR TITLE
fix(staffml): expose expanded state on Nav disclosure toggles

### DIFF
--- a/interviews/staffml/src/__tests__/nav-disclosure-aria.test.tsx
+++ b/interviews/staffml/src/__tests__/nav-disclosure-aria.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * Nav disclosure ARIA guardrails.
+ *
+ * The "Tools" dropdown toggle and the mobile hamburger are disclosure buttons
+ * that show/hide a menu, but they exposed no expanded/collapsed state to
+ * assistive tech — the only cue was a visual chevron rotation. Screen-reader
+ * users couldn't tell whether the menu was open. Both now carry
+ * aria-expanded / aria-haspopup / aria-controls, and the controlled menu
+ * gets a matching id.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/',
+}));
+
+import Nav from '@/components/Nav';
+import ThemeProvider from '@/components/ThemeProvider';
+
+function renderNav() {
+  return render(
+    <ThemeProvider>
+      <Nav />
+    </ThemeProvider>,
+  );
+}
+
+describe('Nav Tools dropdown ARIA', () => {
+  it('reflects expanded state and wires aria-controls to the menu', () => {
+    renderNav();
+    const toggle = screen.getByRole('button', { name: 'Tools' });
+
+    expect(toggle).toHaveAttribute('aria-haspopup', 'true');
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(toggle).toHaveAttribute('aria-controls', 'nav-tools-menu');
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+    const menu = document.getElementById('nav-tools-menu');
+    expect(menu).not.toBeNull();
+    // Sanity-check the controlled element actually holds the tool links.
+    expect(within(menu as HTMLElement).getByText('Framework')).toBeInTheDocument();
+  });
+});
+
+describe('Nav mobile hamburger ARIA', () => {
+  it('reflects expanded state and wires aria-controls to the mobile menu', () => {
+    renderNav();
+    const toggle = screen.getByRole('button', { name: 'Toggle navigation menu' });
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(toggle).toHaveAttribute('aria-controls', 'nav-mobile-menu');
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(document.getElementById('nav-mobile-menu')).not.toBeNull();
+  });
+});

--- a/interviews/staffml/src/components/Nav.tsx
+++ b/interviews/staffml/src/components/Nav.tsx
@@ -127,6 +127,9 @@ export default function Nav() {
             <div ref={toolsRef} className="relative">
               <button
                 onClick={() => setToolsOpen(!toolsOpen)}
+                aria-haspopup="true"
+                aria-expanded={toolsOpen}
+                aria-controls="nav-tools-menu"
                 className={clsx(
                   "flex items-center gap-1 px-2.5 py-1.5 rounded-md text-[13px] font-medium transition-colors",
                   toolLinks.some(l => isActive(l.href))
@@ -135,10 +138,10 @@ export default function Nav() {
                 )}
               >
                 Tools
-                <ChevronDown className={clsx("w-3 h-3 transition-transform", toolsOpen && "rotate-180")} />
+                <ChevronDown aria-hidden="true" className={clsx("w-3 h-3 transition-transform", toolsOpen && "rotate-180")} />
               </button>
               {toolsOpen && (
-                <div className="absolute top-full left-0 mt-1 w-48 bg-background border border-border rounded-lg shadow-lg py-1 z-50">
+                <div id="nav-tools-menu" className="absolute top-full left-0 mt-1 w-48 bg-background border border-border rounded-lg shadow-lg py-1 z-50">
                   {toolLinks.map(({ href, label, icon: Icon }) => (
                     <Link
                       key={href}
@@ -169,15 +172,18 @@ export default function Nav() {
             onClick={() => setMobileOpen(!mobileOpen)}
             className="md:hidden p-2 text-textTertiary hover:text-textPrimary transition-colors"
             aria-label="Toggle navigation menu"
+            aria-haspopup="true"
+            aria-expanded={mobileOpen}
+            aria-controls="nav-mobile-menu"
           >
-            {mobileOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
+            {mobileOpen ? <X aria-hidden="true" className="w-5 h-5" /> : <Menu aria-hidden="true" className="w-5 h-5" />}
           </button>
         </div>
       </div>
 
       {/* Mobile menu */}
       {mobileOpen && (
-        <div className="md:hidden border-t border-border bg-surface px-4 py-3 space-y-1">
+        <div id="nav-mobile-menu" className="md:hidden border-t border-border bg-surface px-4 py-3 space-y-1">
           {primaryLinks.map(({ href, label, icon: Icon }) => (
             <Link
               key={href}


### PR DESCRIPTION
## Problem

The **Tools** dropdown toggle and the **mobile hamburger** in the top nav are disclosure buttons that show/hide a menu, but they exposed no expanded/collapsed state to assistive technology. The only cue that the menu was open was a visual chevron rotation, so screen-reader and keyboard users had no programmatic signal (WCAG 4.1.2).

## Fix

- Add `aria-haspopup="true"`, `aria-expanded={open}`, and `aria-controls` to both toggles.
- Give each controlled menu a matching `id` (`nav-tools-menu`, `nav-mobile-menu`).
- Mark the purely decorative chevron / menu / close icons `aria-hidden="true"`.

No visual or behavioral change for sighted users.

## Test

Adds `nav-disclosure-aria.test.tsx` asserting both toggles report `aria-expanded` correctly before/after click and that `aria-controls` points at the rendered menu.