### PR TITLE
fix(mlperf-edu): remove vacuous deterministic-seed check from quick_check_model

### DIFF
--- a/mlperf-edu/scripts/compliance_checker.py
+++ b/mlperf-edu/scripts/compliance_checker.py
@@ -290,7 +290,6 @@ def quick_check_model(workload: str) -> ComplianceResult:
         n_params = sum(p.numel() for p in model.parameters())
         result.check("Model instantiation", True, cls_name)
         check_param_count(result, n_params, workload)
-        check_deterministic_seed(result)
 
         # Check dataset loads
         from reference.dataset_factory import get_dataloaders


### PR DESCRIPTION
## Summary
- `quick_check_model()` only instantiates a fresh reference model to sanity-check parameter counts and dataset loading; no training run ever happens and no seed is read anywhere in this path.
- `check_deterministic_seed(result)` was called with no `seed` argument, so it always compared the hardcoded default (`42`) against itself and passed unconditionally, regardless of whether a real run used any particular seed.
- `check_from_log()` already performs this check correctly elsewhere by reading the real seed out of the training log (`log.get("seed", -1)`), so this call in `quick_check_model()` was pure dead weight that could only ever report a false PASS.

## Test plan
- [x] Confirmed via code reading: `check_deterministic_seed(seed: int = 42)` compares `seed == 42`; the only other call site (`check_from_log`) passes the real seed, so removing the argument-less call in `quick_check_model()` does not affect any real seed verification.
- [x] `grep` confirms no remaining calls to `check_deterministic_seed` without an explicit seed argument.