### PR TITLE
fix(mlperf-edu): anomaly-ae-train model-size gate impossible to pass

### DIFF
--- a/mlperf-edu/registry/suites/tiny/anomaly-ae-train.yaml
+++ b/mlperf-edu/registry/suites/tiny/anomaly-ae-train.yaml
@@ -44,7 +44,7 @@ verified_baseline:
   epochs: 20
   time_seconds: 5
   note: Val loss intentionally higher — anomalous digits have high recon error
-max_model_size_kb: 32
+max_model_size_kb: 300
 scenario: offline
 public:
   status: score-bearing


### PR DESCRIPTION
## Summary
- `max_model_size_kb: 32` could never be satisfied by the reference model it gates: `AnomalyDetectionAE` (640/784 -> 128x4 -> 8 -> 128x4 -> 640, `reference/tiny/anomaly_detection_ae.py`) has ~266K parameters -- matching this same file's own `params: 0.3M` -- which is ~1.03MB at FP32 and ~260KB even fully INT8-quantized.
- A submitter who trains exactly this reference model and reports the true model size would automatically fail the size gate regardless of reconstruction quality, since even the best-case (INT8) size is ~8x over budget.

## Test plan
- [x] Manually computed parameter count from the architecture definition (5 linear layers each side: 640->128->128->128->128->8 encoder, 8->128->128->128->128->640 decoder): 265,864 params, matching the YAML's own declared `params: 0.3M`.
- [x] FP32 size: 265,864 * 4 bytes ~= 1.01 MiB. INT8 size: 265,864 bytes ~= 260 KB. Both far exceed the old 32KB budget.
- [x] Corrected to 300KB, consistent with the file's own stated 0.3M parameter count at 1 byte/param (INT8).
- [x] `pre-commit`'s YAML syntax check passes on the edited file.