### PR TITLE
fix(staffml): make local-corpus vault-CLI probe work on Windows

### DIFF
--- a/interviews/staffml/scripts/build-local-corpus.mjs
+++ b/interviews/staffml/scripts/build-local-corpus.mjs
@@ -30,8 +30,12 @@ if (process.env.STAFFML_SKIP_LOCAL_CORPUS === "1") {
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
 
-const which = spawnSync("which", ["vault"], { encoding: "utf8" });
-if (which.status !== 0 || !which.stdout.trim()) {
+// Probe by actually invoking `vault`, not by shelling out to `which` — `which`
+// doesn't exist on Windows (spawnSync just ENOENTs), so that probe always
+// reported "not installed" there even with a correctly-installed vault-cli,
+// silently skipping the local corpus rebuild on every Windows checkout.
+const probe = spawnSync("vault", ["--version"], { encoding: "utf8" });
+if (probe.error || probe.status !== 0) {
   console.log(
     "[build-local-corpus] `vault` CLI not on PATH; skipping local corpus rebuild.\n" +
     "  To enable full-content rendering against your local YAMLs, run:\n" +


### PR DESCRIPTION
## Summary
Second fix from a full StaffML audit (deps install, tsc/eslint/vitest, then driving the dev server end to end with Playwright). This one explains a real blank-page bug on the most important page in the app: `/practice`.

## Problem
`scripts/build-local-corpus.mjs` runs before `npm run dev` to regenerate `public/data/corpus.json` from the local YAMLs (so local edits are visible without shipping to the worker first). It probes for the `vault` CLI like this:

```js
const which = spawnSync("which", ["vault"], { encoding: "utf8" });
if (which.status !== 0 || !which.stdout.trim()) { /* treat as "not installed", skip */ }
```

`which` does not exist on Windows. `spawnSync("which", ...)` always fails there (ENOENT), so the script always concludes `vault` isn't installed and silently skips the local corpus rebuild — regardless of whether `pip install -e interviews/vault-cli` was actually run.

Effect: on Windows, `public/data/corpus.json` never gets written. `NEXT_PUBLIC_VAULT_FALLBACK=static` (set by `.env.development` for local dev) makes `getStaticFullDetail()` in `lib/corpus.ts` fetch `/data/corpus.json`, which 404s. `/practice`, `/plans`, and `/gauntlet` all depend on this for question content, and none of them surface an error for this path — the page just renders blank with nothing in the console pointing at the actual cause (the failure happens in a build step, not the running app).

## Fix
Probe by invoking `vault --version` directly instead of routing through a Unix-only intermediary (`which.error` / non-zero exit means "not installed or not runnable" on any platform).

## Verification
Reproduced and fixed end-to-end:
1. Installed `vault-cli` into a venv (`pip install -e interviews/vault-cli`).
2. Confirmed `vault --version` worked directly in the shell, but the *old* probe still logged "`vault` CLI not on PATH; skipping" — reproducing the bug.
3. Loaded `/practice` in that state: page rendered blank (screenshot showed only the nav, no question content; network tab showed `GET /data/corpus.json` → 404).
4. Applied this fix, reran `node scripts/build-local-corpus.mjs`: now correctly runs `vault build --local`, writes `public/data/corpus.json` (9,525 questions).
5. Reloaded `/practice`: full question content renders. Drove the whole practice flow with Playwright (select an MCQ option → reveal answer → dismiss the "think longer?" guard dialog → next question) with zero console/page errors.
6. `npm run build` — production static export still succeeds.