### PR TITLE
fix(mlperf-edu): dataset download race on shared fixed temp filename

### DIFF
--- a/mlperf-edu/src/mlperf/assets.py
+++ b/mlperf-edu/src/mlperf/assets.py
@@ -6,6 +6,7 @@ import os
 import shutil
 import subprocess
 import tarfile
+import uuid
 import warnings
 import zipfile
 import urllib.request
@@ -652,21 +653,27 @@ def ensure_movielens_100k(*, download: bool = True, root: Path | None = None) ->
 
 
 def _download(url: str, destination: Path) -> None:
+    # Download to a process- and call-unique path first, then atomically move
+    # it into place. Two concurrent fetches of the same asset (e.g. two
+    # workload runs racing to populate a shared dataset cache) must not write
+    # through the same temp file, or a slower writer's in-progress download
+    # can be clobbered mid-write by the other process before either renames.
+    unique_tmp = destination.with_name(f"{destination.name}.{os.getpid()}.{uuid.uuid4().hex[:8]}.part")
     try:
-        urllib.request.urlretrieve(url, destination)
-        return
-    except Exception as urllib_exc:
-        if shutil.which("curl"):
-            try:
-                subprocess.run(
-                    ["curl", "--fail", "--location", "--silent", "--show-error", url, "--output", str(destination)],
-                    check=True,
-                )
-                return
-            except subprocess.CalledProcessError as curl_exc:
-                if destination.exists():
-                    destination.unlink()
-                raise RuntimeError(f"failed to download {url} with urllib and curl") from curl_exc
-        if destination.exists():
-            destination.unlink()
-        raise RuntimeError(f"failed to download {url}") from urllib_exc
+        try:
+            urllib.request.urlretrieve(url, unique_tmp)
+        except Exception as urllib_exc:
+            if shutil.which("curl"):
+                try:
+                    subprocess.run(
+                        ["curl", "--fail", "--location", "--silent", "--show-error", url, "--output", str(unique_tmp)],
+                        check=True,
+                    )
+                except subprocess.CalledProcessError as curl_exc:
+                    raise RuntimeError(f"failed to download {url} with urllib and curl") from curl_exc
+            else:
+                raise RuntimeError(f"failed to download {url}") from urllib_exc
+        unique_tmp.replace(destination)
+    finally:
+        if unique_tmp.exists():
+            unique_tmp.unlink()


### PR DESCRIPTION
## Summary
- `_download()` wrote directly to the caller-provided destination -- a fixed `.download` temp path with no PID/UUID component (`tmp = raw.with_suffix(".download")`, used identically by `ensure_tinyshakespeare`, `ensure_cifar100`, `ensure_movielens_100k`).
- Two concurrent fetches of the same asset (plausible since multiple workload training runs each call the dataset factory on first use) both `urlretrieve`/`curl` to the identical path with independent file handles -- a slower writer's in-progress download could be clobbered mid-write by the other process before either side renamed to the final path.

## Fix
Download to a process- and call-unique temp file first (`destination.download.<pid>.<uuid8>.part`), then atomically replace the destination. Concurrent callers now only race on the final atomic rename (last-writer-wins, both writes are complete valid downloads), never on the write itself.

## Test plan
- [x] `python -m py_compile` passes on the edited file.
- [x] Simulated two "concurrent" downloads targeting the same destination with the new unique-temp-then-atomic-replace pattern: final content is a complete, uncorrupted write from whichever finished last, and no leftover `.part` temp files remain.