### PR TITLE
fix(mlperf-edu): CSV leaderboard export crashes on mixed grade result shapes

### DIFF
--- a/mlperf-edu/scripts/autograder/grade_all.py
+++ b/mlperf-edu/scripts/autograder/grade_all.py
@@ -87,8 +87,12 @@ class GraderPipeline:
 
     def _export_leaderboard(self, grades):
         if not grades: return
-        
-        keys = grades[0].keys()
+
+        keys = []
+        for grade in grades:
+            for key in grade.keys():
+                if key not in keys:
+                    keys.append(key)
         with open(self.output_csv, 'w', newline='') as output_file:
             dict_writer = csv.DictWriter(output_file, fieldnames=keys)
             dict_writer.writeheader()


### PR DESCRIPTION
## Summary
- `_export_leaderboard()` derived `csv.DictWriter` fieldnames from `grades[0].keys()` alone. Non-validated results (`CORRUPT_ZIP`, `NO_PAYLOAD`, `JSON_ERROR`) have fewer keys than a `VALIDATED` result (missing `Throughput`), so whenever a non-validated submission happened to sort first from `glob.glob()` (filesystem-order dependent, not guaranteed alphabetical), writing a later `VALIDATED` row raised `ValueError: dict contains fields not in fieldnames`, crashing the export for the entire batch.

## Test plan
- [x] Reproduced: called the real `_export_leaderboard()` with a `CORRUPT_ZIP` result first and a `VALIDATED` result second -- confirmed `ValueError: dict contains fields not in fieldnames: 'Throughput'`.
- [x] After the fix (fieldnames built from the union of keys across all grades, first-seen order preserved): export succeeds, CSV has all columns with blanks for missing fields on rows that lack them.