### PR TITLE
chore: clean up stale merged branches, add auto-cleanup workflow

### DIFF
--- a/.github/workflows/infra-cleanup-stale-branches.yml
+++ b/.github/workflows/infra-cleanup-stale-branches.yml
@@ -1,0 +1,90 @@
+name: '🔧 Infra · 🧹 Cleanup Stale Branches'
+
+# =============================================================================
+# 🧹 Cleanup Stale Branches — Delete already-merged branches to keep the repo tidy
+# =============================================================================
+#
+# Finds branches that are fully merged into dev and whose last commit is older
+# than a configurable threshold (default 14 days), then deletes them. Deleting
+# a merged branch never loses history since every commit already lives on dev.
+#
+# Flow:
+#   1. FETCH    — Fetch all remote branches with full history
+#   2. FILTER   — Keep branches merged into dev, older than threshold, not protected
+#   3. DELETE   — Remove stale branches (or dry-run preview)
+#
+# Triggers:
+#   - schedule: Weekly (Monday 4am UTC)
+#   - workflow_dispatch: Manual with days threshold and dry_run toggle
+#
+# Secrets:    GITHUB_TOKEN (automatic)
+#
+# =============================================================================
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+on:
+  schedule:
+    - cron: '0 4 * * 1'  # Weekly cleanup (Monday at 4am UTC)
+  workflow_dispatch:
+    inputs:
+      days:
+        description: 'Delete branches merged and inactive for this many days'
+        required: false
+        default: '14'
+        type: string
+      dry_run:
+        description: 'Show what would be deleted without actually deleting'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  cleanup:
+    name: '🔧 Infra · 🧹 Cleanup Stale Branches'
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'harvard-edge'
+
+    steps:
+      - name: '📥 Checkout repository'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: '🌿 Find and delete merged branches'
+        env:
+          DAYS_TO_KEEP: ${{ github.event.inputs.days || '14' }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+          PROTECTED_BRANCHES: 'main dev gh-pages'
+        run: |
+          git fetch origin
+          echo "🧹 Looking for branches merged into dev, inactive for ${DAYS_TO_KEEP}+ days..."
+
+          cutoff=$(date -d "-${DAYS_TO_KEEP} days" +%s)
+
+          git for-each-ref --format='%(refname:short) %(committerdate:unix)' refs/remotes/origin | while read -r ref committed; do
+            branch="${ref#origin/}"
+            [ "$branch" = "HEAD" ] && continue
+
+            skip=false
+            for protected in $PROTECTED_BRANCHES; do
+              [ "$branch" = "$protected" ] && skip=true
+            done
+            [ "$skip" = "true" ] && continue
+
+            if git merge-base --is-ancestor "origin/$branch" origin/dev 2>/dev/null; then
+              if [ "$committed" -lt "$cutoff" ]; then
+                if [ "$DRY_RUN" = "true" ]; then
+                  echo "  🔍 Would delete: $branch (merged, last commit $(date -d @"$committed" '+%Y-%m-%d'))"
+                else
+                  echo "  🗑️  Deleting: $branch"
+                  git push origin --delete "$branch" || echo "    ❌ Failed to delete $branch"
+                fi
+              fi
+            fi
+          done


### PR DESCRIPTION
## Problem
Merged branches never get cleaned up, so the repo has accumulated a pile of dead branches with no way forward.

## Fix
Adds `.github/workflows/infra-cleanup-stale-branches.yml`: weekly, deletes any branch that's fully merged into `dev` and inactive 14+ days. Skips `main`, `dev`, `gh-pages`. Supports `workflow_dispatch` with a `dry_run` toggle for manual testing.

Only ever deletes branches whose commits are already an ancestor of `dev`, so it can't lose work.

## Also included
30 branches already merged and safe to delete right now:

```
chore/precommit-cleanup, chore/staffml-ci-path, cleanup/book-validate-paths,
feat/container-preflight-urls, fix/badge-fixes, fix/callout-flow,
fix/staffml-reusable-concurrency, fix/staffml-trigger-on-workflow-edits, fmt-fix,
kai/clarify-community-map-totals, vol1/ch1-pass4, vol1/ch10-pass3, vol1/ch11-pass3,
vol1/ch12-pass3, vol1/ch13-pass3, vol1/ch14-pass3, vol1/ch2-final, vol1/ch2-pass3,
vol1/ch3-final, vol1/ch4-final, vol1/ch5-final, vol1/ch5-pass2, vol1/ch5-pass4,
vol1/ch6-pass4, vol1/ch7-pass3, vol1/ch8-final, vol1/ch8-pass3, vol1/ch9-final,
vol1/ch9-pass3, vol1/frontmater-final, vol1/frontmatter
```

@profvjreddi could you delete these (or grant access) when you get a chance?

## Test plan
- [ ] `workflow_dispatch` with `dry_run: true`, confirm candidate list matches above
- [ ] Run for real, confirm branches removed
- [ ] Confirm `main`/`dev`/`gh-pages` and open-PR branches untouched