### PR TITLE
fix(socratiq): correct IndexedDB store name and key in getIncorrectQuestions()

### DIFF
--- a/socratiq/src_shadow/js/components/quiz/quiz-storage.js
+++ b/socratiq/src_shadow/js/components/quiz/quiz-storage.js
@@ -352,7 +352,7 @@ export async function getQuizStats() {
 export async function getIncorrectQuestions() {
     try {
         const dbManager = await initDB();
-        const incorrectQuestions = await dbManager.getByKey('ongoing-incorrect-questions');
+        const incorrectQuestions = await dbManager.getByKey('ongoingIncorrectQuestions', 'current'); // Match store name from db_configs_one.js and writer in updateIncorrectQuestions()
         
         return incorrectQuestions ? incorrectQuestions.questions : [];
     } catch (error) {


### PR DESCRIPTION
## Problem

`getIncorrectQuestions()` in `socratiq/src_shadow/js/components/quiz/quiz-storage.js` reads from an IndexedDB store that does not exist:

```js
const incorrectQuestions = await dbManager.getByKey('ongoing-incorrect-questions');
```

- The store defined in `db_configs_one.js` is `ongoingIncorrectQuestions` (camelCase). The hyphenated name appears nowhere else in the codebase, so opening a transaction on it throws `NotFoundError`.
- The call also passes no key, while the writer `updateIncorrectQuestions()` stores the record under the fixed id `'current'`. Every other `getByKey` call in the codebase passes `(storeName, key)`.

Incorrect quiz answers **are** being recorded on every quiz submission today (`saveQuizResult → updateIncorrectQuestions`), but this bug made that data unretrievable.

## Fix

One line — read from the same store and key the writer uses:

```js
const incorrectQuestions = await dbManager.getByKey('ongoingIncorrectQuestions', 'current');
```

## Notes

- This unblocks re-enabling the "study past incorrect questions" feature (`initiateStudyBtn`, currently commented out at `index.js:107` / `index.js:616`) — as written it would have thrown on first click.
- No bundle rebuild needed: since the feature is disabled, this module is tree-shaken out of `book/quarto/tools/scripts/socratiQ/bundle.js`, so built output is unchanged.