### PR TITLE
docs(instructors): fix broken lab links

### DIFF
--- a/instructors/course-map.qmd
+++ b/instructors/course-map.qmd
@@ -32,22 +32,22 @@ The **Theory → Build → Simulation → Reality** loop is the core pedagogical
 
 | Week | Part | Read | Build (TinyTorch) | Explore (Lab) |
 |:---|:---|:---|:---|:---|
-| 1 | I | [Introduction](https://mlsysbook.ai/vol1/introduction/introduction.html) | [Module 01: Tensor](https://mlsysbook.ai/tinytorch/modules/01_tensor.html) | [Lab 00](https://mlsysbook.ai/labs/vol1/lab_00_introduction.html) |
-| 2 | I | [ML Systems](https://mlsysbook.ai/vol1/ml_systems/ml_systems.html) | Module 01 (cont.) | [Lab 01](https://mlsysbook.ai/labs/vol1/lab_01_ml_intro.html) |
-| 3 | I | [ML Workflow](https://mlsysbook.ai/vol1/ml_workflow/ml_workflow.html) | [Module 02: Activations](https://mlsysbook.ai/tinytorch/modules/02_activations.html) | [Lab 02](https://mlsysbook.ai/labs/vol1/lab_02_ml_systems.html) |
-| 4 | I | [Data Engineering](https://mlsysbook.ai/vol1/data_engineering/data_engineering.html) | Module 02 (cont.) | [Lab 03](https://mlsysbook.ai/labs/vol1/lab_03_ml_workflow.html) |
-| 5 | II | [Neural Computation](https://mlsysbook.ai/vol1/nn_computation/nn_computation.html) | [Module 03: Layers](https://mlsysbook.ai/tinytorch/modules/03_layers.html) | [Lab 04](https://mlsysbook.ai/labs/vol1/lab_04_data_engr.html) |
-| 6 | II | [NN Architectures](https://mlsysbook.ai/vol1/nn_architectures/nn_architectures.html) | [Module 04: Losses](https://mlsysbook.ai/tinytorch/modules/04_losses.html) | [Lab 05](https://mlsysbook.ai/labs/vol1/lab_05_nn_compute.html) |
-| 7 | II | [ML Frameworks](https://mlsysbook.ai/vol1/frameworks/frameworks.html) | [Module 05: DataLoader](https://mlsysbook.ai/tinytorch/modules/05_dataloader.html) | [Lab 06](https://mlsysbook.ai/labs/vol1/lab_06_nn_arch.html) |
-| 8 | II | [Training](https://mlsysbook.ai/vol1/training/training.html) | [Module 06: Autograd](https://mlsysbook.ai/tinytorch/modules/06_autograd.html) | [Lab 07](https://mlsysbook.ai/labs/vol1/lab_07_ml_frameworks.html) |
-| 9 | III | [Data Selection](https://mlsysbook.ai/vol1/data_selection/data_selection.html) | [Module 07: Optimizers](https://mlsysbook.ai/tinytorch/modules/07_optimizers.html) | [Lab 08](https://mlsysbook.ai/labs/vol1/lab_08_model_train.html) |
-| 10 | III | [Model Compression](https://mlsysbook.ai/vol1/optimizations/model_compression.html) | [Module 08: Training](https://mlsysbook.ai/tinytorch/modules/08_training.html) | [Lab 09](https://mlsysbook.ai/labs/vol1/lab_09_data_selection.html) |
-| 11 | III | [HW Acceleration](https://mlsysbook.ai/vol1/hw_acceleration/hw_acceleration.html) | Module 08 (cont.) | [Lab 10](https://mlsysbook.ai/labs/vol1/lab_10_model_compress.html) |
-| 12 | III | [Benchmarking](https://mlsysbook.ai/vol1/benchmarking/benchmarking.html) | *Catch-up* | [Lab 11](https://mlsysbook.ai/labs/vol1/lab_11_hw_accel.html) |
-| 13 | IV | [Model Serving](https://mlsysbook.ai/vol1/model_serving/model_serving.html) | *Capstone prep* | [Lab 12](https://mlsysbook.ai/labs/vol1/lab_12_perf_bench.html) |
-| 14 | IV | [ML Operations](https://mlsysbook.ai/vol1/ml_ops/ml_ops.html) | *Capstone prep* | [Lab 13](https://mlsysbook.ai/labs/vol1/lab_13_model_serving.html) |
-| 15 | IV | [Responsible Engr.](https://mlsysbook.ai/vol1/responsible_engr/responsible_engr.html) | *Capstone work* | [Lab 14](https://mlsysbook.ai/labs/vol1/lab_14_ml_ops.html) |
-| 16 | IV | [Conclusion](https://mlsysbook.ai/vol1/conclusion/conclusion.html) | *AI Olympics* | [Lab 15](https://mlsysbook.ai/labs/vol1/lab_15_responsible_engr.html) |
+| 1 | I | [Introduction](https://mlsysbook.ai/vol1/introduction/introduction.html) | [Module 01: Tensor](https://mlsysbook.ai/tinytorch/modules/01_tensor.html) | [Lab 00](https://mlsysbook.ai/labs/vol1/lab_00_introduction/) |
+| 2 | I | [ML Systems](https://mlsysbook.ai/vol1/ml_systems/ml_systems.html) | Module 01 (cont.) | [Lab 01](https://mlsysbook.ai/labs/vol1/lab_01_ml_intro/) |
+| 3 | I | [ML Workflow](https://mlsysbook.ai/vol1/ml_workflow/ml_workflow.html) | [Module 02: Activations](https://mlsysbook.ai/tinytorch/modules/02_activations.html) | [Lab 02](https://mlsysbook.ai/labs/vol1/lab_02_ml_systems/) |
+| 4 | I | [Data Engineering](https://mlsysbook.ai/vol1/data_engineering/data_engineering.html) | Module 02 (cont.) | [Lab 03](https://mlsysbook.ai/labs/vol1/lab_03_ml_workflow/) |
+| 5 | II | [Neural Computation](https://mlsysbook.ai/vol1/nn_computation/nn_computation.html) | [Module 03: Layers](https://mlsysbook.ai/tinytorch/modules/03_layers.html) | [Lab 04](https://mlsysbook.ai/labs/vol1/lab_04_data_engr/) |
+| 6 | II | [NN Architectures](https://mlsysbook.ai/vol1/nn_architectures/nn_architectures.html) | [Module 04: Losses](https://mlsysbook.ai/tinytorch/modules/04_losses.html) | [Lab 05](https://mlsysbook.ai/labs/vol1/lab_05_nn_compute/) |
+| 7 | II | [ML Frameworks](https://mlsysbook.ai/vol1/frameworks/frameworks.html) | [Module 05: DataLoader](https://mlsysbook.ai/tinytorch/modules/05_dataloader.html) | [Lab 06](https://mlsysbook.ai/labs/vol1/lab_06_nn_arch/) |
+| 8 | II | [Training](https://mlsysbook.ai/vol1/training/training.html) | [Module 06: Autograd](https://mlsysbook.ai/tinytorch/modules/06_autograd.html) | [Lab 07](https://mlsysbook.ai/labs/vol1/lab_07_ml_frameworks/) |
+| 9 | III | [Data Selection](https://mlsysbook.ai/vol1/data_selection/data_selection.html) | [Module 07: Optimizers](https://mlsysbook.ai/tinytorch/modules/07_optimizers.html) | [Lab 08](https://mlsysbook.ai/labs/vol1/lab_08_model_train/) |
+| 10 | III | [Model Compression](https://mlsysbook.ai/vol1/optimizations/model_compression.html) | [Module 08: Training](https://mlsysbook.ai/tinytorch/modules/08_training.html) | [Lab 09](https://mlsysbook.ai/labs/vol1/lab_09_data_selection/) |
+| 11 | III | [HW Acceleration](https://mlsysbook.ai/vol1/hw_acceleration/hw_acceleration.html) | Module 08 (cont.) | [Lab 10](https://mlsysbook.ai/labs/vol1/lab_10_model_compress/) |
+| 12 | III | [Benchmarking](https://mlsysbook.ai/vol1/benchmarking/benchmarking.html) | *Catch-up* | [Lab 11](https://mlsysbook.ai/labs/vol1/lab_11_hw_accel/) |
+| 13 | IV | [Model Serving](https://mlsysbook.ai/vol1/model_serving/model_serving.html) | *Capstone prep* | [Lab 12](https://mlsysbook.ai/labs/vol1/lab_12_perf_bench/) |
+| 14 | IV | [ML Operations](https://mlsysbook.ai/vol1/ml_ops/ml_ops.html) | *Capstone prep* | [Lab 13](https://mlsysbook.ai/labs/vol1/lab_13_model_serving/) |
+| 15 | IV | [Responsible Engr.](https://mlsysbook.ai/vol1/responsible_engr/responsible_engr.html) | *Capstone work* | [Lab 14](https://mlsysbook.ai/labs/vol1/lab_14_ml_ops/) |
+| 16 | IV | [Conclusion](https://mlsysbook.ai/vol1/conclusion/conclusion.html) | *AI Olympics* | [Lab 15](https://mlsysbook.ai/labs/vol1/lab_15_responsible_engr/) |
 
 ---
 

--- a/instructors/foundations-syllabus.qmd
+++ b/instructors/foundations-syllabus.qmd
@@ -36,7 +36,7 @@ Each chapter has a companion Beamer slide deck with speaker notes, timing guidan
 | Component | Assignment |
 |:---|:---|
 | **Read** | [Introduction](https://mlsysbook.ai/vol1/introduction/introduction.html) |
-| **Lab** | [Lab 00](https://mlsysbook.ai/labs/vol1/lab_00_introduction.html): The Architect's Portal (orientation) |
+| **Lab** | [Lab 00](https://mlsysbook.ai/labs/vol1/lab_00_introduction/): The Architect's Portal (orientation) |
 | **Build** | [TinyTorch Module 01: Tensor](https://mlsysbook.ai/tinytorch/modules/01_tensor.html) |
 | **Due** | Lab 00 Decision Log |
 
@@ -52,7 +52,7 @@ Have students predict: "A GPU is how many times faster than a CPU for a $1024{\t
 | Component | Assignment |
 |:---|:---|
 | **Read** | [ML Systems](https://mlsysbook.ai/vol1/ml_systems/ml_systems.html) |
-| **Lab** | [Lab 01](https://mlsysbook.ai/labs/vol1/lab_01_ml_intro.html): The Magnitude Gap |
+| **Lab** | [Lab 01](https://mlsysbook.ai/labs/vol1/lab_01_ml_intro/): The Magnitude Gap |
 | **Build** | [TinyTorch Module 01](https://mlsysbook.ai/tinytorch/modules/01_tensor.html): Tensor (continued) |
 | **Due** | Module 01 notebook + Lab 01 Decision Log |
 
@@ -63,7 +63,7 @@ Have students predict: "A GPU is how many times faster than a CPU for a $1024{\t
 | Component | Assignment |
 |:---|:---|
 | **Read** | [ML Workflow](https://mlsysbook.ai/vol1/ml_workflow/ml_workflow.html) |
-| **Lab** | [Lab 02](https://mlsysbook.ai/labs/vol1/lab_02_ml_systems.html): The Workflow Pipeline |
+| **Lab** | [Lab 02](https://mlsysbook.ai/labs/vol1/lab_02_ml_systems/): The Workflow Pipeline |
 | **Build** | [TinyTorch Module 02: Activations](https://mlsysbook.ai/tinytorch/modules/02_activations.html) |
 | **Due** | Lab 02 Decision Log |
 
@@ -74,7 +74,7 @@ Have students predict: "A GPU is how many times faster than a CPU for a $1024{\t
 | Component | Assignment |
 |:---|:---|
 | **Read** | [Data Engineering](https://mlsysbook.ai/vol1/data_engineering/data_engineering.html) |
-| **Lab** | [Lab 03](https://mlsysbook.ai/labs/vol1/lab_03_ml_workflow.html): The Data Pipeline |
+| **Lab** | [Lab 03](https://mlsysbook.ai/labs/vol1/lab_03_ml_workflow/): The Data Pipeline |
 | **Build** | [TinyTorch Module 02](https://mlsysbook.ai/tinytorch/modules/02_activations.html): Activations (continued) |
 | **Due** | Module 02 notebook + Lab 03 Decision Log |
 
@@ -91,7 +91,7 @@ Have students predict: "A GPU is how many times faster than a CPU for a $1024{\t
 | Component | Assignment |
 |:---|:---|
 | **Read** | [Neural Computation](https://mlsysbook.ai/vol1/nn_computation/nn_computation.html) |
-| **Lab** | [Lab 04](https://mlsysbook.ai/labs/vol1/lab_04_data_engr.html): The Computation Graph |
+| **Lab** | [Lab 04](https://mlsysbook.ai/labs/vol1/lab_04_data_engr/): The Computation Graph |
 | **Build** | [TinyTorch Module 03: Layers](https://mlsysbook.ai/tinytorch/modules/03_layers.html) |
 | **Due** | Lab 04 Decision Log |
 
@@ -102,7 +102,7 @@ Have students predict: "A GPU is how many times faster than a CPU for a $1024{\t
 | Component | Assignment |
 |:---|:---|
 | **Read** | [NN Architectures](https://mlsysbook.ai/vol1/nn_architectures/nn_architectures.html) |
-| **Lab** | [Lab 05](https://mlsysbook.ai/labs/vol1/lab_05_nn_compute.html): Architecture Tradeoffs |
+| **Lab** | [Lab 05](https://mlsysbook.ai/labs/vol1/lab_05_nn_compute/): Architecture Tradeoffs |
 | **Build** | [TinyTorch Module 04: Losses](https://mlsysbook.ai/tinytorch/modules/04_losses.html) |
 | **Due** | Module 03 notebook + Lab 05 Decision Log |
 
@@ -113,7 +113,7 @@ Have students predict: "A GPU is how many times faster than a CPU for a $1024{\t
 | Component | Assignment |
 |:---|:---|
 | **Read** | [ML Frameworks](https://mlsysbook.ai/vol1/frameworks/frameworks.html) |
-| **Lab** | [Lab 06](https://mlsysbook.ai/labs/vol1/lab_06_nn_arch.html): The Dispatch Tax |
+| **Lab** | [Lab 06](https://mlsysbook.ai/labs/vol1/lab_06_nn_arch/): The Dispatch Tax |
 | **Build** | [TinyTorch Module 05: DataLoader](https://mlsysbook.ai/tinytorch/modules/05_dataloader.html) |
 | **Due** | Module 04 notebook + Lab 06 Decision Log |
 
@@ -129,7 +129,7 @@ This is the "aha" week. Students have been building TinyTorch piece by piece —
 | Component | Assignment |
 |:---|:---|
 | **Read** | [Training](https://mlsysbook.ai/vol1/training/training.html) |
-| **Lab** | [Lab 07](https://mlsysbook.ai/labs/vol1/lab_07_ml_frameworks.html): The Training Loop |
+| **Lab** | [Lab 07](https://mlsysbook.ai/labs/vol1/lab_07_ml_frameworks/): The Training Loop |
 | **Build** | [TinyTorch Module 06: Autograd](https://mlsysbook.ai/tinytorch/modules/06_autograd.html) |
 | **Due** | Module 05 notebook + Lab 07 Decision Log |
 
@@ -151,7 +151,7 @@ By Week 8, students should have a working TinyTorch that can: create tensors, ap
 | Component | Assignment |
 |:---|:---|
 | **Read** | [Data Selection](https://mlsysbook.ai/vol1/data_selection/data_selection.html) |
-| **Lab** | [Lab 08](https://mlsysbook.ai/labs/vol1/lab_08_model_train.html): Data Quality |
+| **Lab** | [Lab 08](https://mlsysbook.ai/labs/vol1/lab_08_model_train/): Data Quality |
 | **Build** | [TinyTorch Module 07: Optimizers](https://mlsysbook.ai/tinytorch/modules/07_optimizers.html) |
 | **Due** | Module 06 notebook + Lab 08 Decision Log |
 
@@ -162,7 +162,7 @@ By Week 8, students should have a working TinyTorch that can: create tensors, ap
 | Component | Assignment |
 |:---|:---|
 | **Read** | [Model Compression](https://mlsysbook.ai/vol1/optimizations/model_compression.html) |
-| **Lab** | [Lab 09](https://mlsysbook.ai/labs/vol1/lab_09_data_selection.html): The Data Selection Paradox |
+| **Lab** | [Lab 09](https://mlsysbook.ai/labs/vol1/lab_09_data_selection/): The Data Selection Paradox |
 | **Build** | [TinyTorch Module 08: Training](https://mlsysbook.ai/tinytorch/modules/08_training.html) |
 | **Due** | Module 07 notebook + Lab 09 Decision Log |
 
@@ -178,7 +178,7 @@ Lab 09 is where students viscerally experience the accuracy-efficiency tradeoff.
 | Component | Assignment |
 |:---|:---|
 | **Read** | [Hardware Acceleration](https://mlsysbook.ai/vol1/hw_acceleration/hw_acceleration.html) |
-| **Lab** | [Lab 10](https://mlsysbook.ai/labs/vol1/lab_10_model_compress.html): The Compression Paradox |
+| **Lab** | [Lab 10](https://mlsysbook.ai/labs/vol1/lab_10_model_compress/): The Compression Paradox |
 | **Build** | TinyTorch Module 08: Training (continued) |
 | **Due** | Module 08 notebook + Lab 10 Decision Log |
 
@@ -189,7 +189,7 @@ Lab 09 is where students viscerally experience the accuracy-efficiency tradeoff.
 | Component | Assignment |
 |:---|:---|
 | **Read** | [Benchmarking](https://mlsysbook.ai/vol1/benchmarking/benchmarking.html) |
-| **Lab** | [Lab 11](https://mlsysbook.ai/labs/vol1/lab_11_hw_accel.html): The Hardware Roofline |
+| **Lab** | [Lab 11](https://mlsysbook.ai/labs/vol1/lab_11_hw_accel/): The Hardware Roofline |
 | **Build** | *No new module — catch-up week* |
 | **Due** | Lab 11 Decision Log |
 
@@ -206,7 +206,7 @@ Lab 09 is where students viscerally experience the accuracy-efficiency tradeoff.
 | Component | Assignment |
 |:---|:---|
 | **Read** | [Model Serving](https://mlsysbook.ai/vol1/model_serving/model_serving.html) |
-| **Lab** | [Lab 12](https://mlsysbook.ai/labs/vol1/lab_12_perf_bench.html): The Benchmarking Trap |
+| **Lab** | [Lab 12](https://mlsysbook.ai/labs/vol1/lab_12_perf_bench/): The Benchmarking Trap |
 | **Build** | *Capstone prep* |
 | **Due** | Lab 12 Decision Log |
 
@@ -217,7 +217,7 @@ Lab 09 is where students viscerally experience the accuracy-efficiency tradeoff.
 | Component | Assignment |
 |:---|:---|
 | **Read** | [ML Operations](https://mlsysbook.ai/vol1/ml_ops/ml_ops.html) |
-| **Lab** | [Lab 13](https://mlsysbook.ai/labs/vol1/lab_13_model_serving.html): The Tail Latency Trap |
+| **Lab** | [Lab 13](https://mlsysbook.ai/labs/vol1/lab_13_model_serving/): The Tail Latency Trap |
 | **Build** | *Capstone prep* |
 | **Due** | Lab 13 Decision Log |
 
@@ -228,7 +228,7 @@ Lab 09 is where students viscerally experience the accuracy-efficiency tradeoff.
 | Component | Assignment |
 |:---|:---|
 | **Read** | [Responsible Engineering](https://mlsysbook.ai/vol1/responsible_engr/responsible_engr.html) |
-| **Lab** | [Lab 14](https://mlsysbook.ai/labs/vol1/lab_14_ml_ops.html): The Silent Degradation Problem |
+| **Lab** | [Lab 14](https://mlsysbook.ai/labs/vol1/lab_14_ml_ops/): The Silent Degradation Problem |
 | **Build** | *Capstone work* |
 | **Due** | Lab 14 Decision Log + Capstone draft |
 
@@ -239,7 +239,7 @@ Lab 09 is where students viscerally experience the accuracy-efficiency tradeoff.
 | Component | Assignment |
 |:---|:---|
 | **Read** | [Conclusion](https://mlsysbook.ai/vol1/conclusion/conclusion.html) |
-| **Lab** | [Lab 15](https://mlsysbook.ai/labs/vol1/lab_15_responsible_engr.html): No Free Fairness |
+| **Lab** | [Lab 15](https://mlsysbook.ai/labs/vol1/lab_15_responsible_engr/): No Free Fairness |
 | **Capstone** | AI Olympics Competition |
 | **Due** | Final submission + 1,000-word design report |
 

--- a/instructors/getting-started.qmd
+++ b/instructors/getting-started.qmd
@@ -115,7 +115,7 @@ Need to adapt for a quarter system, a graduate seminar, or a specific emphasis? 
 Here is exactly what to assign on Day 1:
 
 1. **Reading**: [Vol I, Introduction](https://mlsysbook.ai/vol1/introduction/introduction.html) (45 min)
-2. **Lab**: [Lab 00](https://mlsysbook.ai/labs/vol1/lab_00_introduction.html) — The Architect's Portal (30 min)
+2. **Lab**: [Lab 00](https://mlsysbook.ai/labs/vol1/lab_00_introduction/) — The Architect's Portal (30 min)
 3. **TinyTorch**: [Module 01: Tensor](https://mlsysbook.ai/tinytorch/modules/01_tensor.html) — due end of Week 1 (4–6 hrs)
 4. **Prediction Lock**: "A GPU is how many times faster than a CPU for a $1024{\times}1024$ matrix multiply?" (students commit a number before Lab 01)
 


### PR DESCRIPTION
## Summary

Update 33 broken Lab links across three Instructor guides from obsolete flat
`.html` endpoints to the directory routes generated by the Labs build.

## Area

- [ ] Book (textbook content, figures, exercises)
- [ ] TinyTorch (modules, tests, milestones)
- [ ] StaffML (interview questions, challenges)
- [ ] Kits (hardware labs)
- [ ] Infrastructure (CI/CD, scripts, config)
- [x] Instructors (course map, syllabus, getting-started guide)

## Changes

- Replace 33 `/labs/vol1/lab_*.html` links with canonical
  `/labs/vol1/lab_*/` routes.
- Keep link text and course content unchanged.
- Cover all 16 Volume I labs referenced by the Instructor materials.

## Testing

- [ ] Rendered the book locally (`quarto render`)
- [ ] Ran tests (`pytest tests/`)
- [ ] Ran `tito module test NN` for affected module(s)
- [x] Manual verification (described below)
- [x] Ran pre-commit on all three changed files
- [x] Ran `shared/scripts/check-internal-links.py` on all three changed files
- [x] Confirmed all 16 unique replacement URLs return HTTP 200
- [x] Confirmed `git diff --check` passes

The old sample route `/labs/vol1/lab_00_introduction.html` returns HTTP 404,
while `/labs/vol1/lab_00_introduction/` returns HTTP 200. Quarto is not
installed in my local environment, so the repository's Instructor validation
workflow will perform the full site render.

## Related Issues

Related to #1810

---
*By submitting this PR, you agree to release your contribution under the project's license.*
