### PR TITLE
fix(tinytorch): tito CLI crashes on Windows due to no-op encoding fix

### DIFF
--- a/tinytorch/tito/main.py
+++ b/tinytorch/tito/main.py
@@ -16,10 +16,23 @@ import sys
 from pathlib import Path
 from typing import Dict, Type, Optional, List
 
-# Fix encoding issues on Windows (emoji/unicode output)
+# Fix encoding issues on Windows (emoji/unicode output).
 # See: https://github.com/harvard-edge/cs249r_book/discussions/1145
+#
+# Setting PYTHONIOENCODING here has no effect: sys.stdout/sys.stderr are
+# already constructed by the time this module executes, using whatever
+# encoding the interpreter picked at startup (typically the console's
+# legacy codepage, e.g. cp1252, not UTF-8). Reading the env var again
+# after the fact changes nothing, so every emoji this CLI prints
+# (banners, checkmarks, error icons) raised an unhandled
+# UnicodeEncodeError and crashed with a raw traceback on most Windows
+# terminals. Reconfiguring the already-open streams directly is the
+# only way to actually fix the encoding for this process.
 if sys.platform == "win32" or os.name == "nt":
     os.environ.setdefault("PYTHONIOENCODING", "utf-8")
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
 
 # Set TINYTORCH_QUIET before any tinytorch imports to suppress autograd messages
 os.environ['TINYTORCH_QUIET'] = '1'


### PR DESCRIPTION
## Problem

`tito` (the TinyTorch CLI) crashes with a raw Python traceback on Windows the moment it tries to print an emoji, which is nearly every command: the startup banner, `tito setup`, `tito module start`, error panels, etc.

```
File ".../encodings/cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f525' in position 4: character maps to <undefined>
```

## Root cause

`tito/main.py` already has an attempted fix for exactly this (referencing discussion #1145):

```python
if sys.platform == "win32" or os.name == "nt":
    os.environ.setdefault("PYTHONIOENCODING", "utf-8")
```

This is a no-op. By the time this line runs, `sys.stdout` and `sys.stderr` have already been constructed by the interpreter using whatever encoding the console reported at startup (commonly cp1252 on Windows, not UTF-8). Setting the env var afterward doesn't retroactively change already-open streams, so the crash still happens on any Windows console using a legacy codepage, which is the common default (not an edge case).

## Fix

Reconfigure the already-open `sys.stdout`/`sys.stderr` streams directly (`TextIOWrapper.reconfigure`, available since Python 3.7), which actually takes effect for the running process.

## Testing

Reproduced on a fresh Windows install and confirmed the fix end to end:

- Fresh install via `install.sh` -> `tito --version` crashed before the fix, prints cleanly after.
- `tito setup` completed successfully (all-green checklist) instead of crashing on the first banner print.
- `tito module start 01` ran the full flow (notebook generation + Jupyter Lab launch) without crashing.
- Full test suite: 830 passed both before and after this change (same pre-existing failures in both runs, all due to missing optional dev/visualization packages in the test venv, unrelated to this fix) -- no regressions introduced.