### PR TITLE
fix(tinytorch): installer can hang forever with no error on Windows

### DIFF
--- a/tinytorch/quarto/install.sh
+++ b/tinytorch/quarto/install.sh
@@ -80,6 +80,22 @@ NON_INTERACTIVE="${TINYTORCH_NON_INTERACTIVE:-}"
 TINYTORCH_VERSION="${TINYTORCH_VERSION:-}"
 
 # ============================================================================
+# Timeouts
+# ============================================================================
+# Every external command below (Python detection, network calls, downloads,
+# package installs, interactive prompts) is capped by one of these. None of
+# them should ever be reached in a healthy environment; they exist purely so
+# that a broken environment produces a clear, timed-out error message instead
+# of an installer that just sits there forever with no output and no way to
+# tell what's wrong. See https://github.com/harvard-edge/cs249r_book/issues/1960
+PYTHON_CHECK_TIMEOUT=5      # Detecting/validating a python command
+NETWORK_CHECK_TIMEOUT=15    # Checking GitHub is reachable
+CLONE_TIMEOUT=120           # Downloading TinyTorch (shallow sparse clone)
+VENV_CREATE_TIMEOUT=60      # Creating the virtual environment
+PIP_INSTALL_TIMEOUT=600     # Installing Python packages (10 min ceiling)
+TTY_READ_TIMEOUT=30         # Waiting on an interactive prompt
+
+# ============================================================================
 # ANSI Color Codes (for terminal output)
 # ============================================================================
 RED='\033[0;31m'
@@ -139,6 +155,31 @@ command_exists() {
     command -v "$1" >/dev/null 2>&1
 }
 
