### PR TITLE
fix(tinytorch): cached generation step excludes current token from self-attention

### DIFF
--- a/tinytorch/src/18_memoization/18_memoization.py
+++ b/tinytorch/src/18_memoization/18_memoization.py
@@ -937,7 +937,13 @@ def _cached_generation_step(x, attention, cache_obj, layer_idx):
     cache_obj.update(layer_idx, K_heads, V_heads)
 
     # Step 4: Retrieve ALL cached K, V (includes history + new token)
-    K_all, V_all = cache_obj.get(layer_idx)
+    # cache_obj.get() only returns tokens already made visible by advance()
+    # (by design -- see KVCache.get()), which does NOT yet include the token
+    # just written by update() above. Append this step's own K/V, which we
+    # already have in hand, so the new token attends to itself too.
+    K_history, V_history = cache_obj.get(layer_idx)
+    K_all = Tensor(np.concatenate([K_history.data, K_heads.data], axis=2))
+    V_all = Tensor(np.concatenate([V_history.data, V_heads.data], axis=2))
 
     # Step 5: Compute attention using new Q with all cached K, V
     # Using .data (numpy) for inference-only operation (no gradients needed)


### PR DESCRIPTION
## Summary
- `_cached_generation_step()` writes the new token's K/V into the cache via `update()`, then calls `cache_obj.get()` and uses its result directly as `K_all`/`V_all` for the attention computation.
- `KVCache.get()` is correctly designed and tested (`test_unit_kvcache`, which explicitly asserts "Before advance, get() should return empty") to return only tokens already made visible by `advance()` -- exactly **not** the token just written by `update()`, since `advance()` is meant to run once per token after all layers finish.
- So the new token's own K/V was never included in its own attention computation. Worse: on the very first generation step (cache empty, nothing advanced yet), `cache.get()` returns a zero-length sequence, crashing the attention matmul with `ValueError: zero-size array to reduction operation maximum which has no identity` -- cached generation was broken from the first token onward, not just subtly wrong.

## Fix
Concatenate the current step's own `K_heads`/`V_heads` (already computed earlier in the same function, no extra work needed) onto `cache.get()`'s history, instead of using the cache's history alone. `KVCache` itself is untouched -- it already works exactly as designed and tested.

## Test plan
- [x] Built a stub attention module (identity projections) against the real `KVCache` class.
- [x] Reproduced the crash with the old logic on the first token: `cache.get()` returns shape `(1,1,0,4)`, and the subsequent softmax/matmul crashes with `ValueError: zero-size array to reduction operation maximum which has no identity`.
- [x] Confirmed the fixed function produces the correct self-attention output (`[1,0,0,0]`, the token attending fully to itself, the only token present) instead of crashing.
- [x] Confirmed history accumulates correctly across subsequent tokens after `advance()`.
- [x] `python -m py_compile` passes on the edited file.