### PR TITLE
fix(tinytorch): capstone latency divisions crash on coarse timer resolution

### DIFF
--- a/tinytorch/src/20_capstone/20_capstone.py
+++ b/tinytorch/src/20_capstone/20_capstone.py
@@ -587,7 +587,11 @@ class BenchmarkReport:
             'accuracy': float(accuracy),
             'latency_ms_mean': float(avg_latency),
             'latency_ms_std': float(std_latency),
-            'throughput_samples_per_sec': float(1000 / avg_latency)
+            # time.time()'s resolution is coarse enough (~15.6ms on Windows)
+            # that a fast forward pass can measure exactly 0.0 elapsed time;
+            # floor the denominator so throughput stays a large-but-finite
+            # positive number instead of raising ZeroDivisionError.
+            'throughput_samples_per_sec': float(1000 / max(avg_latency, 1e-6))
         }
 
         print(f"\n📊 Benchmark Results for {self.model_name}:")
@@ -790,7 +794,9 @@ def generate_submission(
         optimized_size = optimized_report.metrics['model_size_mb']
 
         submission['improvements'] = {
-            'speedup': float(baseline_latency / optimized_latency),
+            # See the matching guard in benchmark_model: time.time()'s coarse
+            # resolution can measure a fast model's latency as exactly 0.0.
+            'speedup': float(baseline_latency / max(optimized_latency, 1e-6)),
             'compression_ratio': float(baseline_size / optimized_size),
             'accuracy_delta': float(
                 optimized_report.metrics['accuracy'] - baseline_report.metrics['accuracy']


### PR DESCRIPTION
## Summary
- `benchmark_model()`'s `throughput_samples_per_sec` (`float(1000 / avg_latency)`) and `generate_submission()`'s `speedup` (`float(baseline_latency / optimized_latency)`) both divide by a latency measured with `time.time()` around a single tiny forward pass, with no zero-guard.
- `time.time()` has coarse resolution on Windows (commonly ~15.6ms). For a small model, a fast forward pass can legitimately measure `0.0` elapsed time across all runs, making `avg_latency` (and therefore `optimized_latency` downstream in a submission comparison) exactly `0.0` and raising `ZeroDivisionError`.

## Fix
An existing test asserts `throughput_samples_per_sec > 0`, and another asserts `speedup > 0`, so the fix floors each denominator at a small epsilon (`1e-6`) rather than returning `0.0` or `None` -- both of which would fail those assertions and would also misrepresent an immeasurably-fast result as zero throughput.

## Test plan
- [x] Reproduced `ZeroDivisionError` for both `avg_latency=0.0` and `optimized_latency=0.0` with the old expressions.
- [x] Confirmed the floored versions return large-but-finite positive numbers instead (no crash).
- [x] Confirmed normal (non-zero) latency values are unaffected (e.g. `avg_latency=2.0ms -> 500.0` samples/sec, unchanged from before).
- [x] `python -m py_compile` passes on the edited file.