### PR TITLE
fix(mlperf-edu): quality-target check silently skipped for real submissions

### DIFF
--- a/mlperf-edu/scripts/compliance_checker.py
+++ b/mlperf-edu/scripts/compliance_checker.py
@@ -227,14 +227,25 @@ def check_from_submission(submission_path: str) -> ComplianceResult:
     
     # Quality target from workloads.yaml
     metrics = data.get("metrics", {})
-    # Try to find the best matching metric
-    target = QUALITY_TARGETS.get(workload.replace("-12m", "").replace("-1m", ""))
+    # Normalize the same way QUALITY_TARGETS keys were built in _load_quality_targets
+    short_workload = (
+        workload.replace("-train", "").replace("-kws", "").replace("-agent", "")
+        .replace("-12m", "").replace("-1m", "")
+    )
+    target = QUALITY_TARGETS.get(short_workload)
     if target:
         metric_name = target["metric"]
-        # Try common field mappings
-        val = metrics.get(metric_name) or metrics.get("loss") or metrics.get("accuracy")
+        # Try common field mappings, but don't treat a legitimate 0.0 as missing
+        if metric_name in metrics:
+            val = metrics[metric_name]
+        elif "loss" in metrics:
+            val = metrics["loss"]
+        elif "accuracy" in metrics:
+            val = metrics["accuracy"]
+        else:
+            val = None
         if val is not None:
-            check_quality_target(result, val, workload.replace("-12m", "").replace("-1m", ""))
+            check_quality_target(result, val, short_workload)
         else:
             result.check("Quality target", False, f"metric '{metric_name}' not found in submission")
     


### PR DESCRIPTION
## Summary
- `check_from_submission()` looked up `QUALITY_TARGETS` by the full workload id (e.g. `resnet18-train`, matching every `registry/suites/*.yaml` `id` field), but `QUALITY_TARGETS` is keyed by the short form (`resnet18`). The lookup always missed, so the quality-target check never ran at all for any real submission, regardless of reported accuracy.
- Separately, `metrics.get(metric_name) or metrics.get("loss") or metrics.get("accuracy")` used Python truthiness, so a genuine `0.0` accuracy value fell through to the loss value and could pass the quality-target check.

## Test plan
- [x] Reproduced locally: built a `resnet18-train` submission with `top1_accuracy: 0.0`, confirmed the "Quality target reached" check was entirely absent from `check_from_submission()`'s output before the fix.
- [x] After the fix: same submission now correctly reports `FAIL | Quality target reached | 0.0000 < 0.75`.
- [x] Sanity check: a legitimate `top1_accuracy: 0.80` submission still reports `PASS | Quality target reached | 0.8000 >= 0.75`.
- [x] `pre-commit run` passes on the changed file.