### PR TITLE
fix(design-grammar): Fc incorrectly bundled into sharding's symbols

### DIFF
--- a/design-grammar/rewrite-rules.yml
+++ b/design-grammar/rewrite-rules.yml
@@ -41,13 +41,23 @@ rules:
 
   - key: sharding
     name: "Sharding"
-    symbols: ["Sy", "Fc"]
+    symbols: ["Sy"]
     relieves: ["capacity"]
     preserves: ["global logical state"]
     changes: "Splits parameters, optimizer state, gradients, activations, or requests across devices."
     preconditions: ["multiple devices", "communication path", "partitionable state or work"]
     tradeoffs: ["communication overhead", "synchronization complexity", "failure surface grows"]
     examples: ["ZeRO", "FSDP", "tensor parallelism", "sequence parallelism"]
+
+  - key: factorization
+    name: "Factorization"
+    symbols: ["Fc"]
+    relieves: ["capacity"]
+    preserves: ["approximate function"]
+    changes: "Approximates a large matrix as the product of smaller ones (low-rank decomposition)."
+    preconditions: ["approximately low-rank structure", "accuracy tolerance for the approximation"]
+    tradeoffs: ["approximation error", "extra matrix multiply", "rank selection tuning"]
+    examples: ["LoRA", "low-rank KV cache approximation", "SVD-compressed embeddings"]
 
   - key: pipelining
     name: "Pipelining"


### PR DESCRIPTION
## Summary
- `rewrite-rules.yml`'s `sharding` rule listed `symbols: ["Sy", "Fc"]`, but `Fc` is a distinct primitive in `grammar.yml` (`id: 31, name: "Factorization"` -- low-rank matrix decomposition), not a synonym for sharding.
- `paper.tex` also treats `Fc` as its own transformation independent of sharding (e.g. "Capacity (second pass): Fc (low-rank KV approximation...)" listed as a separate filter-path candidate alongside `Sy`).
- There was no separate `factorization` rewrite rule anywhere in the file, so `Fc`'s rewrite semantics were silently conflated with Sharding's `relieves`/`preserves`/`tradeoffs`.

## Fix
Removed `Fc` from `sharding`'s `symbols` and added a dedicated `factorization` rule, using `Fc`'s own `grammar.yml` description ("Approximating a massive matrix as the product of smaller ones (Low-Rank)") and `paper.tex`'s capacity framing.

## Test plan
- [x] Confirmed `Fc` now appears exactly once in `rewrite-rules.yml`, in its own `factorization` rule.
- [x] Parsed the file with `js-yaml` to confirm well-formed structure (14 rules total, `sharding.symbols == ["Sy"]`).
- [x] `node scripts/validate.mjs` (grammar.yml's own validator) still passes cleanly.