### PR TITLE
fix(design-grammar): known_collisions notes cite wrong (row, col) coordinates

### DIFF
--- a/design-grammar/grammar.yml
+++ b/design-grammar/grammar.yml
@@ -1101,13 +1101,13 @@ assemblies:
 known_collisions:
   - sym: "Sm"
     ids: [14, 77]
-    note: "Schema (#77, row 1 col 13, K) + Sampling (#14, row 3 col 7, C)"
+    note: "Schema (#77, row 1 col 14, K) + Sampling (#14, row 3 col 8, C)"
   - sym: "En"
     ids: [36, 80]
-    note: "Entropy (#80, row 1 col 14, M) + Ensembling (#36, row 5 col 10, X)"
+    note: "Entropy (#80, row 1 col 18, M) + Ensembling (#36, row 5 col 11, X)"
   - sym: "Sp"
     ids: [10, 34]
-    note: "Sample (#10, row 3 col 3, R) + Sparsification (#34, row 5 col 5, C)"
+    note: "Sample (#10, row 3 col 3, R) + Sparsification (#34, row 5 col 6, C)"
   - sym: "Ro"
     ids: [26, 82]
-    note: "Routing (#26, row 4 col 7, C) + Routing (#82, row 4 col 13, K)"
+    note: "Routing (#26, row 4 col 8, C) + Routing (#82, row 4 col 14, K)"

--- a/design-grammar/scripts/validate.mjs
+++ b/design-grammar/scripts/validate.mjs
@@ -67,6 +67,33 @@ for (const [sym, count] of Object.entries(symCount)) {
   }
 }
 
+// known_collisions notes must actually match the primitives they describe.
+// Previously only `sym` presence was checked, so the free-text `note` field
+// (row/col call-outs) could drift from the real data with nothing to catch it.
+const byId = new Map(doc.primitives.map((e) => [e.id, e]));
+for (const c of doc.known_collisions || []) {
+  const cited = new Map();
+  const re = /#(\d+)[^)]*?row\s*(\d+)\s*col\s*(\d+)/g;
+  let m;
+  while ((m = re.exec(c.note || "")) !== null) {
+    cited.set(Number(m[1]), { layer: Number(m[2]), col: Number(m[3]) });
+  }
+  for (const id of c.ids || []) {
+    const actual = byId.get(id);
+    const claimed = cited.get(id);
+    if (!actual) {
+      issues.push(`known_collisions '${c.sym}': id ${id} does not exist`);
+    } else if (!claimed) {
+      issues.push(`known_collisions '${c.sym}': note does not cite row/col for #${id}`);
+    } else if (claimed.layer !== actual.layer || claimed.col !== actual.col) {
+      issues.push(
+        `known_collisions '${c.sym}': note claims #${id} is row ${claimed.layer} col ${claimed.col}, ` +
+        `but it is actually row ${actual.layer} col ${actual.col}`
+      );
+    }
+  }
+}
+
 // Expression resolution: every two-letter [A-Z][a-z] token in any expression must
 // resolve to a known primitive symbol.
 for (const section of doc.assemblies || []) {


### PR DESCRIPTION
## Summary
- 7 of 8 documented collision notes in `known_collisions` cited incorrect `(layer, col)` coordinates against the primitives they describe -- off by 1 or more in every case except `#10 Sample`.
- `validate.mjs`'s `known_collisions` check only verified that the colliding `sym` string was present in the list (`declared.has(sym)`); it never checked that the `ids` or descriptive `note` text actually matched the real primitive data, so this drift was permanently invisible to `make validate`.

## Fix
- Corrected all 4 notes to the actual `(layer, col)` values pulled directly from the primitives list.
- Added a validator check that parses `"row N col M"` per cited id in each note and cross-checks it against the real primitive data.

## Test plan
- [x] Fed the new regex the *original* (wrong) note text for `#77`/`#14` in isolation: confirms it parses `row 1 col 13` and `row 3 col 7`, both of which mismatch the actual `row 1 col 14` / `row 3 col 8` -- i.e. the new check would have caught this before it ever shipped.
- [x] `node scripts/validate.mjs` passes cleanly against the corrected data (`✓ grammar.yml is valid`, 90 primitives, 51 assemblies, 4 documented collisions, 0 issues).