### PR TITLE
fix(mlperf-edu): plateau detection mixes losses across NAS attempts

### DIFF
--- a/mlperf-edu/scripts/orchestration/auto_trainer.py
+++ b/mlperf-edu/scripts/orchestration/auto_trainer.py
@@ -205,6 +205,9 @@ def _training_process(model_name: str, target_loss: float):
         model.train()
         optimizer = optim.AdamW(model.parameters(), lr=1e-3, weight_decay=1e-2)
         epoch = 0
+        # Reset per-attempt so plateau detection never mixes the tail of a
+        # discarded architecture's losses with a freshly reloaded model's.
+        attempt_loss_history = []
 
         print(f"[{model_name}] Starting training (NAS attempt {nas_attempt}/{MAX_NAS_ATTEMPTS})")
 
@@ -268,6 +271,7 @@ def _training_process(model_name: str, target_loss: float):
 
             train_loss = sum(epoch_losses) / len(epoch_losses)
             loss_history.append(train_loss)
+            attempt_loss_history.append(train_loss)
 
             # --- Validation pass ---
             model.eval()
@@ -318,7 +322,7 @@ def _training_process(model_name: str, target_loss: float):
                 break
 
             # Check plateau → trigger NAS
-            if _detect_plateau(loss_history) and nas_attempt < MAX_NAS_ATTEMPTS:
+            if _detect_plateau(attempt_loss_history) and nas_attempt < MAX_NAS_ATTEMPTS:
                 print(f"[{model_name}] 📉 Plateau detected at epoch {total_epochs + epoch}. "
                       f"Triggering Dual-Agent NAS (attempt {nas_attempt + 1})...")
                 total_epochs += epoch


### PR DESCRIPTION
## Summary
- `loss_history`/`val_loss_history` accumulate across the whole outer NAS loop, but `_load_model()` reloads a fresh (randomly-initialized) model after each LLM-driven rewrite.
- `_detect_plateau()` slides a `PLATEAU_WINDOW`-entry window over this cumulative history, so right after a rewrite the window mixes the discarded architecture's plateaued tail with the new model's high initial losses -- falsely re-triggering NAS almost immediately on an architecture that never got real training, or conversely masking a genuine plateau.

## Fix
Added `attempt_loss_history`, reset at the start of each NAS attempt (right after the model reload) and used only for plateau detection, while `loss_history`/`val_loss_history` keep accumulating the full trajectory used for the saved `results.json` and convergence plot.

## Test plan
- [x] Simulated the control flow in isolation (pure list logic, no torch needed): with the old code, 3 epochs of a freshly-reloaded model immediately re-triggered `_detect_plateau()` because the sliding window still contained the old model's plateaued tail. With the fix, the same 3 epochs correctly report no plateau (not enough data yet for the new attempt).
- [x] `python -m py_compile` passes on the edited file.