### PR TITLE
fix(staffml): give StarGate proper dialog semantics and focus management

### DIFF
--- a/interviews/staffml/src/__tests__/stargate-dialog-a11y.test.tsx
+++ b/interviews/staffml/src/__tests__/stargate-dialog-a11y.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * StarGate dialog accessibility guardrails.
+ *
+ * StarGate is a full-viewport blocking overlay, but it used to render as a
+ * plain <div>: no role="dialog", no aria-modal, no aria-labelledby, no Escape
+ * handler, and no focus management — so the dimmed page behind it stayed
+ * keyboard-reachable and screen readers didn't announce it as a dialog.
+ *
+ * It now mirrors the KeyboardShortcutsOverlay / CommandPalette pattern:
+ * dialog semantics, focus moved to the primary CTA on mount, focus restored
+ * on unmount, Tab trapped within the surface, and Escape to dismiss.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const markVerified = vi.fn();
+
+vi.mock('@/lib/star-gate', () => ({
+  // Never resolves — keeps the live star count in its loading state so the
+  // test doesn't depend on network or timing.
+  fetchStarCount: () => new Promise(() => {}),
+  getStarUrl: () => 'https://github.com/harvard-edge/cs249r_book',
+  markVerified: (...args: unknown[]) => markVerified(...args),
+}));
+
+import StarGate from '@/components/StarGate';
+
+beforeEach(() => {
+  markVerified.mockClear();
+});
+
+describe('StarGate dialog a11y', () => {
+  it('exposes dialog semantics labelled by its heading', () => {
+    render(<StarGate onVerified={() => {}} />);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby', 'stargate-title');
+    expect(document.getElementById('stargate-title')).toHaveTextContent('Our only ask.');
+  });
+
+  it('moves focus to the primary CTA on mount', async () => {
+    render(<StarGate onVerified={() => {}} />);
+    const primary = screen.getByRole('button', { name: /Star on GitHub/i });
+    await waitFor(() => expect(primary).toHaveFocus());
+  });
+
+  it('dismisses on Escape (counts as a dismiss) and restores focus on unmount', () => {
+    const trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    const onVerified = vi.fn();
+    const { unmount } = render(<StarGate onVerified={onVerified} />);
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(markVerified).toHaveBeenCalledWith('dismissed');
+    expect(onVerified).toHaveBeenCalledTimes(1);
+
+    unmount();
+    expect(trigger).toHaveFocus();
+    trigger.remove();
+  });
+});

--- a/interviews/staffml/src/components/StarGate.tsx
+++ b/interviews/staffml/src/components/StarGate.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Star, CheckCircle2, ExternalLink, X } from "lucide-react";
 import { GithubIcon } from "@/components/GithubIcon";
 import { getStarUrl, markVerified, fetchStarCount } from "@/lib/star-gate";
