### PR TITLE
fix(staffml): keep practice-page Cmd+Enter handler fresh via latest-callback refs

### DIFF
--- a/interviews/staffml/src/app/practice/page.tsx
+++ b/interviews/staffml/src/app/practice/page.tsx
@@ -191,6 +191,17 @@ function PracticePage() {
   const setCurrent = setCurrentSummary;
   const skipFilterCount = useRef(0);
   const questionShownAt = useRef(Date.now());
+  // Latest-callback refs for the global keyboard listener below. The
+  // listener is intentionally stable (re-armed only on showAnswer / current
+  // / pickRandom changes) so it doesn't churn on every keystroke. But
+  // handleReveal closes over `userAnswer` (and handleScore over
+  // `effectiveMaxScore` / `questionsAnswered`) which change between
+  // listener re-arms — without these refs the listener would call a stale
+  // handleReveal that still sees `userAnswer=""` after the user has typed
+  // 100+ chars, misfiring the think-guard. Refs are refreshed in the
+  // sync effect right after handleScore is defined.
+  const handleRevealRef = useRef<(force?: boolean) => void>(() => {});
+  const handleScoreRef = useRef<(score: number) => void>(() => {});
   const [showAnswer, setShowAnswer] = useState(false);
   const [userAnswer, setUserAnswer] = useState("");
   // MCQ self-check: the learner's selected option index (null = none yet).
@@ -425,19 +436,23 @@ function PracticePage() {
     setRubricItems([]);
   }, [pool, current, showAnswer]);
 
-  // Keyboard shortcuts: Enter to reveal, 1-4 for scoring, N to skip
+  // Keyboard shortcuts: Cmd/Ctrl+Enter to reveal, 1-4 for scoring, N to skip.
+  // Stable listener — re-armed only when showAnswer/current/pickRandom change.
+  // The handlers are called via refs (see handleRevealRef / handleScoreRef)
+  // so the listener always invokes the LATEST closures even though the
+  // effect itself doesn't re-run on every keystroke.
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.target instanceof HTMLTextAreaElement) {
         // Only Enter (without shift) to reveal when in textarea
         if (e.key === 'Enter' && (e.metaKey || e.ctrlKey) && !showAnswer && current) {
           e.preventDefault();
-          handleReveal();
+          handleRevealRef.current();
         }
         return;
       }
       if (showAnswer && ['1', '2', '3', '4'].includes(e.key)) {
-        handleScore(parseInt(e.key) - 1);
+        handleScoreRef.current(parseInt(e.key) - 1);
       }
       if (e.key === 'n' || e.key === 'N') {
         pickRandom();
@@ -576,6 +591,16 @@ function PracticePage() {
     }
     pickNext();
   };
+
+  // Refresh the keyboard-shortcut refs after every render so the stable
+  // keydown listener above always reads the latest handleReveal /
+  // handleScore closures. Without this the listener invokes a stale
+  // handleReveal that still sees `userAnswer=""` while the user has
+  // typed in the textarea, misfiring the think-guard.
+  useEffect(() => {
+    handleRevealRef.current = handleReveal;
+    handleScoreRef.current = handleScore;
+  });
 
   // Pick next question: from SR due queue if in review mode, else random
   const pickNext = useCallback(() => {


### PR DESCRIPTION
## Summary
The global keyboard listener in `practice/page.tsx` is intentionally stable — re-armed only when `showAnswer`/`current`/`pickRandom` change so it doesn't churn on every keystroke. But the handlers it calls close over state that DOES change between listener re-arms:

### Bug 1 (the one that surfaces visibly): stale `userAnswer`
- `handleReveal` ([line 460+](src/app/practice/page.tsx#L460)) closes over `userAnswer`.
- User types 100+ chars in the textarea → `setUserAnswer` re-renders → fresh `handleReveal` exists in the new render, but the keydown effect's deps (`[showAnswer, current, pickRandom]`) didn't change so the effect doesn't re-run.
- Listener still holds the OLD `handleReveal` which closes over the OLD `userAnswer` (empty string).
- User presses **⌘/Ctrl+Enter** in the textarea → stale handler fires → `charsTyped = userAnswer.trim().length = 0` → think-guard at [line 466](src/app/practice/page.tsx#L466) misfires the \"are you sure?\" modal AFTER the user has actually deliberated.

### Bug 2 (same class, smaller blast radius): stale `effectiveMaxScore`
- `handleScore` ([line 545+](src/app/practice/page.tsx#L545)) closes over `effectiveMaxScore` (derived from `rubricItems` / `napkinResult`).
- User reveals the answer (`showAnswer=true` re-arms the listener) → ticks rubric checkboxes → `effectiveMaxScore` changes → digit-key listener still calls the stale `handleScore` that caps the score at the OLD max.

The Reveal/score **buttons** at lines 1190/1361/1397/1489 are unaffected — they invoke a fresh closure on click.

### Fix
Latest-callback ref pattern (same shape as `useVisibilityPoll` from #1834):

```ts
const handleRevealRef = useRef<(force?: boolean) => void>(() => {});
const handleScoreRef = useRef<(score: number) => void>(() => {});

// Refresh on every render — after handleReveal / handleScore are defined.
useEffect(() => {
  handleRevealRef.current = handleReveal;
  handleScoreRef.current = handleScore;
});

// Listener stays stable, but calls always see the latest closures.
useEffect(() => {
  const handleKeyDown = (e: KeyboardEvent) => {
    // ...
    handleRevealRef.current();
    // ...
    handleScoreRef.current(parseInt(e.key) - 1);
  };
  // ...
}, [showAnswer, current, pickRandom]);
```

Inline comment in both spots documents the trap so a future \"cleanup\" doesn't undo it.

## Test plan
- [x] `npx vitest run` → 126/126 across 22 files passing (unchanged from `dev`; no new tests added — see Notes).
- [x] `npx tsc --noEmit` → clean.
- [ ] Manual repro (before/after):
  1. Open `/practice`. Wait for a question to load.
  2. Type a 100-character answer into the textarea (genuinely think through it for >20s).
  3. Press **⌘/Ctrl+Enter**.
  4. **Before**: think-guard modal pops up (\"Are you sure you want to reveal?\") despite the deliberate input.
  5. **After**: reveal proceeds directly.