### PR TITLE
fix(staffml): dialog semantics + focus management for framework primitive-detail modal

### DIFF
--- a/interviews/staffml/src/__tests__/framework-modal-a11y.test.tsx
+++ b/interviews/staffml/src/__tests__/framework-modal-a11y.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * Framework primitive-detail modal accessibility guardrails.
+ *
+ * The PrimitiveDetail overlay rendered as a plain <div>: no role="dialog",
+ * aria-modal, or aria-labelledby, and no focus management — so screen readers
+ * didn't announce it as a dialog and keyboard focus stayed in the dimmed page
+ * behind it. (Escape was already handled at the page level.)
+ *
+ * It now carries dialog semantics labelled by the primitive name, moves focus
+ * to the close button on mount, restores focus on unmount, and traps Tab —
+ * mirroring KeyboardShortcutsOverlay / CommandPalette.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { PrimitiveDetail } from '@/app/framework/page';
+import { primitives } from '@/data/designGrammar';
+
+const sample = primitives[0];
+
+describe('Framework PrimitiveDetail modal a11y', () => {
+  it('exposes dialog semantics labelled by the primitive name', () => {
+    render(<PrimitiveDetail primitive={sample} onClose={() => {}} onLinkClick={() => {}} />);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby', 'primitive-detail-title');
+    expect(document.getElementById('primitive-detail-title')).toHaveTextContent(sample.name);
+  });
+
+  it('moves focus to the close button on mount and restores it on unmount', async () => {
+    const trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    const { unmount } = render(
+      <PrimitiveDetail primitive={sample} onClose={() => {}} onLinkClick={() => {}} />,
+    );
+    const close = screen.getByRole('button', { name: 'Close' });
+    await waitFor(() => expect(close).toHaveFocus());
+
+    unmount();
+    expect(trigger).toHaveFocus();
+    trigger.remove();
+  });
+});

--- a/interviews/staffml/src/app/framework/page.tsx
+++ b/interviews/staffml/src/app/framework/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState, useEffect, useCallback } from "react";
+import { useMemo, useState, useEffect, useCallback, useRef } from "react";
 import Link from "next/link";
 import { ArrowLeft, Search, X } from "lucide-react";
 import {
@@ -494,7 +494,7 @@ function ExpressionRender({ tokens }: { tokens: ExpressionToken[] }) {
 // Pixel-port of the original .panel CSS from design-grammar/index.html.
 // Sizes use arbitrary Tailwind values to match the original's rems/px
 // exactly rather than rounding to nearest preset.
-function PrimitiveDetail({
+export function PrimitiveDetail({
   primitive,
   onClose,
   onLinkClick,
@@ -506,11 +506,51 @@ function PrimitiveDetail({
   const role = roles[primitive.role];
   const color = role.color;
   const layerName = layerLabels[primitive.layer - 1];
+  const previouslyFocused = useRef<HTMLElement | null>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const closeBtnRef = useRef<HTMLButtonElement>(null);
+
+  // Focus management: move focus into the dialog on open, restore it on close.
+  // Escape is handled by the page-level listener. Mirrors the pattern in
+  // KeyboardShortcutsOverlay / CommandPalette.
+  useEffect(() => {
+    previouslyFocused.current = document.activeElement as HTMLElement | null;
+    const id = setTimeout(() => closeBtnRef.current?.focus(), 0);
+    return () => {
+      clearTimeout(id);
+      previouslyFocused.current?.focus?.();
+    };
+  }, []);
+
+  // Trap Tab/Shift+Tab within the panel so focus can't reach the dimmed page.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Tab" || !panelRef.current) return;
+      const focusables = panelRef.current.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
 
   return (
     <div
       className="fixed inset-0 z-[100] bg-black/60 flex items-center justify-center p-4"
       onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="primitive-detail-title"
     >
       {/*
         Two-layer modal panel:
@@ -523,10 +563,12 @@ function PrimitiveDetail({
         unreachable on small/landscape viewports.
       */}
       <div
+        ref={panelRef}
         className="relative w-full max-w-[500px]"
         onClick={(e) => e.stopPropagation()}
       >
         <button
+          ref={closeBtnRef}
           onClick={onClose}
           className="absolute top-[0.7rem] right-[1rem] z-10 w-10 h-10 flex items-center justify-center bg-transparent border-0 text-textTertiary hover:text-textPrimary text-[1.4rem] leading-none cursor-pointer"
           aria-label="Close"
@@ -551,7 +593,7 @@ function PrimitiveDetail({
             </span>
           </div>
           <div className="min-w-0">
-            <div className="text-[1.15rem] font-bold text-textPrimary leading-tight">
+            <div id="primitive-detail-title" className="text-[1.15rem] font-bold text-textPrimary leading-tight">
               {primitive.name}
             </div>
             <div


### PR DESCRIPTION
## Problem

The framework page's `PrimitiveDetail` overlay rendered as a plain `<div>`:

- no `role="dialog"`, `aria-modal`, or `aria-labelledby` — screen readers didn't announce it as a dialog (WCAG 4.1.2)
- no focus management — focus stayed in the dimmed page behind the modal, and Tab walked through the hidden content (WCAG 2.4.3)

(Escape-to-close was already handled by the page-level keydown listener.)

## Fix

Mirror the pattern already used by `KeyboardShortcutsOverlay` / `CommandPalette`:

- `role="dialog"` + `aria-modal="true"` + `aria-labelledby` pointing at the primitive name
- move focus to the close button on open, restore focus to the previously-focused element on close
- trap Tab/Shift+Tab within the panel

`PrimitiveDetail` is exported so it can be unit-tested in isolation. No visual change.

## Test

Adds `framework-modal-a11y.test.tsx` covering dialog attributes + labelling, focus-to-close on mount, and focus restoration on unmount.