### PR TITLE
fix(tinytorch): benchmark capstone always reports Module 20 as incomplete

### DIFF
--- a/tinytorch/tito/commands/benchmark.py
+++ b/tinytorch/tito/commands/benchmark.py
@@ -285,9 +285,14 @@ class BenchmarkCommand(BaseCommand):
             ))
             return 1
 
-        # Check if Module 20 competition code is available
+        # Check if Module 20 competition code is available. `tito module
+        # complete 20` exports the capstone notebook to tinytorch/olympics.py
+        # (see tito/commands/module/workflow.py's export path mapping), not
+        # tinytorch/competition/submit.py -- that module has never existed,
+        # so this check previously always failed and reported "Module 20 not
+        # complete" even for students who genuinely finished it.
         try:
-            from tinytorch.competition.submit import OlympicEvent, generate_submission
+            from tinytorch.olympics import generate_submission
         except ImportError:
             console.print(Panel(
                 "[yellow]⚠️  Module 20 (Capstone) not complete[/yellow]\n\n"


### PR DESCRIPTION
## Bug

Ran through the full 20-module curriculum end to end (all modules, all 6 milestones). After correctly completing Module 20 (\`tito module complete 20\` succeeds, \`tito module status\` shows it done), \`tito benchmark capstone\` still says:

> ⚠️  Module 20 (Capstone) not complete
> Running simplified capstone benchmarks...

## Root cause

The completion check in \`_run_capstone\` does:

\`\`\`python
from tinytorch.competition.submit import OlympicEvent, generate_submission
\`\`\`

Both names are wrong:
- \`tinytorch.competition.submit\` doesn't exist anywhere in this codebase. \`tito module complete 20\` actually exports the capstone notebook to \`tinytorch/olympics.py\`.
- \`OlympicEvent\` isn't even a Module 20 concept -- it's defined in Module 19's export (\`tinytorch/perf/benchmarking.py\`), so it looks like it was copied from the wrong place.

Since this import always raises \`ImportError\`, every student who correctly finishes Module 20 still gets told it's incomplete and silently gets the simplified benchmark instead of the real one -- with no way to tell that's happening for a wrong reason rather than something they did wrong.

## Fix

\`\`\`python
from tinytorch.olympics import generate_submission
\`\`\`

matching what Module 20 actually produces. Dropped \`OlympicEvent\` since neither branch below actually uses either imported name -- this import exists purely as an "is Module 20 done" probe.

## Testing

Completed Module 20 in a fresh install, confirmed \`tito benchmark capstone\` now correctly takes the full-benchmark path instead of falling back to simplified.