### PR TITLE
fix: swap Acceleration/Memoization descriptions on TinyTorch dashboard

### DIFF
--- a/tinytorch/quarto/community/dashboard.html
+++ b/tinytorch/quarto/community/dashboard.html
@@ -625,13 +625,13 @@
             },
             {
                 id: "17_acceleration", title: "Acceleration", year: "2016", val: 0.85,
-                desc: "KV-Cache for fast inference.",
-                people: [{name: "Pope et al.", role: "Efficiently Scaling Transformers (2022)"}, {name: "vLLM Team", role: "PagedAttention (2023)"}]
+                desc: "Hardware optimization (TPU/GPU).",
+                people: [{name: "NVIDIA", role: "CUDA (2007) / Tensor Cores (2017)"}, {name: "Google", role: "TPU v1 (2016)"}]
             },
             {
                 id: "18_memoization", title: "Memoization", year: "2022", val: 0.80,
-                desc: "Hardware optimization (TPU/GPU).",
-                people: [{name: "NVIDIA", role: "CUDA (2007) / Tensor Cores (2017)"}, {name: "Google", role: "TPU v1 (2016)"}]
+                desc: "KV-Cache for fast inference.",
+                people: [{name: "Pope et al.", role: "Efficiently Scaling Transformers (2022)"}, {name: "vLLM Team", role: "PagedAttention (2023)"}]
             },
             {
                 id: "19_benchmarking", title: "Benchmarking", year: "2018", val: 0.90,


### PR DESCRIPTION
## Summary
Fixes #1976. The milestone cards for modules 17 and 18 on the dashboard had their `desc` and `people` fields swapped between "Acceleration" and "Memoization": the Acceleration card showed the KV-cache description/attribution, and the Memoization card showed the hardware description/attribution.

Confirmed against the actual module source:
- `tinytorch/src/17_acceleration/17_acceleration.py`: vectorization and hardware utilization (CPU/GPU).
- `tinytorch/src/18_memoization/18_memoization.py`: memoization applied to transformers via KV caching.

## Fix
Swapped `desc` and `people` together (not just `desc`) so each card's description stays paired with its correct attribution:
- Acceleration -> "Hardware optimization (TPU/GPU)." with NVIDIA/Google (CUDA, TPU).
- Memoization -> "KV-Cache for fast inference." with Pope et al./vLLM Team (scaling transformers, PagedAttention).

`id`, `title`, `year`, and `val` were left untouched since those match the canonical module folder names.

## Test plan
- [ ] Open `tinytorch/quarto/community/dashboard.html` locally and confirm the Acceleration and Memoization milestone cards show the corrected description/attribution pairs.