### PR TITLE
fix: allow GitHub Pages origin in vault worker CORS allowlist

### DIFF
--- a/interviews/staffml-vault-worker/wrangler.toml
+++ b/interviews/staffml-vault-worker/wrangler.toml
@@ -19,7 +19,7 @@ CACHE_TTL_MANIFEST = "3600"
 CACHE_TTL_QUESTION = "3600"
 CACHE_TTL_SEARCH = "300"
 CACHE_TTL_TAXONOMY = "86400"
-CORS_ALLOWLIST = "https://staffml.mlsysbook.ai,https://mlsysbook.ai,https://staffml-vault.mlsysbook.ai,http://localhost:3000"
+CORS_ALLOWLIST = "https://staffml.mlsysbook.ai,https://mlsysbook.ai,https://staffml-vault.mlsysbook.ai,https://harvard-edge.github.io,http://localhost:3000"
 SCHEMA_FINGERPRINT = "b97218dae6354b1ba0ed4a93242f0ca848554ed02ec86246dc8977ae918c5ad6"
 GRACE_WINDOW_SECONDS = "600"
 


### PR DESCRIPTION
## Summary
Fixes #1977. Study Plans on the StaffML dev preview site never hydrate past the summary metadata; the UI shows "Could not load the full question details. Reload to retry." and reloading never fixes it.

## Root cause
`staffml-preview-dev.yml` builds the dev preview with `NEXT_PUBLIC_VAULT_API` defaulting to the production vault worker (`https://staffml-vault.mlsysbook-ai-account.workers.dev`), and deploys the site to `https://harvard-edge.github.io/cs249r_book_dev/staffml/`.

The production worker's `CORS_ALLOWLIST` in `interviews/staffml-vault-worker/wrangler.toml` only listed the custom `mlsysbook.ai` domains plus localhost. It never included `https://harvard-edge.github.io`, so the browser blocked every `/questions/:id` fetch from the dev preview origin (the worker's own fail-closed CORS logic in `corsHeaders()` correctly omits the `Access-Control-Allow-Origin` header for unlisted origins, causing the browser to reject the response). This is a static config gap, not a transient failure, which is why reloading never helped.

## Fix
Added `https://harvard-edge.github.io` to the production `CORS_ALLOWLIST` in `wrangler.toml`. That origin serves the dev preview path (`/cs249r_book_dev/staffml/`) and is deployed via `wrangler deploy` in `staffml-publish-live.yml` on merge, so the change takes effect on the next production worker deploy.

## Test plan
- [ ] After merge and worker redeploy, load `https://harvard-edge.github.io/cs249r_book_dev/staffml/plans/`, start a study plan, and confirm the scenario/details load without the error banner.
- [ ] `interviews/staffml-vault-worker` vitest suite still passes (unaffected by this change; its CORS tests stub their own allowlist).