### PR TITLE
fix(tinytorch): unguarded accuracy_retention division crashes on zero baseline

### DIFF
--- a/tinytorch/src/19_benchmarking/19_benchmarking.py
+++ b/tinytorch/src/19_benchmarking/19_benchmarking.py
@@ -3321,7 +3321,10 @@ def _calculate_improvements(base_metrics: Dict[str, float], opt_metrics: Dict[st
 
     if 'accuracy' in base_metrics and 'accuracy' in opt_metrics:
         # Accuracy retention (higher is better)
-        improvements['accuracy_retention'] = opt_metrics['accuracy'] / base_metrics['accuracy']
+        if base_metrics['accuracy'] > 0:
+            improvements['accuracy_retention'] = opt_metrics['accuracy'] / base_metrics['accuracy']
+        else:
+            improvements['accuracy_retention'] = 1.0
 
     return improvements
     ### END SOLUTION


### PR DESCRIPTION
## Summary
- `_calculate_improvements()` guards the latency/memory/energy division against `opt_metrics[metric] <= 0` with a documented "fallback to 1.0" (matching the function's own docstring: "Handle division by zero with fallback to 1.0"), but `accuracy_retention = opt_metrics['accuracy'] / base_metrics['accuracy']` had no such guard on the denominator.
- A baseline model with `0.0` accuracy (a broken/failing baseline -- exactly the kind of input a benchmarking suite should handle gracefully) raises `ZeroDivisionError` and crashes the whole comparison, while the sibling metrics computed two lines above degrade gracefully.

## Fix
Added the same guard pattern already used for the other three metrics.

## Test plan
- [x] Confirmed the old code raises `ZeroDivisionError` for `base_metrics={'accuracy': 0.0}`.
- [x] Confirmed the fixed code returns `accuracy_retention=1.0` instead for that case.
- [x] Confirmed the normal (non-zero) case is unaffected: `base={'accuracy': 0.5}, opt={'accuracy': 0.6}` still returns `accuracy_retention=1.2`.
- [x] `python -m py_compile` passes on the edited file.