### PR TITLE
fix(mlperf-edu): NameError masks real model-load failure in auto_trainer

### DIFF
--- a/mlperf-edu/scripts/orchestration/auto_trainer.py
+++ b/mlperf-edu/scripts/orchestration/auto_trainer.py
@@ -193,6 +193,7 @@ def _training_process(model_name: str, target_loss: float):
     total_epochs = 0
     loss_history = []
     val_loss_history = []
+    model = None
 
     while nas_attempt <= MAX_NAS_ATTEMPTS:
         # (Re-)load the model
@@ -343,6 +344,10 @@ def _training_process(model_name: str, target_loss: float):
         # If we converged, break the outer NAS loop too
         if loss_history and loss_history[-1] <= target_loss:
             break
+
+    if model is None:
+        print(f"[{model_name}] ❌ Aborting: model never loaded successfully, nothing to save.")
+        return
 
     # --- Save results ---
     ckpt_dir = os.path.join(CHECKPOINT_ROOT, model_name)


### PR DESCRIPTION
## Summary
- If `_load_model()` raised on the very first NAS attempt (`nas_attempt=0`), the `except` block printed the error and `break`d out of the outer `while` loop before `model` was ever bound.
- Execution then fell through to `torch.save(model.state_dict(), save_path)`, raising `NameError: name 'model' is not defined` and hiding the real load failure behind an unrelated crash.

## Fix
Initialize `model = None` before the loop and check it after, returning early with a clear log message instead of crashing if the model never loaded successfully.

## Test plan
- [x] Simulated the control flow in isolation (pure Python, no torch needed): confirmed the old logic would crash on `model.state_dict()` after a load failure; with the fix, it logs `Aborting: model never loaded successfully, nothing to save.` and returns cleanly.
- [x] `python -m py_compile` passes on the edited file.