### PR TITLE
a11y(shared): make subscribe modal a real dialog for keyboard and screen-reader users

### DIFF
--- a/book/quarto/assets/scripts/subscribe-modal.js
+++ b/book/quarto/assets/scripts/subscribe-modal.js
@@ -28,14 +28,14 @@
   function createModalHTML() {
     return `
       <div id="subscribe-modal" class="modal-overlay" style="display: none;">
-        <div class="modal-container">
+        <div class="modal-container" role="dialog" aria-modal="true" aria-labelledby="subscribe-modal-title">
           <button class="modal-close" data-close-modal aria-label="Close">&times;</button>
           <div class="modal-content">
             <div class="modal-header">
               <div class="modal-brand-row">
                 <span class="modal-brand-item">📚 MLSysBook</span>
               </div>
-              <h2 class="modal-title">Stay in the Loop</h2>
+              <h2 class="modal-title" id="subscribe-modal-title">Stay in the Loop</h2>
               <p class="modal-subtitle">Get updates on new chapters, hands-on labs, and ML systems resources.</p>
             </div>
             <form id="subscribe-modal-form" class="subscribe-form" action="https://buttondown.email/api/emails/embed-subscribe/mlsysbook" method="post">
@@ -465,6 +465,14 @@
         color: #60a5fa;
       }
 
+      /* Respect reduced-motion preference */
+      @media (prefers-reduced-motion: reduce) {
+        .modal-overlay,
+        .modal-container {
+          animation: none;
+        }
+      }
+
       /* Responsive */
       @media (max-width: 640px) {
         .modal-content {
@@ -497,8 +505,12 @@
     const form = document.getElementById('subscribe-modal-form');
     const success = document.getElementById('modal-subscribe-success');
 
+    // Element that had focus before the modal opened, restored on close
+    let openerElement = null;
+
     // Open modal function
     window.openModal = function() {
+      openerElement = document.activeElement;
       modal.style.display = 'flex';
       document.body.style.overflow = 'hidden';
 
@@ -514,6 +526,12 @@
       modal.style.display = 'none';
       document.body.style.overflow = '';
 
+      // Return focus to the element that opened the modal
+      if (openerElement && typeof openerElement.focus === 'function') {
+        openerElement.focus();
+      }
+      openerElement = null;
+
       // Reset form after closing
       setTimeout(() => {
         form.style.display = 'flex';
@@ -521,6 +539,28 @@
         success.style.display = 'none';
       }, 300);
     };
+
+    // Trap Tab focus inside the modal while it is open
+    modal.addEventListener('keydown', (e) => {
+      if (e.key !== 'Tab') return;
+
+      const focusable = Array.from(modal.querySelectorAll(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      )).filter(el => !el.disabled && el.offsetParent !== null);
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+
+      if (e.shiftKey && (active === first || !modal.contains(active))) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && (active === last || !modal.contains(active))) {
+        e.preventDefault();
+        first.focus();
+      }
+    });
 
     // Close on overlay click
     modal.addEventListener('click', (e) => {

--- a/kits/assets/scripts/subscribe-modal.js
+++ b/kits/assets/scripts/subscribe-modal.js
@@ -28,14 +28,14 @@
   function createModalHTML() {
     return `
       <div id="subscribe-modal" class="modal-overlay" style="display: none;">
-        <div class="modal-container">
+        <div class="modal-container" role="dialog" aria-modal="true" aria-labelledby="subscribe-modal-title">
           <button class="modal-close" data-close-modal aria-label="Close">&times;</button>
           <div class="modal-content">
             <div class="modal-header">
               <div class="modal-brand-row">
                 <span class="modal-brand-item">📚 MLSysBook</span>
               </div>
-              <h2 class="modal-title">Stay in the Loop</h2>
+              <h2 class="modal-title" id="subscribe-modal-title">Stay in the Loop</h2>
               <p class="modal-subtitle">Get updates on new chapters, hands-on labs, and ML systems resources.</p>
             </div>
             <form id="subscribe-modal-form" class="subscribe-form" action="https://buttondown.email/api/emails/embed-subscribe/mlsysbook" method="post">
@@ -465,6 +465,14 @@
         color: #60a5fa;
       }
 
