### PR TITLE
fix(tinytorch): integration test collection failure silently treated as no-tests

### DIFF
--- a/tinytorch/tito/commands/module/workflow.py
+++ b/tinytorch/tito/commands/module/workflow.py
@@ -1037,14 +1037,28 @@ class ModuleWorkflowCommand(BaseCommand):
             # pytest itself errored (e.g. a collection-time import failure in
             # the exported package) rather than legitimately having zero
             # tests. Surface this as a failure instead of silently reporting
-            # "no integration tests for this module".
+            # "no integration tests for this module" -- except for two cases
+            # that are not real collection failures:
+            #   - exit code 5: pytest's own "no tests collected" signal
+            #   - exit code 4: a pytest.UsageError, which conftest.py raises
+            #     from _validate_package_exported() when core modules that
+            #     come *later* in the build order haven't been exported yet.
+            #     That check is unconditional (it requires every core file to
+            #     exist, not just the one under test), so it legitimately
+            #     trips for early modules during a progressive build.
             error_msg = (result.stderr or result.stdout).strip()
-            concise_error = '\n'.join(error_msg.split('\n')[:5]) if error_msg else "pytest exited with an error"
-            tests_run = [{
-                'name': 'pytest_collection',
-                'passed': False,
-                'error': concise_error,
-            }]
+            is_no_tests_collected = result.returncode == 5
+            is_progressive_export_gate = (
+                result.returncode == 4
+                and "TINYTORCH PACKAGE NOT EXPORTED" in error_msg
+            )
+            if not is_no_tests_collected and not is_progressive_export_gate:
+                concise_error = '\n'.join(error_msg.split('\n')[:5]) if error_msg else "pytest exited with an error"
+                tests_run = [{
+                    'name': 'pytest_collection',
+                    'passed': False,
+                    'error': concise_error,
+                }]
 
         if verbose:
             for test in tests_run:

--- a/tinytorch/tito/commands/module/workflow.py
+++ b/tinytorch/tito/commands/module/workflow.py
@@ -1033,6 +1033,19 @@ class ModuleWorkflowCommand(BaseCommand):
         # Parse pytest output
         tests_run = self._parse_pytest_output(result.stdout, result.stderr)
 
+        if not tests_run and result.returncode != 0:
+            # pytest itself errored (e.g. a collection-time import failure in
+            # the exported package) rather than legitimately having zero
+            # tests. Surface this as a failure instead of silently reporting
+            # "no integration tests for this module".
+            error_msg = (result.stderr or result.stdout).strip()
+            concise_error = '\n'.join(error_msg.split('\n')[:5]) if error_msg else "pytest exited with an error"
+            tests_run = [{
+                'name': 'pytest_collection',
+                'passed': False,
+                'error': concise_error,
+            }]
+
         if verbose:
             for test in tests_run:
                 icon = "✅" if test['passed'] else "❌"


### PR DESCRIPTION
## Summary
- `_run_integration_tests()` captures `result.returncode` from the pytest subprocess but no caller (`complete_module`, `_complete_module_quiet`, `run_module_tests`) ever reads it -- only `'passed'`/`'failed'` are checked.
- If pytest fails during **collection** (e.g. an import-time error in the exported package -- distinct from the notebook-syntax check, which only `compile()`s notebook cells, not the exported package), it exits nonzero with no `PASSED`/`FAILED` lines to parse. `_parse_pytest_output` returns an empty list, so the result comes back as `passed=0, failed=0`.
- Every caller's `if integration_result['failed'] > 0` check is then `False`, so `tito module complete` prints `"No integration tests for this module"` and marks the module complete despite the exported package being unimportable/broken.

## Fix
Treat "zero parsed tests + nonzero pytest exit code" as a collection failure rather than "no tests exist", surfacing it through the same tests-list/error-field shape `_parse_test_output` already uses for its own unit-test fallback case. The legitimate "no test file for this module" short-circuit (returns before pytest even runs) and the "pytest ran fine but collected zero tests" case (`returncode == 0`) are unaffected.

## Test plan
- [x] Fed `_parse_pytest_output` a real pytest collection-error transcript (`ImportError` during test collection): confirmed it returns zero parsed tests, matching the bug's premise.
- [x] Confirmed the new guard turns that into `failed=1` instead of the old `passed=0/failed=0`, which now correctly trips the existing `if integration_result['failed'] > 0` branch in every caller.
- [x] `python -m py_compile` passes on the edited file.