### PR TITLE
fix(mlperf-edu): p99 decode-latency formula wrong for small sample counts

### DIFF
--- a/mlperf-edu/reference/cloud/nanogpt_decode.py
+++ b/mlperf-edu/reference/cloud/nanogpt_decode.py
@@ -13,6 +13,7 @@ import statistics
 import time
 import torch
 
+from mlperf.harness import percentile
 from .nanogpt_train import NanoGPTWhiteBox
 
 
@@ -115,7 +116,7 @@ class NanoGPTDecode:
 
         kv_bytes = kv_cache_bytes(kv)
         median_itl = statistics.median(per_step) if per_step else float("nan")
-        p99_itl = sorted(per_step)[int(len(per_step) * 0.99) - 1] if per_step else float("nan")
+        p99_itl = percentile(per_step, 99) if per_step else float("nan")
         # Achieved bandwidth: each decode step re-reads the full KV cache
         # (the model also re-reads weights, but those usually live in LLC
         # after warmup). KV stream is the *additive* per-step cost.


### PR DESCRIPTION
## Summary
- `sorted(per_step)[int(len(per_step) * 0.99) - 1]` picks the wrong index for small `n`. For the min/smoke profile's default of 4 decode steps (`n_loop=3`), `int(3*0.99)-1 = 1`, i.e. the ~66th percentile (the middle value), not p99 (which for 3 samples should be the max).
- `mlperf/harness.py`'s own `percentile()` already implements this correctly with a ceil-based rank (`rank = max(1, ceil(p/100*n))`), matching the same pattern already used elsewhere in `reference/cloud/` (e.g. `from mlperf.roofline import measure_roofline`). Reused it instead of duplicating the broken formula.

## Test plan
- [x] Verified the old formula against `per_step=[10.0, 20.0, 30.0]`: returned `20.0` (the median), not p99.
- [x] Verified `harness.percentile([10.0, 20.0, 30.0], 99)` returns `30.0` (the correct max/p99 for 3 samples).
- [x] `python -m py_compile` passes on the edited file.