### PR TITLE
fix(tinytorch): tito dev clean/build crash with raw traceback when make is missing

### DIFF
--- a/tinytorch/tito/commands/dev/build.py
+++ b/tinytorch/tito/commands/dev/build.py
@@ -73,9 +73,23 @@ class DevBuildCommand(BaseCommand):
 
         console.print(f"[cyan]🔨 {config['label']}...[/cyan]")
 
-        result = subprocess.run(
-            config['command'],
-            cwd=str(cwd),
-        )
+        # `make` isn't bundled with Git Bash on Windows (unlike git/python,
+        # it has no equivalent auto-installed fallback), so this is a very
+        # reachable crash for any Windows user without WSL or a separate
+        # make install: subprocess.run raises FileNotFoundError with no
+        # indication of *why*, rather than something recognizable as
+        # "install this tool".
+        try:
+            result = subprocess.run(
+                config['command'],
+                cwd=str(cwd),
+            )
+        except FileNotFoundError:
+            console.print("[red]❌ 'make' is not installed or not on your PATH[/red]")
+            console.print("  This command needs GNU Make to run its build targets.")
+            console.print("  Windows: install via 'choco install make', WSL, or Git Bash's own")
+            console.print("           MinGW package manager.")
+            console.print("  macOS/Linux: usually preinstalled, or 'brew install make' / 'apt install make'.")
+            return 1
 
         return result.returncode

--- a/tinytorch/tito/commands/dev/clean.py
+++ b/tinytorch/tito/commands/dev/clean.py
@@ -45,10 +45,24 @@ class DevCleanCommand(BaseCommand):
                 console.print(f"[red]❌ Directory not found: {cwd}[/red]")
                 return 1
             console.print("[cyan]🧹 Cleaning site build artifacts...[/cyan]")
-            result = subprocess.run(['make', 'clean'], cwd=str(cwd))
         else:
             cwd = self.config.project_root
             console.print("[cyan]🧹 Cleaning all generated files...[/cyan]")
+
+        # `make` isn't bundled with Git Bash on Windows (unlike git/python,
+        # it has no equivalent auto-installed fallback), so this is a very
+        # reachable crash for any Windows user without WSL or a separate
+        # make install: subprocess.run raises FileNotFoundError with no
+        # indication of *why*, rather than something recognizable as
+        # "install this tool".
+        try:
             result = subprocess.run(['make', 'clean'], cwd=str(cwd))
+        except FileNotFoundError:
+            console.print("[red]❌ 'make' is not installed or not on your PATH[/red]")
+            console.print("  This command needs GNU Make to run its clean targets.")
+            console.print("  Windows: install via 'choco install make', WSL, or Git Bash's own")
+            console.print("           MinGW package manager.")
+            console.print("  macOS/Linux: usually preinstalled, or 'brew install make' / 'apt install make'.")
+            return 1
 
         return result.returncode


### PR DESCRIPTION
## Bug

\`tito dev clean\` crashes outright on any system without \`make\` installed:

\`\`\`
FileNotFoundError: [WinError 2] The system cannot find the file specified
❌ Unexpected error: [WinError 2] The system cannot find the file specified
\`\`\`

## Root cause

Both \`tito/commands/dev/clean.py\` and \`tito/commands/dev/build.py\` run \`subprocess.run(['make', ...])\` with no error handling at all. \`make\` isn't bundled with Git Bash on Windows -- unlike git/python, which \`install.sh\` already checks for and gives specific install guidance on -- so any Windows user without WSL or a separately-installed \`make\` hits this. \`dev clean\`'s default target runs against the project root (which always exists), so this is reachable by just running \`tito dev clean\`, not some obscure edge case.

## Fix

Wrapped both \`subprocess.run\` calls in \`try/except FileNotFoundError\`, with a message that says what's actually missing (\`make\`) and how to install it per platform, instead of a raw traceback ending in an opaque Windows error code.

## Testing

Verified \`tito dev clean\` on a machine without \`make\` on PATH now prints a clear, actionable message instead of crashing.