### PR TITLE
fix(staffml): remove invalid HTML button nested inside the explore SVG

### DIFF
--- a/interviews/staffml/src/__tests__/explore-svg-markup.test.tsx
+++ b/interviews/staffml/src/__tests__/explore-svg-markup.test.tsx
@@ -1,0 +1,26 @@
+/**
+ * Explore radial-chart markup guardrail.
+ *
+ * The center "zoom out" affordance used to be an HTML <button> wrapping an SVG
+ * <circle>. A <button> is not valid SVG content — it doesn't focus reliably
+ * across browsers and has no accessible name. The click handler now lives on
+ * the <circle> directly; the keyboard-accessible navigation is the Breadcrumb
+ * and the ExplorerPanel, and the chart is exposed to assistive tech as a
+ * single labelled role="img".
+ *
+ * This test locks in that the SVG contains no nested HTML <button>.
+ */
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import ExplorePage from '@/app/explore/page';
+
+describe('Explore radial chart markup', () => {
+  it('renders the chart as a labelled role="img" with no HTML <button> nested in the SVG', () => {
+    const { container } = render(<ExplorePage />);
+    const svg = container.querySelector('svg[role="img"]');
+    expect(svg).not.toBeNull();
+    expect(svg).toHaveAttribute('aria-label');
+    // Invalid SVG content: there must be no HTML button inside the SVG.
+    expect(svg!.querySelector('button')).toBeNull();
+  });
+});

--- a/interviews/staffml/src/app/explore/page.tsx
+++ b/interviews/staffml/src/app/explore/page.tsx
@@ -411,16 +411,29 @@ export default function ExplorePage() {
                   </defs>
 
                   <circle cx={CX} cy={CY} r="108" className="fill-surface stroke-border" strokeWidth="1" />
-                  <button
-                    type="button"
+                  {/*
+                    Mouse affordance to zoom out (clicking the hub jumps to the
+                    parent focus). An HTML <button> is not valid SVG content and
+                    won't focus reliably across browsers, so the click handler
+                    lives on the <circle> directly. The keyboard-accessible
+                    equivalents are the Breadcrumb above and the ExplorerPanel
+                    beside this chart; the whole SVG is exposed to assistive
+                    tech as a single labelled role="img".
+                  */}
+                  <circle
+                    cx={CX}
+                    cy={CY}
+                    r="92"
                     onClick={() => {
                       const parent = focusParent(focus);
                       if (parent) goToFocus(parent);
                     }}
-                    className="cursor-pointer"
-                  >
-                    <circle cx={CX} cy={CY} r="92" className="fill-background stroke-borderSubtle hover:stroke-accentBlue transition-colors" strokeWidth="1" />
-                  </button>
+                    className={clsx(
+                      "fill-background stroke-borderSubtle transition-colors",
+                      focusParent(focus) && "cursor-pointer hover:stroke-accentBlue"
+                    )}
+                    strokeWidth="1"
+                  />
                   <text x={CX} y={CY - 8} textAnchor="middle" className="fill-textPrimary text-[18px] font-bold">
                     {focusLabel(focus)}
                   </text>


### PR DESCRIPTION
## Problem

The radial explorer's center "zoom out" affordance was an HTML `<button>` wrapping an SVG `<circle>`:

```jsx
<button type="button" onClick={...} className="cursor-pointer">
  <circle cx={CX} cy={CY} r="92" ... />
</button>
```

An HTML `<button>` is **not valid SVG content** — it doesn't focus reliably across browsers and exposed no accessible name (WCAG 4.1.2). At the root focus it was also a silent no-op.

## Fix

- Move the click handler onto the `<circle>` directly (valid SVG, preserves the mouse zoom-out).
- Only show the pointer/hover affordance when there is a parent focus to zoom out to.

Keyboard navigation is unchanged: the **Breadcrumb** above the chart and the **ExplorerPanel** beside it already provide real `<button>` controls for the same focus changes, and the chart is exposed to assistive tech as a single labelled `role="img"`. A code comment documents this so the redundancy is intentional and discoverable.

## Test

Adds `explore-svg-markup.test.tsx` asserting the chart renders as a labelled `role="img"` with no nested HTML `<button>`.