### PR TITLE
fix(site): make All-Reduce Rhythm chunks animate, taps flash, and game clean up

### DIFF
--- a/site/assets/games/allreduce.mjs
+++ b/site/assets/games/allreduce.mjs
@@ -60,7 +60,9 @@ export async function mountAllreduce(canvas, opts = {}) {
     gpuContainer.position.set(x, y);
 
     const box = new P.Graphics();
-    box.roundRect(-25, -25, 50, 50, 8).fill({ color: COL.gpu });
+    // Fill white and tint down to the base color so a white tint can flash the box on tap
+    box.roundRect(-25, -25, 50, 50, 8).fill({ color: 0xffffff });
+    box.tint = COL.gpu;
     
     const label = new P.Text({
       text: (i + 1).toString(),
@@ -92,15 +94,16 @@ export async function mountAllreduce(canvas, opts = {}) {
 
     const duration = beatInterval * 0.8;
     const cancelTween = tween(
-      [chunk.position, chunk.position],
-      ["x", "y"],
+      chunk,
+      ["position.x", "position.y"],
       [startObj.x, startObj.y],
       [endObj.x, endObj.y],
       duration,
       "linear"
     );
-    
+
     setTimeout(() => {
+      cancelTween();
       chunk.destroy();
       burst(gameLayer, endObj.x, endObj.y, COL.chunk, 10, { speed: 1.5 });
     }, duration);
@@ -115,7 +118,7 @@ export async function mountAllreduce(canvas, opts = {}) {
 
     const box = gpus[idx].box;
     box.tint = 0xffffff;
-    setTimeout(() => { if (!box.destroyed) box.tint = 0xffffff; }, 100);
+    setTimeout(() => { if (!box.destroyed) box.tint = COL.gpu; }, 100);
 
     if (diff <= tolerance) {
       // Perfect
@@ -135,11 +138,12 @@ export async function mountAllreduce(canvas, opts = {}) {
     }
   }
 
-  window.addEventListener('keydown', (e) => {
+  function handleKeydown(e) {
     if (e.key >= '1' && e.key <= '4') {
       handleInput(parseInt(e.key) - 1);
     }
-  });
+  }
+  window.addEventListener('keydown', handleKeydown);
 
   // Pre-game READY overlay
   mountReadyOverlay(stage, {
@@ -168,6 +172,10 @@ export async function mountAllreduce(canvas, opts = {}) {
   return {
     id: "allreduce",
     ahaLabel: "You just experienced",
-    ahaText: "Ring All-Reduce synchronizes gradients across GPUs by passing chunks in a circle. Perfect timing (synchronous steps) ensures maximum bandwidth utilization. When GPUs fall out of sync, collisions and pipeline stalls occur, cratering your training throughput."
+    ahaText: "Ring All-Reduce synchronizes gradients across GPUs by passing chunks in a circle. Perfect timing (synchronous steps) ensures maximum bandwidth utilization. When GPUs fall out of sync, collisions and pipeline stalls occur, cratering your training throughput.",
+    destroy() {
+      window.removeEventListener('keydown', handleKeydown);
+      app.destroy(true, { children: true, texture: true });
+    }
   };
 }


### PR DESCRIPTION
## Problem

Three defects in the All-Reduce Rhythm mini-game (`site/assets/games/allreduce.mjs`):

**1. Gradient chunks never animate — the game's core visual is broken.**
`tween()` (`runtime.mjs:307`) has signature `tween(target, prop, from, to, ms, ease)`. The call passed `[chunk.position, chunk.position]` as `target` with props `["x","y"]`, so the multi-prop branch assigned `x`/`y` onto the *array*, never onto `chunk.position`. On every perfect beat a chunk spawned at the source GPU, sat frozen for the whole beat, then vanished with a burst at the destination. The ring-transfer metaphor — data traveling GPU to GPU, the point of the game — never rendered.

**2. Tap highlight is a no-op.**
The GPU box was filled with `COL.gpu` and the "flash" set `tint = 0xffffff` (the identity tint in Pixi), then "reset" it to the same `0xffffff`. Players got zero visual feedback that their tap registered.

**3. No cleanup on unmount.**
Unlike sibling games (`cluster.mjs`, `pipeline.mjs`), the module registered an **anonymous global `keydown` listener** and returned no `destroy()`. Remounting without a full page reload stacks permanent handlers bound to dead game state and leaks a WebGL context per mount.

## Fix

- `tween(chunk, ["position.x", "position.y"], ...)` — same pattern as `moe.mjs:82`. Also cancel the tween before `chunk.destroy()` so the tween's final tick can't touch a destroyed object.
- Fill the box **white** and tint it down to `COL.gpu` at rest (Pixi tints can only darken). The white tint on tap now genuinely flashes the box; the 100 ms reset restores `COL.gpu`. Resting render is pixel-identical (`0xffffff × COL.gpu = COL.gpu`).
- Named `handleKeydown` + `destroy()` in the returned object, matching the `cluster.mjs` convention: removes the listener and calls `app.destroy(true, { children: true, texture: true })`.

No scoring, timing, or gameplay logic touched. Verified with `node --check`; +16/−8 in one file.