+      /* Respect reduced-motion preference */
+      @media (prefers-reduced-motion: reduce) {
+        .modal-overlay,
+        .modal-container {
+          animation: none;
+        }
+      }
+
       /* Responsive */
       @media (max-width: 640px) {
         .modal-content {
@@ -497,8 +505,12 @@
     const form = document.getElementById('subscribe-modal-form');
     const success = document.getElementById('modal-subscribe-success');
 
+    // Element that had focus before the modal opened, restored on close
+    let openerElement = null;
+
     // Open modal function
     window.openModal = function() {
+      openerElement = document.activeElement;
       modal.style.display = 'flex';
       document.body.style.overflow = 'hidden';
 
@@ -514,6 +526,12 @@
       modal.style.display = 'none';
       document.body.style.overflow = '';
 
+      // Return focus to the element that opened the modal
+      if (openerElement && typeof openerElement.focus === 'function') {
+        openerElement.focus();
+      }
+      openerElement = null;
+
       // Reset form after closing
       setTimeout(() => {
         form.style.display = 'flex';
@@ -521,6 +539,28 @@
         success.style.display = 'none';
       }, 300);
     };
+
+    // Trap Tab focus inside the modal while it is open
+    modal.addEventListener('keydown', (e) => {
+      if (e.key !== 'Tab') return;
+
+      const focusable = Array.from(modal.querySelectorAll(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      )).filter(el => !el.disabled && el.offsetParent !== null);
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+
+      if (e.shiftKey && (active === first || !modal.contains(active))) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && (active === last || !modal.contains(active))) {
+        e.preventDefault();
+        first.focus();
+      }
+    });
 
     // Close on overlay click
     modal.addEventListener('click', (e) => {

--- a/labs/assets/scripts/subscribe-modal.js
+++ b/labs/assets/scripts/subscribe-modal.js
@@ -28,14 +28,14 @@
   function createModalHTML() {
     return `
       <div id="subscribe-modal" class="modal-overlay" style="display: none;">
-        <div class="modal-container">
+        <div class="modal-container" role="dialog" aria-modal="true" aria-labelledby="subscribe-modal-title">
           <button class="modal-close" data-close-modal aria-label="Close">&times;</button>
           <div class="modal-content">
             <div class="modal-header">
               <div class="modal-brand-row">
                 <span class="modal-brand-item">📚 MLSysBook</span>
               </div>
-              <h2 class="modal-title">Stay in the Loop</h2>
+              <h2 class="modal-title" id="subscribe-modal-title">Stay in the Loop</h2>
               <p class="modal-subtitle">Get updates on new chapters, hands-on labs, and ML systems resources.</p>
             </div>
             <form id="subscribe-modal-form" class="subscribe-form" action="https://buttondown.email/api/emails/embed-subscribe/mlsysbook" method="post">
@@ -465,6 +465,14 @@
         color: #60a5fa;
       }
 
+      /* Respect reduced-motion preference */
+      @media (prefers-reduced-motion: reduce) {
+        .modal-overlay,
+        .modal-container {
+          animation: none;
+        }
+      }
+
       /* Responsive */
       @media (max-width: 640px) {
         .modal-content {
@@ -497,8 +505,12 @@
     const form = document.getElementById('subscribe-modal-form');
     const success = document.getElementById('modal-subscribe-success');
 
+    // Element that had focus before the modal opened, restored on close
+    let openerElement = null;
+
     // Open modal function
     window.openModal = function() {
+      openerElement = document.activeElement;
       modal.style.display = 'flex';
       document.body.style.overflow = 'hidden';
 
@@ -514,6 +526,12 @@
       modal.style.display = 'none';
       document.body.style.overflow = '';
 
+      // Return focus to the element that opened the modal
+      if (openerElement && typeof openerElement.focus === 'function') {
+        openerElement.focus();
+      }
+      openerElement = null;
+
       // Reset form after closing
       setTimeout(() => {
         form.style.display = 'flex';
@@ -521,6 +539,28 @@
         success.style.display = 'none';
       }, 300);
     };
+
+    // Trap Tab focus inside the modal while it is open
+    modal.addEventListener('keydown', (e) => {
+      if (e.key !== 'Tab') return;
+
+      const focusable = Array.from(modal.querySelectorAll(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      )).filter(el => !el.disabled && el.offsetParent !== null);
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+
+      if (e.shiftKey && (active === first || !modal.contains(active))) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && (active === last || !modal.contains(active))) {
+        e.preventDefault();
+        first.focus();
+      }
+    });
 
     // Close on overlay click
     modal.addEventListener('click', (e) => {

--- a/mlsysim/docs/scripts/subscribe-modal.js
+++ b/mlsysim/docs/scripts/subscribe-modal.js
@@ -28,14 +28,14 @@
   function createModalHTML() {
     return `
       <div id="subscribe-modal" class="modal-overlay" style="display: none;">
-        <div class="modal-container">
+        <div class="modal-container" role="dialog" aria-modal="true" aria-labelledby="subscribe-modal-title">
           <button class="modal-close" data-close-modal aria-label="Close">&times;</button>
           <div class="modal-content">
             <div class="modal-header">
               <div class="modal-brand-row">
                 <span class="modal-brand-item">📚 MLSysBook</span>
               </div>
-              <h2 class="modal-title">Stay in the Loop</h2>
+              <h2 class="modal-title" id="subscribe-modal-title">Stay in the Loop</h2>
               <p class="modal-subtitle">Get updates on new chapters, hands-on labs, and ML systems resources.</p>
             </div>
             <form id="subscribe-modal-form" class="subscribe-form" action="https://buttondown.email/api/emails/embed-subscribe/mlsysbook" method="post">
@@ -465,6 +465,14 @@
         color: #60a5fa;
       }
 
+      /* Respect reduced-motion preference */
+      @media (prefers-reduced-motion: reduce) {
+        .modal-overlay,
+        .modal-container {
+          animation: none;
+        }
+      }
+
       /* Responsive */
       @media (max-width: 640px) {
         .modal-content {
@@ -497,8 +505,12 @@
     const form = document.getElementById('subscribe-modal-form');
     const success = document.getElementById('modal-subscribe-success');
 
+    // Element that had focus before the modal opened, restored on close
+    let openerElement = null;
+
     // Open modal function
     window.openModal = function() {
+      openerElement = document.activeElement;
       modal.style.display = 'flex';
       document.body.style.overflow = 'hidden';
 
@@ -514,6 +526,12 @@
       modal.style.display = 'none';
       document.body.style.overflow = '';
 
+      // Return focus to the element that opened the modal
+      if (openerElement && typeof openerElement.focus === 'function') {
+        openerElement.focus();
+      }
+      openerElement = null;
+
       // Reset form after closing
       setTimeout(() => {
         form.style.display = 'flex';
@@ -521,6 +539,28 @@
         success.style.display = 'none';
       }, 300);
     };
+
+    // Trap Tab focus inside the modal while it is open
+    modal.addEventListener('keydown', (e) => {
+      if (e.key !== 'Tab') return;
+
+      const focusable = Array.from(modal.querySelectorAll(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      )).filter(el => !el.disabled && el.offsetParent !== null);
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+
+      if (e.shiftKey && (active === first || !modal.contains(active))) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && (active === last || !modal.contains(active))) {
+        e.preventDefault();
+        first.focus();
+      }
+    });
 
     // Close on overlay click
     modal.addEventListener('click', (e) => {

--- a/shared/scripts/subscribe-modal.js
+++ b/shared/scripts/subscribe-modal.js
@@ -28,14 +28,14 @@
   function createModalHTML() {
     return `
       <div id="subscribe-modal" class="modal-overlay" style="display: none;">
-        <div class="modal-container">
+        <div class="modal-container" role="dialog" aria-modal="true" aria-labelledby="subscribe-modal-title">
           <button class="modal-close" data-close-modal aria-label="Close">&times;</button>
           <div class="modal-content">
             <div class="modal-header">
               <div class="modal-brand-row">
                 <span class="modal-brand-item">📚 MLSysBook</span>
               </div>
-              <h2 class="modal-title">Stay in the Loop</h2>
+              <h2 class="modal-title" id="subscribe-modal-title">Stay in the Loop</h2>
               <p class="modal-subtitle">Get updates on new chapters, hands-on labs, and ML systems resources.</p>
             </div>
             <form id="subscribe-modal-form" class="subscribe-form" action="https://buttondown.email/api/emails/embed-subscribe/mlsysbook" method="post">
@@ -465,6 +465,14 @@
         color: #60a5fa;
       }
 
+      /* Respect reduced-motion preference */
+      @media (prefers-reduced-motion: reduce) {
+        .modal-overlay,
+        .modal-container {
+          animation: none;
+        }
+      }
+
       /* Responsive */
       @media (max-width: 640px) {
         .modal-content {
@@ -497,8 +505,12 @@
     const form = document.getElementById('subscribe-modal-form');
     const success = document.getElementById('modal-subscribe-success');
 
+    // Element that had focus before the modal opened, restored on close
+    let openerElement = null;
+
     // Open modal function
     window.openModal = function() {
+      openerElement = document.activeElement;
       modal.style.display = 'flex';
       document.body.style.overflow = 'hidden';
 
@@ -514,6 +526,12 @@
       modal.style.display = 'none';
       document.body.style.overflow = '';
 
+      // Return focus to the element that opened the modal
+      if (openerElement && typeof openerElement.focus === 'function') {
+        openerElement.focus();
+      }
+      openerElement = null;
+
       // Reset form after closing
       setTimeout(() => {
         form.style.display = 'flex';
@@ -521,6 +539,28 @@
         success.style.display = 'none';
       }, 300);
     };
+
+    // Trap Tab focus inside the modal while it is open
+    modal.addEventListener('keydown', (e) => {
+      if (e.key !== 'Tab') return;
+
+      const focusable = Array.from(modal.querySelectorAll(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      )).filter(el => !el.disabled && el.offsetParent !== null);
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+
+      if (e.shiftKey && (active === first || !modal.contains(active))) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && (active === last || !modal.contains(active))) {
+        e.preventDefault();
+        first.focus();
+      }
+    });
 
     // Close on overlay click
     modal.addEventListener('click', (e) => {

--- a/site/assets/scripts/subscribe-modal.js
+++ b/site/assets/scripts/subscribe-modal.js
@@ -28,14 +28,14 @@
   function createModalHTML() {
     return `
       <div id="subscribe-modal" class="modal-overlay" style="display: none;">
-        <div class="modal-container">
+        <div class="modal-container" role="dialog" aria-modal="true" aria-labelledby="subscribe-modal-title">
           <button class="modal-close" data-close-modal aria-label="Close">&times;</button>
           <div class="modal-content">
             <div class="modal-header">
               <div class="modal-brand-row">
                 <span class="modal-brand-item">📚 MLSysBook</span>
               </div>
-              <h2 class="modal-title">Stay in the Loop</h2>
+              <h2 class="modal-title" id="subscribe-modal-title">Stay in the Loop</h2>
               <p class="modal-subtitle">Get updates on new chapters, hands-on labs, and ML systems resources.</p>
             </div>
             <form id="subscribe-modal-form" class="subscribe-form" action="https://buttondown.email/api/emails/embed-subscribe/mlsysbook" method="post">
@@ -465,6 +465,14 @@
         color: #60a5fa;
       }
 
+      /* Respect reduced-motion preference */
+      @media (prefers-reduced-motion: reduce) {
+        .modal-overlay,
+        .modal-container {
+          animation: none;
+        }
+      }
+
       /* Responsive */
       @media (max-width: 640px) {
         .modal-content {
@@ -497,8 +505,12 @@
     const form = document.getElementById('subscribe-modal-form');
     const success = document.getElementById('modal-subscribe-success');
 
+    // Element that had focus before the modal opened, restored on close
+    let openerElement = null;
+
     // Open modal function
     window.openModal = function() {
+      openerElement = document.activeElement;
       modal.style.display = 'flex';
       document.body.style.overflow = 'hidden';
 
@@ -514,6 +526,12 @@
       modal.style.display = 'none';
       document.body.style.overflow = '';
 
+      // Return focus to the element that opened the modal
+      if (openerElement && typeof openerElement.focus === 'function') {
+        openerElement.focus();
+      }
+      openerElement = null;
+
       // Reset form after closing
       setTimeout(() => {
         form.style.display = 'flex';
@@ -521,6 +539,28 @@
         success.style.display = 'none';
       }, 300);
     };
+
+    // Trap Tab focus inside the modal while it is open
+    modal.addEventListener('keydown', (e) => {
+      if (e.key !== 'Tab') return;
+
+      const focusable = Array.from(modal.querySelectorAll(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      )).filter(el => !el.disabled && el.offsetParent !== null);
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+
+      if (e.shiftKey && (active === first || !modal.contains(active))) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && (active === last || !modal.contains(active))) {
+        e.preventDefault();
+        first.focus();
+      }
+    });
 
     // Close on overlay click
     modal.addEventListener('click', (e) => {


### PR DESCRIPTION
## Problem

The shared subscribe modal (`shared/scripts/subscribe-modal.js`, mirrored to the book, site, labs, kits, and mlsysim subsites) is a plain `<div>` overlay with several accessibility gaps:

- **Not announced as a dialog** — no `role="dialog"`, `aria-modal`, or accessible name. Screen-reader users get no announcement when it opens and can keep reading the page *behind* the overlay without knowing a form is blocking the view.
- **No focus trap** — a few Tab presses inside the form move focus out of the modal into the visually hidden background page; the focus outline disappears behind the overlay (WCAG 2.4.3).
- **No focus restore** — closing the modal drops keyboard users at the top of the document instead of back on the Subscribe link they activated (WCAG 4.1.2 context).
- **Motion regardless of preference** — the slide-up/scale entrance plays even with `prefers-reduced-motion: reduce` set (WCAG 2.3.3).

## Fix (canonical file only, mirrors regenerated)

- `role="dialog" aria-modal="true" aria-labelledby="subscribe-modal-title"` on `.modal-container`, id added to the existing title → announced as "Stay in the Loop, dialog".
- Tab/Shift+Tab cycle within the modal's visible, enabled controls. The focusable list is computed per keypress, so the trap also works on the post-submit success view where the form is hidden.
- `openModal()` saves `document.activeElement`; `closeModal()` refocuses it.
- `@media (prefers-reduced-motion: reduce)` disables the `fadeIn`/`slideUp` animations.

## Behavior

No visual or functional change for mouse users: same design, same animations (when motion is allowed), Escape and overlay-click still close it.

Mirrors were regenerated with `bash shared/scripts/sync-mirrors.sh` (all six copies stay byte-identical for the CI drift check). Verified with `node --check`.