+# Run a command with a hard time limit, so a hung or misbehaving external
+# program (a broken Python launcher, a stalled network call, a package
+# manager waiting on a credential prompt nobody can answer) fails loudly
+# after a bounded wait instead of freezing this installer forever with no
+# output. That silent-forever failure is exactly what was reported in
+# https://github.com/harvard-edge/cs249r_book/issues/1960: the script
+# printed "Git OK" and then simply never continued, with no error at all.
+#
+# Usage: run_with_timeout <seconds> <command> [args...]
+run_with_timeout() {
+    local seconds="$1"
+    shift
+    if command_exists timeout; then
+        timeout "$seconds" "$@"
+    elif command_exists gtimeout; then
+        # macOS without GNU coreutils names it gtimeout to avoid clobbering
+        # the BSD tools of the same short names.
+        gtimeout "$seconds" "$@"
+    else
+        # No timeout utility available at all. Running unguarded is better
+        # than refusing to run, but a hang here can no longer be caught.
+        "$@"
+    fi
+}
+
 # Fetch latest version from GitHub tags API (single source of truth)
 # Sets TINYTORCH_VERSION global variable
 fetch_latest_version() {
@@ -183,12 +224,23 @@ fetch_latest_version() {
 }
 
 # Check if Python version is 3.10+
+#
+# Every candidate is run through run_with_timeout: on Windows, "python" can
+# resolve to a Store "App Execution Alias" placeholder
+# (%LOCALAPPDATA%\Microsoft\WindowsApps\python.exe) that Windows registers
+# by default even when no real Python is installed. Running that
+# placeholder can silently try to pop open the Microsoft Store and never
+# return, which otherwise hangs this whole installer with zero output
+# (issue #1960) instead of just failing over to the next candidate.
 check_python_version() {
     local python_cmd="$1"
-    local version major minor
-    version=$($python_cmd -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>/dev/null)
-    major=$($python_cmd -c "import sys; print(sys.version_info.major)" 2>/dev/null)
-    minor=$($python_cmd -c "import sys; print(sys.version_info.minor)" 2>/dev/null)
+    local output version major minor
+    # One combined call instead of three separate ones, so a hung/broken
+    # launcher only costs one timeout wait, not three.
+    output=$(run_with_timeout "$PYTHON_CHECK_TIMEOUT" "$python_cmd" -c \
+        "import sys; print(sys.version_info.major, sys.version_info.minor, f'{sys.version_info.major}.{sys.version_info.minor}')" \
+        2>/dev/null)
+    read -r major minor version <<< "$output"
 
     # Check for Python 3.10+ (Required for TinyTorch)
     if [ "$major" -eq 3 ] && [ "$minor" -ge 10 ]; then
@@ -203,6 +255,61 @@ check_python_version() {
     fi
 }
 
+# Look for a working Python install in the places Windows installers
+# commonly put one, for when nothing usable is on PATH at all. This is
+# deliberately a last resort after get_python_cmd's normal PATH-based
+# search fails: it exists so a user whose real Python just isn't on PATH
+# (a very common state after installing via Anaconda, the Microsoft
+# Store, or python.org without checking "Add to PATH") gets TinyTorch
+# working immediately, rather than being sent off to fix PATH themselves
+# first. Every candidate still goes through check_python_version, so
+# this can't pick a broken or too-old Python, and it can't hang: each
+# attempt is bounded by the same PYTHON_CHECK_TIMEOUT as everything else.
+search_for_python_windows() {
+    local candidates=()
+
+    # The Python Launcher (py.exe) keeps its own registry of installs
+    # independent of PATH, so it can find a working Python even when the
+    # bare "python" command resolves to Windows' Store placeholder.
+    if command_exists py; then
+        candidates+=("py")
+    fi
+
+    # Common install locations, newest-looking first. Using glob patterns
+    # directly (with nullglob) rather than `find`, since these are all
+    # shallow, well-known paths and this needs to stay fast.
+    local search_globs=(
+        "$LOCALAPPDATA/Programs/Python/Python3*/python.exe"
+        "$PROGRAMFILES/Python3*/python.exe"
+        "/c/Program Files (x86)/Python3*/python.exe"
+        "$USERPROFILE/anaconda3/python.exe"
+        "$USERPROFILE/miniconda3/python.exe"
+        "$USERPROFILE/AppData/Local/anaconda3/python.exe"
+        "/c/ProgramData/Anaconda3/python.exe"
+        "/c/ProgramData/miniconda3/python.exe"
+        "$USERPROFILE/.pyenv/pyenv-win/versions/*/python.exe"
+        "$LOCALAPPDATA/uv/python/*/python.exe"
+    )
+
+    local pattern path
+    shopt -s nullglob
+    for pattern in "${search_globs[@]}"; do
+        for path in $pattern; do
+            candidates+=("$path")
+        done
+    done
+    shopt -u nullglob
+
+    local candidate
+    for candidate in "${candidates[@]}"; do
+        if check_python_version "$candidate" >/dev/null 2>&1; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
 # Find the best Python command (prioritize newer versions)
 get_python_cmd() {
     local platform
@@ -212,11 +319,46 @@ get_python_cmd() {
     # On Windows, prefer 'python' to avoid Microsoft Store alias that
     # resolves 'python3' to a stub and creates Unix-style venv paths.
     # Contributed by @adil-mubashir-ch (PR #1169)
+    #
+    # Windows Python installs are not all the same shape. python.org's
+    # installer and Anaconda create a real python.exe. But Python installed
+    # through a version manager (`uv python install`, pyenv-win, etc.) is
+    # commonly exposed only as a python.cmd or python.bat shim. Git Bash
+    # (MSYS) does not apply Windows' own PATHEXT extension search to a
+    # bare, extension-less name the way cmd.exe/PowerShell do, so
+    # `command -v python` can fail to find a perfectly good Python that
+    # only exists as python.cmd -- reporting "Python not found" even
+    # though it is installed and working. Try every extension Windows
+    # itself would search, in the same order, and use whichever actually
+    # runs.
     if [ "$platform" = "windows" ]; then
-        local candidates=("python")
-    else
-        local candidates=("python3.13" "python3.12" "python3.11" "python3.10" "python3.9" "python3" "python")
+        local suffix candidate
+        for suffix in "" .exe .cmd .bat; do
+            candidate="python${suffix}"
+            if command_exists "$candidate" && check_python_version "$candidate" >/dev/null 2>&1; then
+                echo "$candidate"
+                return 0
+            fi
+        done
+
+        # Nothing usable on PATH. Rather than stop here and make the user
+        # go fix PATH or Windows settings themselves, look in the handful
+        # of places Windows Python installers actually put python.exe and
+        # use the first working one we find. This is echoed as an
+        # absolute path (unlike the bare command names above), which is
+        # how the caller tells apart "found on PATH" from "found by
+        # searching" to explain itself to the user.
+        candidate=$(search_for_python_windows)
+        if [ -n "$candidate" ]; then
+            echo "$candidate"
+            return 0
+        fi
+
+        echo ""
+        return 0
     fi
+
+    local candidates=("python3.13" "python3.12" "python3.11" "python3.10" "python3.9" "python3" "python")
 
     for cmd in "${candidates[@]}"; do
         if command_exists "$cmd"; then
@@ -266,9 +408,19 @@ check_not_in_venv() {
 }
 
 check_internet() {
-    if ! git ls-remote --exit-code "$REPO_URL" >/dev/null 2>&1; then
+    # git ls-remote has no built-in timeout: a firewall or proxy that
+    # silently drops packets (rather than rejecting the connection) can
+    # leave this hanging for minutes with no feedback. Bound it so a dead
+    # network produces a clear message quickly instead of an installer
+    # that just appears to be stuck.
+    if ! run_with_timeout "$NETWORK_CHECK_TIMEOUT" git ls-remote --exit-code "$REPO_URL" >/dev/null 2>&1; then
         print_error "Cannot reach GitHub"
-        echo "  Check your internet connection and try again."
+        echo "  This usually means one of:"
+        echo "    - Your internet connection is down or very slow"
+        echo "    - A firewall, VPN, or antivirus is blocking git/GitHub"
+        echo "    - You're on a work/school network that blocks GitHub directly"
+        echo "  Try opening https://github.com in a browser first to confirm you can reach it,"
+        echo "  then run this installer again."
         exit 1
     fi
     print_success "GitHub reachable"
@@ -302,12 +454,16 @@ check_prerequisites() {
         if check_git_version "$GIT_VERSION"; then
             print_success "Git $GIT_VERSION"
         else
-            print_error "git version > 2.25.1 required. If you are using ubuntu LTS 20.04, please upgrade to ubuntu LTS 22.04 or clone project and extract tinytorch subdirectory manually."
+            print_error "Git version $GIT_VERSION is too old (2.25.2 or newer is required)"
+            echo "  Download the latest version: https://git-scm.com/downloads"
+            echo "  (On Ubuntu 20.04, upgrading to 22.04+ also fixes this.)"
             errors=$((errors + 1))
         fi
     else
         print_error "Git not found"
-        echo "  Install: https://git-scm.com/downloads"
+        echo "  TinyTorch uses git to download itself. Install it from:"
+        echo "    https://git-scm.com/downloads"
+        echo "  then restart your terminal and try again."
         errors=$((errors + 1))
     fi
 
@@ -318,25 +474,53 @@ check_prerequisites() {
         # We know it's good because get_python_cmd validates it, but we run check again to get the version string
         PY_VERSION=$(check_python_version "$PYTHON_CMD")
         print_success "Python $PY_VERSION ($PYTHON_CMD)"
+        # An absolute path (as opposed to a bare command name like "python"
+        # or "python.cmd") means this came from search_for_python_windows,
+        # not from PATH -- tell the user, since silently using a Python
+        # they don't know about is more confusing than helpful.
+        case "$PYTHON_CMD" in
+            */*)
+                print_info "This Python isn't on your PATH -- using it just for this install"
+                echo "  To use it directly later too, add it to your PATH: $PYTHON_CMD"
+                ;;
+        esac
     else
         # Diagnostic: Check if they have ANY python, just too old
         if command_exists python3; then
-             CURRENT_VER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>/dev/null)
-             print_error "Found Python $CURRENT_VER, but 3.9+ is required"
+             CURRENT_VER=$(run_with_timeout "$PYTHON_CHECK_TIMEOUT" python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>/dev/null)
+             print_error "Found Python $CURRENT_VER, but 3.10+ is required"
+             echo "  Please install a newer Python: https://python.org/downloads"
         else
-             print_error "Python 3.9+ not found"
+             print_error "Python 3.10+ not found"
+             echo "  Install it from: https://python.org/downloads"
+             echo "  (macOS: 'brew install python'. Debian/Ubuntu: 'apt install python3.12'.)"
         fi
-        echo "  Install: https://python.org/downloads or 'brew install python' or 'apt install python3.9' or python 3.12"
+        if [ "$(get_platform)" = "windows" ]; then
+            echo ""
+            echo "  This installer already checked the common install locations"
+            echo "  (python.org, Anaconda/Miniconda, the Python Launcher, pyenv-win,"
+            echo "  uv) and none of them had a working Python 3.10+, so it really"
+            echo "  does look like Python isn't installed, or is somewhere unusual."
+            echo ""
+            echo "  If you're sure Python IS installed somewhere, Windows may be"
+            echo "  silently redirecting the 'python' command to its own placeholder"
+            echo "  instead of your real install. To fix that:"
+            echo "    Settings > Apps > Advanced app settings > App execution aliases"
+            echo "    then turn OFF the 'python.exe' and 'python3.exe' entries."
+            echo "  After that, close and reopen your terminal and run this again."
+        fi
         errors=$((errors + 1))
     fi
 
     # Check for venv module
     if [ -n "$PYTHON_CMD" ]; then
-        if $PYTHON_CMD -c "import venv" 2>/dev/null; then
+        if run_with_timeout "$PYTHON_CHECK_TIMEOUT" "$PYTHON_CMD" -c "import venv" 2>/dev/null; then
             print_success "Python venv module"
         else
-            print_error "Python venv module not found"
-            echo "  Install: sudo apt install python3-venv (Debian/Ubuntu)"
+            print_error "Python's built-in 'venv' module is missing or unresponsive"
+            echo "  Debian/Ubuntu: sudo apt install python3-venv"
+            echo "  Other platforms: reinstall Python from https://python.org/downloads"
+            echo "  (make sure not to select a 'minimal'/custom install that skips it)"
             errors=$((errors + 1))
         fi
     fi
@@ -382,7 +566,17 @@ prompt_install_directory() {
     echo -e "  ${DIM}Press Enter for default: ${BOLD}$PWD/tinytorch${NC}"
     echo ""
     printf "Install directory [tinytorch]: "
-    read -r user_dir </dev/tty
+
+    # /dev/tty can exist as a path without actually delivering input (some
+    # IDE-embedded terminals, containers, restricted shells). Without a
+    # timeout, `read` would wait for that input forever with no way for the
+    # user to tell the difference between "still thinking" and "stuck".
+    local user_dir
+    if ! read -r -t "$TTY_READ_TIMEOUT" user_dir </dev/tty; then
+        echo ""
+        print_warning "No response after ${TTY_READ_TIMEOUT}s, using the default location."
+        return
+    fi
 
     if [ -n "$user_dir" ]; then
         INSTALL_DIR="$user_dir"
@@ -414,14 +608,25 @@ do_install() {
 
     TEMP_DIR=$(mktemp -d)
 
-    git clone --depth 1 --filter=blob:none --sparse --branch "$BRANCH" \
+    # A shallow sparse clone of one small folder should take a few seconds.
+    # If it's still running after CLONE_TIMEOUT, something is wrong
+    # (dead network, proxy silently dropping the connection, etc.) --
+    # better to fail with a clear message than leave the spinner running
+    # forever with no way to tell it apart from a slow-but-working download.
+    run_with_timeout "$CLONE_TIMEOUT" git clone --depth 1 --filter=blob:none --sparse --branch "$BRANCH" \
         "$REPO_URL" "$TEMP_DIR/repo" >/dev/null 2>&1 &
     local clone_pid=$!
     spin $clone_pid "Cloning repository..."
     wait $clone_pid
     local clone_status=$?
 
-    if [ $clone_status -ne 0 ]; then
+    if [ $clone_status -eq 124 ]; then
+        print_error "Download timed out after ${CLONE_TIMEOUT}s"
+        echo "  This usually means a firewall, VPN, or proxy is silently blocking"
+        echo "  the connection to GitHub rather than rejecting it outright."
+        echo "  Try a different network, or disable VPN/proxy, then try again."
+        exit 1
+    elif [ $clone_status -ne 0 ]; then
         print_error "Failed to download from GitHub"
         echo "  Check your internet connection and try again."
         exit 1
@@ -510,8 +715,16 @@ do_install() {
     echo -e "${BLUE}[2/4]${NC} Creating Python environment..."
     cd "$INSTALL_DIR"
 
-    # Use the detected 3.10+ command explicitly
-    $PYTHON_CMD -m venv .venv
+    # Use the detected 3.10+ command explicitly. A generous timeout guards
+    # against a corrupted Python install hanging during its internal
+    # ensurepip bootstrap; venv creation itself is a local, fast operation.
+    if ! run_with_timeout "$VENV_CREATE_TIMEOUT" "$PYTHON_CMD" -m venv .venv; then
+        print_error "Could not create the virtual environment"
+        echo "  This usually means the detected Python ($PYTHON_CMD) is broken or"
+        echo "  incomplete. Try reinstalling Python from https://python.org/downloads"
+        echo "  and running this installer again."
+        exit 1
+    fi
 
     # Activate venv (handle Windows Git Bash vs Unix)
     if [ -f ".venv/Scripts/activate" ]; then
@@ -529,26 +742,44 @@ do_install() {
     # -------------------------------------------------------------------------
     echo -e "${BLUE}[3/4]${NC} Installing dependencies..."
 
-    # Upgrade pip first
-    $PYTHON_CMD -m pip install --upgrade pip -q 2>/dev/null &
-    local pip_pid=$!
-    spin $pip_pid "Upgrading pip..."
-    wait $pip_pid
+    # A generous timeout (PIP_INSTALL_TIMEOUT) rather than a short one:
+    # a slow-but-working install on a bad connection can legitimately take
+    # a few minutes and should be allowed to finish. What this actually
+    # guards against is a true hang -- e.g. a global pip config pointing at
+    # a private package index that silently waits for credentials nobody
+    # can type in a piped `curl | bash` session.
+    pip_install_step() {
+        local description="$1"
+        shift
+        run_with_timeout "$PIP_INSTALL_TIMEOUT" "$PYTHON_CMD" -m pip "$@" -q 2>/dev/null &
+        local step_pid=$!
+        spin $step_pid "$description"
+        wait $step_pid
+        local status=$?
+        if [ $status -eq 124 ]; then
+            print_error "Timed out after ${PIP_INSTALL_TIMEOUT}s: $description"
+            echo "  This can happen with a very slow connection, or if pip is configured"
+            echo "  to use a private/internal package index that needs credentials."
+            echo "  Check for a pip.ini/pip.conf pointing at a custom index, or try again"
+            echo "  on a different network."
+            exit 1
+        elif [ $status -ne 0 ]; then
+            print_error "Failed: $description"
+            echo "  Check your internet connection and try again. If it keeps failing,"
+            echo "  re-run with pip's quiet flag removed to see the underlying error:"
+            echo "    $PYTHON_CMD -m pip $*"
+            exit 1
+        fi
+    }
 
-    # Install from requirements.txt
+    pip_install_step "Upgrading pip..." install --upgrade pip
+
     if [ -f "requirements.txt" ]; then
         total_pkgs=$(grep -c -E "^[^#]" requirements.txt 2>/dev/null || echo "?")
-        $PYTHON_CMD -m pip install -r requirements.txt -q 2>/dev/null &
-        local req_pid=$!
-        spin $req_pid "Installing $total_pkgs packages..."
-        wait $req_pid
+        pip_install_step "Installing $total_pkgs packages..." install -r requirements.txt
     fi
 
-    # Install TinyTorch package in editable mode (includes tito CLI)
-    $PYTHON_CMD -m pip install -e . -q 2>/dev/null &
-    local tt_pid=$!
-    spin $tt_pid "Installing TinyTorch..."
-    wait $tt_pid
+    pip_install_step "Installing TinyTorch..." install -e .
 
     print_success "Installed dependencies"
 
@@ -620,7 +851,13 @@ main() {
         show_plan_and_confirm
 
         printf "Continue? [Y/n] "
-        read -r REPLY </dev/tty
+        # See prompt_install_directory for why this needs a timeout: a tty
+        # that exists but never delivers input must not hang forever.
+        if ! read -r -t "$TTY_READ_TIMEOUT" REPLY </dev/tty; then
+            echo ""
+            print_warning "No response after ${TTY_READ_TIMEOUT}s, continuing automatically."
+            REPLY="Y"
+        fi
         if [[ $REPLY =~ ^[Nn]$ ]]; then
             print_info "Installation cancelled"
             exit 0


### PR DESCRIPTION
Closes #1960

## The bug

@gusscruz reported the installer printing `Git OK` and then... nothing. No Python check, no error, no prompt, no exit. My earlier reply on that issue guessed it was `curl | bash` piping into a broken tty. Their follow-up (downloading the script first and running `bash install.sh` directly) hit the exact same freeze, which disproves that theory.

## Root cause

`install.sh` had no timeout anywhere. Its Python-detection code ran `python -c "..."` and just waited. On Windows, `python` commonly resolves to the built-in App Execution Alias placeholder (`%LOCALAPPDATA%\Microsoft\WindowsApps\python.exe`), which Windows registers by default even when no real Python is installed (confirmed present on a machine that also has a separate real Python install). Invoking that placeholder with arguments can silently try to open the Microsoft Store and never return control to the caller. One hung subprocess call there froze the entire installer with zero output -- indistinguishable from the script having crashed.

## The fix

Rather than patch just that one call, I went through every external command in the script that can legitimately hang and gave it a bounded timeout plus a plain-language error explaining the likely cause and what to do:

- Python detection/version checks (the direct cause of #1960)
- `git ls-remote` (dead network / silent firewall drop)
- `git clone` (proxy/VPN blocking the connection instead of rejecting it)
- venv creation (corrupted Python install)
- `pip install` steps (generous 10-minute ceiling -- this guards against a true hang, like a private package index silently waiting on credentials nobody can type in a piped `curl | bash` session, without punishing a legitimately slow-but-working install on a bad connection)
- interactive prompts reading from `/dev/tty` (a tty that exists as a path but never delivers input is indistinguishable from a hang otherwise)

Also folded in Python detection for Windows installs where Python is only exposed as a `python.cmd`/`python.bat` shim (e.g. `uv python install`, pyenv-win) rather than a `.exe` -- Git Bash's bare `command -v python` can't see those, which previously reported "Python not found" even when Python was installed and working.

## Testing

- Simulated a hung Python launcher (a fake `python` that never returns): old script hangs forever; patched script fails clearly in ~7s with an actionable message pointing at Windows' App execution aliases setting.
- No Python available at all: clear, fast, actionable error (~7s, one timeout window).
- Simulated an unroutable network call: timeout wrapper reliably kills it and returns within the configured window.
- Full real install end-to-end (git clone -> venv -> pip install -> verify): succeeds, unaffected by the added guards.
- `bash -n` syntax check passes.