### PR TITLE
perf(book): stop unbounded full-document rescans in quiz numbering fix

### DIFF
--- a/book/quarto/assets/scripts/sidebar-auto-collapse.js
+++ b/book/quarto/assets/scripts/sidebar-auto-collapse.js
@@ -225,7 +225,6 @@ document.addEventListener('DOMContentLoaded', function() {
         if (currentUrl === linkUrl || currentPath === new URL(linkUrl).pathname) {
           link.classList.add('active');
           link.setAttribute('aria-current', 'page');
-          console.log('Setting active:', link.textContent.trim(), 'Current:', currentUrl, 'Link:', linkUrl);
         }
       }
     });
@@ -240,7 +239,10 @@ document.addEventListener('DOMContentLoaded', function() {
   // Fix quiz numbering: Remove chapter numbers from quiz callouts (HTML only)
   // Transform "Self-Check: Question 1.3" to "Self-Check: Question 3"
   function fixQuizNumbering() {
-    const quizCallouts = document.querySelectorAll('.callout-quiz-question, .callout-quiz-answer');
+    // Only visit callouts not already processed, so repeat passes are cheap
+    const quizCallouts = document.querySelectorAll(
+      '.callout-quiz-question:not([data-quiz-number-fixed]), .callout-quiz-answer:not([data-quiz-number-fixed])'
+    );
 
     quizCallouts.forEach(callout => {
       // Try multiple selectors to find the text element
@@ -256,8 +258,8 @@ document.addEventListener('DOMContentLoaded', function() {
         if (match) {
           const [, prefix, chapterNum, questionNum, suffix] = match;
           textElement.textContent = `${prefix} ${questionNum}${suffix}`;
-          console.log(`Fixed quiz numbering: "${originalText}" → "${textElement.textContent}"`);
         }
+        callout.setAttribute('data-quiz-number-fixed', 'true');
       }
     });
   }
@@ -267,9 +269,12 @@ document.addEventListener('DOMContentLoaded', function() {
     setTimeout(fixQuizNumbering, delay);
   });
 
-  // Also run on any dynamic content loads
+  // Also run on any dynamic content loads, coalescing mutation bursts
+  // (Bootstrap collapses, tooltips, math typesetting) into a single pass
+  let quizNumberingTimer = null;
   const observer = new MutationObserver(() => {
-    setTimeout(fixQuizNumbering, 100);
+    clearTimeout(quizNumberingTimer);
+    quizNumberingTimer = setTimeout(fixQuizNumbering, 100);
   });
 
   observer.observe(document.body, {


### PR DESCRIPTION
## Problem

`book/quarto/assets/scripts/sidebar-auto-collapse.js` (loaded on every book page) sets up:

```js
const observer = new MutationObserver(() => {
  setTimeout(fixQuizNumbering, 100);
});
observer.observe(document.body, { childList: true, subtree: true });
```

Every DOM mutation anywhere on the page schedules a **fresh, un-debounced** `fixQuizNumbering()` pass, and each pass runs a full-document `querySelectorAll` over all quiz callouts plus a `console.log` per renamed element. Consequences on long chapter pages:

- Mutation bursts (Bootstrap collapses, tooltips, KaTeX typesetting, SocratiQ chat streaming, lightbox) queue **dozens of overlapping full-page scans** — one timer per mutation — competing with rendering on the main thread for the life of the page.
- `fixQuizNumbering()` itself writes `textContent`, re-triggering the very observer it runs under.
- The observer never becomes cheap: every pass re-walks and re-regexes every callout, forever.
- Per-element `console.log` spam here and in `setNavbarActiveState()` on every pass.

Users feel this as slower time-to-interactive, scroll/typing jank while SocratiQ streams, and battery drain on long reading sessions.

## Fix

- **Mark processed callouts** with `data-quiz-number-fixed` and exclude them via `:not([data-quiz-number-fixed])` in the selector — repeat passes match nothing and return immediately. Callouts whose title element isn't rendered yet stay unmarked, so the existing staggered retries (100/500/1000/2000 ms) still pick them up.
- **Debounce the observer** with a single re-armed timer, coalescing each mutation burst into one pass instead of one pass per mutation. (The observer only watches `childList`, so setting the marker attribute cannot re-trigger it.)
- **Remove `console.log`** from the `fixQuizNumbering()` and `setNavbarActiveState()` hot paths.

## Behavior

No visible change: quiz titles are still renamed ("Self-Check: Question 1.3" → "Self-Check: Question 3"), same retry schedule, and dynamically injected callouts are still processed (new nodes lack the marker attribute). Only the redundant re-scanning is eliminated.

Verified with `node --check`; diff is +10/−5 lines in one file.