### PR TITLE
fix(mlperf-edu): stop silently bypassing anti-cheat when mlperf CLI is missing

### DIFF
--- a/mlperf-edu/scripts/autograder/grade_all.py
+++ b/mlperf-edu/scripts/autograder/grade_all.py
@@ -59,14 +59,14 @@ class GraderPipeline:
         
         # Execute absolute Cryptographic Anti-Cheating Protocol
         # We physically call the CLI `mlperf verify` gracefully validating hash mapping constraints natively
-        cli_executable = "mlperf" 
+        cli_executable = "mlperf"
         try:
             res = subprocess.run([cli_executable, "verify", target_payload], capture_output=True, text=True)
             if "CHEATING DETECTED" in res.stdout:
                 return {"HUID": huid, "Status": "INVALID", "Score": 0.0, "Energy": 0.0, "Cheating": "YES"}
         except FileNotFoundError:
-            # Fallback natively structurally reading hashes directly algebraically safely
-            pass
+            print(f"❌ [Failed] {huid}: `mlperf` CLI not found on PATH -- cannot run anti-cheat verification!")
+            return {"HUID": huid, "Status": "VERIFY_UNAVAILABLE", "Score": 0.0, "Energy": 0.0, "Cheating": "UNVERIFIED"}
 
         # Parse Native Score Matrix cleanly mapping LoadGen validations manually efficiently!
         try:


### PR DESCRIPTION
## Summary
- `GraderPipeline._process_zip()` runs `mlperf verify` as the only anti-cheat check. If the `mlperf` CLI isn't on PATH (the common case for a bare grading checkout that hasn't `pip install -e`'d the package), the `FileNotFoundError` was caught and silently `pass`ed, and the pipeline fell straight through to parsing the submission's self-reported JSON metrics with `"Cheating": "NO"` unconditionally.
- Concrete impact: a student can hand-edit their submission JSON to claim any accuracy/throughput they want, and it gets graded as `VALIDATED` with no verification at all.

## Test plan
- [x] Confirmed `mlperf` is not on PATH in a clean grading environment (`where mlperf` fails).
- [x] Built a forged submission zip (`achieved_accuracy: 0.99`, `throughput_qps: 99999`) and ran the real `_process_zip()` against it before the fix: returned `{'Status': 'VALIDATED', 'Score': 0.99, 'Cheating': 'NO'}`.
- [x] After the fix, the same forged zip returns `{'Status': 'VERIFY_UNAVAILABLE', 'Score': 0.0, 'Cheating': 'UNVERIFIED'}` and logs the failure instead of silently grading it.