### PR TITLE
fix(tinytorch): UnboundLocalError when reading an HTTP error body fails

### DIFF
--- a/tinytorch/tito/core/submission.py
+++ b/tinytorch/tito/core/submission.py
@@ -260,12 +260,14 @@ class SubmissionHandler:
                 return SyncResult(ok=False, error="unauthorized after refresh")
             else:
                 self.console.print(f"❌ [red]Upload failed (HTTP {e.code}): {e.reason}[/red]")
+                error_body = ""
                 try: # Attempt to read error body if available
                     error_body = e.read().decode('utf-8')
                     error_json = json.loads(error_body)
                     self.console.print(f"   [dim red]Error details: {error_json.get('error', 'No message provided.')}[/dim red]")
                 except (json.JSONDecodeError, Exception):
-                    self.console.print(f"   [dim red]Error details: {error_body[:200]}...[/dim red]")
+                    if error_body:
+                        self.console.print(f"   [dim red]Error details: {error_body[:200]}...[/dim red]")
             return SyncResult(ok=False, error=f"HTTP {e.code}: {e.reason}")
         except urllib.error.URLError as e:
             self.console.print(f"❌ [red]Network error:[/red] Could not connect to the server.")


### PR DESCRIPTION
## Summary
- In the HTTP-error handler, `error_body` was only assigned inside the `try` block (`e.read().decode('utf-8')`). If that read/decode itself raised (network hiccup mid-read, or a non-UTF-8 error body from the server), the broad `except (json.JSONDecodeError, Exception)` still ran and referenced `error_body` unconditionally, raising `UnboundLocalError` -- a confusing crash in the middle of `tito module complete`'s auto-sync step, instead of the clean "Upload failed" message this code is trying to produce.

## Fix
Initialize `error_body = ""` before the `try`, and only print it in the `except` block when it's non-empty, so a read/decode failure degrades to "nothing to print" instead of crashing.

## Test plan
- [x] Simulated both scenarios in isolation: (1) the read/decode call raising before `error_body` is ever set -- old logic crashes with `UnboundLocalError`, new logic handles it silently; (2) read succeeding but `json.loads` failing (the normal case this except block exists for) -- both old and new logic correctly print the error body.
- [x] `python -m py_compile` passes on the edited file.