### PR TITLE
fix(design-grammar): rewrite-rules.yml was never validated at all

### DIFF
--- a/design-grammar/rewrite-rules.yml
+++ b/design-grammar/rewrite-rules.yml
@@ -82,7 +82,7 @@ rules:
   - key: prefetching
     name: "Prefetching"
     symbols: ["Pf"]
-    relieves: ["latency", "bandwidth stalls"]
+    relieves: ["latency", "bandwidth"]
     preserves: ["data values"]
     changes: "Moves data before it is needed so transfer overlaps useful work."
     preconditions: ["predictable access pattern", "available overlap window", "spare bandwidth"]
@@ -102,7 +102,7 @@ rules:
   - key: sparsification
     name: "Sparsification"
     symbols: ["Sp"]
-    relieves: ["compute", "capacity", "bandwidth"]
+    relieves: ["utilization", "capacity", "bandwidth"]
     preserves: ["approximate function"]
     changes: "Introduces zeros or structured omission so fewer values are stored or processed."
     preconditions: ["sparse-tolerant model", "hardware or kernels that exploit sparsity"]

--- a/design-grammar/scripts/validate.mjs
+++ b/design-grammar/scripts/validate.mjs
@@ -15,6 +15,7 @@ import yaml from "js-yaml";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const YAML_PATH = path.join(__dirname, "..", "grammar.yml");
+const REWRITE_RULES_PATH = path.join(__dirname, "..", "rewrite-rules.yml");
 
 const doc = yaml.load(fs.readFileSync(YAML_PATH, "utf8"));
 const issues = [];
@@ -77,6 +78,27 @@ for (const section of doc.assemblies || []) {
     while ((m = re.exec(cleaned)) !== null) {
       if (!knownSyms.has(m[1])) {
         issues.push(`Assembly "${item.name}" references unknown symbol '${m[1]}': ${item.expression}`);
+      }
+    }
+  }
+}
+
+// ── rewrite-rules.yml ────────────────────────────────────────────────────
+// Previously never read by this validator at all, so drift here was silent
+// and permanent. Check that every rule's `relieves` entries are drawn from
+// the file's own declared constraint vocabulary.
+if (!fs.existsSync(REWRITE_RULES_PATH)) {
+  issues.push(`rewrite-rules.yml not found at ${REWRITE_RULES_PATH}`);
+} else {
+  const rewriteDoc = yaml.load(fs.readFileSync(REWRITE_RULES_PATH, "utf8"));
+  const knownConstraints = new Set(rewriteDoc.constraints || []);
+  const rules = (rewriteDoc && rewriteDoc.rules) || [];
+  for (const rule of rules) {
+    for (const constraint of rule.relieves || []) {
+      if (!knownConstraints.has(constraint)) {
+        issues.push(
+          `rewrite-rules.yml rule '${rule.key}': relieves '${constraint}' is not in the declared constraint vocabulary`
+        );
       }
     }
   }


### PR DESCRIPTION
## Summary
- Confirmed via grep: `validate.mjs` and `build-html.mjs` only ever read `grammar.yml` -- neither script mentions `rewrite-rules.yml` anywhere. Any drift in that file stays silent and permanent.
- Two of its rules already used `relieves` values outside the file's own declared constraint vocabulary: `prefetching` listed `"bandwidth stalls"` (the file declares `"bandwidth"`, not that phrase) and `sparsification` listed `"compute"` (not declared at all).

## Fix
- Added a check to `validate.mjs` that loads `rewrite-rules.yml` and verifies every rule's `relieves` entries are drawn from the file's own declared `constraints:` list.
- Corrected the two anomalies: `"bandwidth stalls"` -> `"bandwidth"`, and `"compute"` -> `"utilization"` (sparsification reduces the values processed, i.e. relieves compute-utilization pressure -- the closest existing term in the declared vocabulary).

## Test plan
- [x] `node scripts/validate.mjs` failed with both issues before the data fix:
  ```
  rewrite-rules.yml rule 'prefetching': relieves 'bandwidth stalls' is not in the declared constraint vocabulary
  rewrite-rules.yml rule 'sparsification': relieves 'compute' is not in the declared constraint vocabulary
  ```
- [x] Passes cleanly after the fix (`✓ grammar.yml is valid`, 90 primitives, 51 assemblies, 0 issues).