@@ -8,6 +8,9 @@ import { getStarUrl, markVerified, fetchStarCount } from "@/lib/star-gate";
 export default function StarGate({ onVerified }: { onVerified: () => void }) {
   const [starCount, setStarCount] = useState<number | null>(null);
   const [retired, setRetired] = useState<"starred" | "honor" | null>(null);
+  const previouslyFocused = useRef<HTMLElement | null>(null);
+  const surfaceRef = useRef<HTMLDivElement>(null);
+  const primaryBtnRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -30,19 +33,65 @@ export default function StarGate({ onVerified }: { onVerified: () => void }) {
     setTimeout(onVerified, 1500);
   };
 
-  const handleDismiss = () => {
+  const handleDismiss = useCallback(() => {
     markVerified("dismissed");
     onVerified();
-  };
+  }, [onVerified]);
+
+  // Focus management: move focus into the gate on mount, restore it to the
+  // previously-focused element when the gate unmounts. Mirrors the pattern in
+  // KeyboardShortcutsOverlay / CommandPalette.
+  useEffect(() => {
+    previouslyFocused.current = document.activeElement as HTMLElement | null;
+    const id = setTimeout(() => primaryBtnRef.current?.focus(), 0);
+    return () => {
+      clearTimeout(id);
+      previouslyFocused.current?.focus?.();
+    };
+  }, []);
+
+  // Escape dismisses the gate (counts as a dismiss), and Tab is trapped within
+  // the dialog surface so focus can't escape behind the blocking overlay.
+  useEffect(() => {
+    if (retired) return; // the confirmation panel has no interactive content
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        handleDismiss();
+        return;
+      }
+      if (e.key !== "Tab" || !surfaceRef.current) return;
+      const focusables = surfaceRef.current.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [retired, handleDismiss]);
 
   if (retired) {
     return (
-      <div className="fixed inset-0 z-50 bg-background/90 backdrop-blur-sm flex items-center justify-center p-6">
+      <div
+        className="fixed inset-0 z-50 bg-background/90 backdrop-blur-sm flex items-center justify-center p-6"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="stargate-retired-title"
+      >
         <div className="max-w-md w-full bg-background border border-border rounded-2xl p-8 shadow-lg text-center">
           <div className="w-16 h-16 rounded-full bg-accentGreen/10 border border-accentGreen/30 flex items-center justify-center mx-auto mb-4">
             <CheckCircle2 className="w-8 h-8 text-accentGreen" />
           </div>
-          <h2 className="text-xl font-bold text-textPrimary mb-2">Thank you.</h2>
+          <h2 id="stargate-retired-title" className="text-xl font-bold text-textPrimary mb-2">Thank you.</h2>
           <p className="text-sm text-textSecondary">
             {retired === "starred"
               ? "That signal matters more than you know."
@@ -56,8 +105,13 @@ export default function StarGate({ onVerified }: { onVerified: () => void }) {
   const formattedCount = starCount !== null ? starCount.toLocaleString() : null;
 
   return (
-    <div className="fixed inset-0 z-50 bg-background/90 backdrop-blur-sm flex items-center justify-center p-6">
-      <div className="relative max-w-md w-full bg-background border border-border rounded-2xl p-8 shadow-lg">
+    <div
+      className="fixed inset-0 z-50 bg-background/90 backdrop-blur-sm flex items-center justify-center p-6"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="stargate-title"
+    >
+      <div ref={surfaceRef} className="relative max-w-md w-full bg-background border border-border rounded-2xl p-8 shadow-lg">
         {/* Close (X) — counts as dismiss */}
         <button
           onClick={handleDismiss}
@@ -70,7 +124,7 @@ export default function StarGate({ onVerified }: { onVerified: () => void }) {
         {/* Header */}
         <div className="flex items-center justify-center gap-2 mb-2">
           <Star className="w-5 h-5 text-accentAmber" />
-          <h2 className="text-xl font-bold text-textPrimary">Our only ask.</h2>
+          <h2 id="stargate-title" className="text-xl font-bold text-textPrimary">Our only ask.</h2>
         </div>
         <p className="text-sm text-textSecondary text-center mb-5 leading-relaxed">
           StaffML, the textbook, TinyTorch, the hardware kits — all free, forever.
@@ -98,6 +152,7 @@ export default function StarGate({ onVerified }: { onVerified: () => void }) {
 
         {/* Primary CTA */}
         <button
+          ref={primaryBtnRef}
           onClick={handleStar}
           className="flex items-center justify-center gap-2 w-full py-3 bg-accentBlue text-white font-bold rounded-lg text-sm hover:opacity-90 transition-opacity mb-2"
         >


### PR DESCRIPTION
## Problem

`StarGate` is a full-viewport **blocking** overlay (the "only ask" star gate), but it rendered as a plain `<div>`:

- no `role="dialog"`, `aria-modal`, or `aria-labelledby` — screen readers didn't announce it as a dialog
- no Escape handler
- no focus management — focus stayed on whatever was behind the gate, and Tab walked into the dimmed, non-interactive page behind the overlay (WCAG 2.4.3 / 2.1.2 / 4.1.2)

## Fix

Mirror the pattern already used by `KeyboardShortcutsOverlay` and `CommandPalette`:

- `role="dialog"` + `aria-modal="true"` + `aria-labelledby` pointing at the heading (both the gate and the post-action "Thank you" confirmation panel)
- move focus to the primary "Star on GitHub" CTA on mount, restore focus to the previously-focused element on unmount
- trap Tab/Shift+Tab within the dialog surface
- Escape dismisses the gate (honor-system: counts as a dismiss, same as the ✕)

No visual change.

## Test

Adds `stargate-dialog-a11y.test.tsx` covering dialog attributes + labelling, focus-to-CTA on mount, Escape→dismiss, and focus restoration on unmount. Full suite (117 tests) green.