### PR TITLE
fix(staffml): track and clear toast auto-dismiss timers

### DIFF
--- a/interviews/staffml/src/__tests__/toast-timer-cleanup.test.tsx
+++ b/interviews/staffml/src/__tests__/toast-timer-cleanup.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * Toast auto-dismiss timer cleanup regression.
+ *
+ * Each toast schedules a 4s setTimeout to auto-dismiss itself. The timer
+ * handle used to be discarded, so it was never cleared: if the provider
+ * unmounted within 4s the timer still fired setState on a dead tree, and a
+ * manual dismiss left the timer running. Timers are now tracked in a ref,
+ * cleared on manual dismiss, and all cleared on unmount.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { ToastProvider, useToast } from '@/components/Toast';
+
+function Trigger() {
+  const { show } = useToast();
+  return (
+    <button onClick={() => show({ type: 'info', title: 'hi' })}>fire toast</button>
+  );
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('Toast auto-dismiss timer cleanup', () => {
+  it('clears the pending auto-dismiss timer when the provider unmounts', () => {
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const { unmount } = render(
+      <ToastProvider>
+        <Trigger />
+      </ToastProvider>,
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByText('fire toast'));
+    });
+
+    const before = clearSpy.mock.calls.length;
+    unmount();
+    // Unmount must clear the still-pending 4s timer.
+    expect(clearSpy.mock.calls.length).toBeGreaterThan(before);
+
+    // Flushing timers after unmount must not throw (no setState on dead tree).
+    expect(() => act(() => vi.runOnlyPendingTimers())).not.toThrow();
+    clearSpy.mockRestore();
+  });
+
+  it('cancels the auto-dismiss timer on manual dismiss', () => {
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+    render(
+      <ToastProvider>
+        <Trigger />
+      </ToastProvider>,
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByText('fire toast'));
+    });
+    expect(screen.getByText('hi')).toBeInTheDocument();
+
+    const before = clearSpy.mock.calls.length;
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /dismiss notification/i }));
+    });
+    // Manual dismiss must cancel the pending auto-dismiss timer.
+    expect(clearSpy.mock.calls.length).toBeGreaterThan(before);
+
+    // Advancing past the original 4s window must not throw — the timer was
+    // cancelled, so its callback never runs (no double-removal / dead setState).
+    expect(() => act(() => vi.advanceTimersByTime(5000))).not.toThrow();
+    clearSpy.mockRestore();
+  });
+});

--- a/interviews/staffml/src/components/Toast.tsx
+++ b/interviews/staffml/src/components/Toast.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, createContext, useContext } from "react";
+import { useState, useEffect, useCallback, useRef, createContext, useContext } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { X, Trophy, Flame, CheckCircle2 } from "lucide-react";
 import clsx from "clsx";
@@ -26,18 +26,38 @@ let nextId = 0;
 
 export function ToastProvider({ children }: { children: React.ReactNode }) {
   const [toasts, setToasts] = useState<ToastMessage[]>([]);
+  // Track each toast's auto-dismiss timer so we can cancel it on manual
+  // dismiss and clear any still-pending timers if the provider unmounts —
+  // otherwise a timer firing after unmount calls setState on a dead tree.
+  const timers = useRef<Map<number, ReturnType<typeof setTimeout>>>(new Map());
+
+  const dismiss = useCallback((id: number) => {
+    const timer = timers.current.get(id);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timers.current.delete(id);
+    }
+    setToasts(prev => prev.filter(t => t.id !== id));
+  }, []);
 
   const show = useCallback((msg: Omit<ToastMessage, 'id'>) => {
     const id = nextId++;
     setToasts(prev => [...prev, { ...msg, id }]);
     // Auto-dismiss after 4s
-    setTimeout(() => {
+    const timer = setTimeout(() => {
+      timers.current.delete(id);
       setToasts(prev => prev.filter(t => t.id !== id));
     }, 4000);
+    timers.current.set(id, timer);
   }, []);
 
-  const dismiss = useCallback((id: number) => {
-    setToasts(prev => prev.filter(t => t.id !== id));
+  // Clear any pending auto-dismiss timers on unmount.
+  useEffect(() => {
+    const pending = timers.current;
+    return () => {
+      pending.forEach(clearTimeout);
+      pending.clear();
+    };
   }, []);
 
   return (


### PR DESCRIPTION
## Problem

Each toast schedules a 4s `setTimeout` to auto-dismiss itself, but the timer handle was discarded:

```js
const show = useCallback((msg) => {
  const id = nextId++;
  setToasts(prev => [...prev, { ...msg, id }]);
  setTimeout(() => { setToasts(prev => prev.filter(t => t.id !== id)); }, 4000); // never cleared
}, []);
```

So the timer was never cleared. If `ToastProvider` unmounts within 4s of a toast (route teardown, fast-refresh, test cleanup) the timer still fires `setToasts` on a dead tree, and a manual dismiss leaves the timer running to a wasted no-op tick.

## Fix

- Track each toast's timer in a `useRef<Map<id, timeout>>`.
- Cancel the timer in `dismiss()`.
- Clear all pending timers in a provider unmount cleanup.

No user-visible behavior change.

## Test

Adds `toast-timer-cleanup.test.tsx` (fake timers) asserting the pending timer is cleared on unmount and on manual dismiss, and that flushing timers afterward doesn't throw.