### PR TITLE
fix(tinytorch): tito olympics logo crashes with NameError

### DIFF
--- a/tinytorch/tito/commands/olympics.py
+++ b/tinytorch/tito/commands/olympics.py
@@ -43,19 +43,8 @@ class OlympicsCommand(BaseCommand):
             help='Check your Olympics participation status'
         )
 
-    def run(self, args: Namespace) -> int:
-        """Show coming soon message with Olympics branding."""
-        console = self.console
-
-        # Handle subcommands
-        if hasattr(args, 'olympics_command') and args.olympics_command == 'logo':
-            print_olympics_logo(console)
-            return 0
-
-        # Build the content with logo inside the panel
-        # Olympic rings ASCII art with colors
-        # Blue (ring 1), White (ring 2), Red (ring 3) on top
-        # Yellow (ring 4), Green (ring 5) on bottom, interlocking
+    def _build_logo(self) -> Text:
+        """Build the Olympic rings ASCII art (blue/white/red on top, yellow/green on bottom, interlocking)."""
         logo_lines = ["",
             "[blue]⠀⠀⢀⣠⢖⠗⠟⠛⠛⠟⢶⢦⣀[/]⠀⠀⠀⠀⠀⠀⠀[bright_white]⣠⣶⡿⠿⠿⠿⣿⣷⣦⣄[/]⠀⠀⠀⠀⠀⠀⠀[red]⣄⡴⡳⠛⠛⠛⠟⢞⣦⣄[/]⠀⠀⠀",
             "[blue]⠀⣠⢾⠑⠁⠀⠀⠀⠀⠀⠀⠉⠫⣷⡀[/]⠀⠀⠀[bright_white]⣠⣾⡟⠉⠀⠀⠀⠀⠀⠀⠙⢻⣷⣄[/]⠀⠀⠀[red]⢠⢾⠕⠉⠀⠀⠀⠀⠀⠀⠈⠚⡷⡄[/]⠀",
@@ -70,8 +59,22 @@ class OlympicsCommand(BaseCommand):
             "⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀[yellow]⠐⠕⡄⡀⠀⠀⠀⠀⠀⡀⠤⡊⠌[/]⠀⠀⠀⠀[green]⠑⢷⢤⡀⠀⠀⠀⠀⠀⢀⡤⣞⠕[/]⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀",
             "⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀[yellow]⠈⠌⠊⡒⢔⠑⠌⠊⠂[/]⠀⠀⠀⠀⠀⠀⠀⠀[green]⠑⠫⠛⡖⡶⣙⠞⠝⠊[/]⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀",
         ]
+        return Text.from_markup("\n".join(logo_lines) + "\n\n")
 
-        logo = Text.from_markup("\n".join(logo_lines) + "\n\n")
+    def run(self, args: Namespace) -> int:
+        """Show coming soon message with Olympics branding."""
+        console = self.console
+        logo = self._build_logo()
+
+        # Handle subcommands
+        if hasattr(args, 'olympics_command') and args.olympics_command == 'logo':
+            console.print(Panel(
+                Align.center(logo),
+                title="⚡ TINYTORCH OLYMPICS ⚡",
+                border_style="bright_yellow",
+                padding=(1, 2)
+            ))
+            return 0
 
         message = Text()
         message.append("🚧 COMING SOON 🚧\n\n", style="bold yellow")


### PR DESCRIPTION
## Bug

\`tito olympics logo\` crashes outright:

\`\`\`
NameError: name 'print_olympics_logo' is not defined
\`\`\`

## Root cause

The 'logo' subcommand calls \`print_olympics_logo(console)\`, a function that doesn't exist anywhere in the codebase (confirmed via a repo-wide grep). The default \`tito olympics\` / \`tito olympics status\` path already builds the exact same Olympic rings ASCII art correctly, just inline as part of a larger combined panel -- this looks like the 'logo' subcommand was meant to reuse that same rendering but the extraction was never finished.

## Fix

Extracted the logo-building code into a small \`_build_logo()\` method shared by both code paths. The dedicated \`logo\` subcommand now shows just the logo in its own panel (matching its documented help text: "Display the Neural Networks Olympics logo"), while the default/\`status\` path is unchanged and still shows the full logo-plus-message panel.

## Testing

\`tito olympics logo\` now runs cleanly and renders the ASCII art instead of crashing. Found while running the full TinyTorch student + supplementary command surface end to end (all 20 modules, all 6 milestones, and every command group) looking for exactly this class of bug.