### PR TITLE
fix(staffml): fix static-corpus fetch race and unhandled rejection in Gauntlet

### DIFF
--- a/interviews/staffml/src/app/gauntlet/page.tsx
+++ b/interviews/staffml/src/app/gauntlet/page.tsx
@@ -205,10 +205,16 @@ export default function GauntletPage() {
     // Hydrate scenario/details for the whole session in parallel. When the
     // worker responses come back, swap the questions state to the hydrated
     // copies. Until then the UI shows summaries (empty scenario/details).
-    Promise.all(selected.map(q => getQuestionFullDetail(q.id))).then(results => {
+    // allSettled (not all) so one failed hydration doesn't reject the whole
+    // batch — Promise.all would turn a single rejected fetch into an
+    // unhandled promise rejection here, since there was no .catch().
+    Promise.allSettled(selected.map(q => getQuestionFullDetail(q.id))).then(results => {
       // Fall back to the original summary for any question the Worker couldn't hydrate
       // rather than silently discarding the entire batch when even one fetch fails.
-      const merged = selected.map((s, i) => results[i] ?? s);
+      const merged = selected.map((s, i) => {
+        const r = results[i];
+        return (r.status === 'fulfilled' && r.value) ? r.value : s;
+      });
       setQuestions(merged);
     });
   }, [selectedTrack, selectedLevel, selectedDuration]);

--- a/interviews/staffml/src/lib/corpus.ts
+++ b/interviews/staffml/src/lib/corpus.ts
@@ -842,25 +842,46 @@ const _detailsCache = new Map<string, Question>();
 // it caused those questions to re-fetch from the worker on every access.
 const _hydratedIds = new Set<string>();
 let _staticDetailsCache: Map<string, Question> | null = null;
+// In-flight fetch of the static corpus, shared across concurrent callers.
+// Without this, a batch hydration (e.g. Gauntlet's Promise.all over N
+// questions) sees `_staticDetailsCache` as null on every one of the N
+// concurrent calls before any of them finishes the first fetch, so each
+// independently re-fetches the full corpus.json instead of sharing one.
+let _staticCorpusPromise: Promise<Map<string, Question>> | null = null;
 
-async function getStaticFullDetail(id: string, summary: Question): Promise<Question | undefined> {
-  if (!_staticDetailsCache) {
+async function loadStaticCorpus(): Promise<Map<string, Question>> {
+  if (_staticDetailsCache) return _staticDetailsCache;
+  if (!_staticCorpusPromise) {
     // Fetch corpus.json from /data/corpus.json (served from public/). This
     // file is written by `vault build --local-json` and exists only in local
     // dev. Production deploys neither emit nor bundle it; the worker fetch
     // path handles those. If the file is missing at runtime the fetch fails
     // and the caller surfaces an error to the UI.
-    const res = await fetch("/data/corpus.json");
-    if (!res.ok) {
-      throw new Error(
-        `Static corpus.json not available at /data/corpus.json (status ${res.status}). ` +
-        "Run 'vault build --local-json' from the repo root to regenerate it.",
-      );
-    }
-    const data = (await res.json()) as Question[];
-    _staticDetailsCache = new Map(data.map((q) => [q.id, q]));
+    _staticCorpusPromise = fetch("/data/corpus.json")
+      .then(async (res) => {
+        if (!res.ok) {
+          throw new Error(
+            `Static corpus.json not available at /data/corpus.json (status ${res.status}). ` +
+            "Run 'vault build --local-json' from the repo root to regenerate it.",
+          );
+        }
+        const data = (await res.json()) as Question[];
+        const map = new Map(data.map((q) => [q.id, q]));
+        _staticDetailsCache = map;
+        return map;
+      })
+      .catch((err) => {
+        // Let a later call retry instead of caching a permanent rejection.
+        _staticCorpusPromise = null;
+        throw err;
+      });
   }
-  const full = _staticDetailsCache.get(id);
+  return _staticCorpusPromise;
+}
+
+async function getStaticFullDetail(id: string, summary: Question): Promise<Question | undefined> {
+  const cache = await loadStaticCorpus();
+  const full = cache.get(id);
   if (!full) return undefined;
   const merged: Question = {
     ...summary,


### PR DESCRIPTION
## Summary
Third fix from the ongoing StaffML audit, found by actually starting a Mock Interview (Gauntlet) session with Playwright and watching the network tab / console instead of just loading pages.

## Problem
Starting a 5-question Gauntlet session fires 5 separate `GET /data/corpus.json` requests (30 MB each in local static-fallback dev mode), not 1, and one of them can throw an uncaught `Failed to fetch` that reaches the browser as an unhandled promise rejection (visible via Next.js's dev error indicator).

Two compounding bugs:

1. **`lib/corpus.ts` `getStaticFullDetail()`** memoized the parsed corpus with a `if (!_staticDetailsCache) { await fetch(...); _staticDetailsCache = ...}` guard. That check-then-fetch isn't atomic across concurrent callers. `gauntlet/page.tsx`'s `startGauntlet()` calls `getQuestionFullDetail()` for every session question via `Promise.all(...map...)` — all N calls fire concurrently, so all N see `_staticDetailsCache` as `null` before any of them finishes the first fetch, and each independently re-fetches and re-parses the whole corpus file.
2. **`gauntlet/page.tsx`**: the `Promise.all(...).then(...)` hydrating those questions had no `.catch()`. The comment directly above it says "fall back to the original summary ... rather than silently discarding the entire batch" — but that's not what `Promise.all` does: one rejected member sinks the whole batch as an unhandled rejection, bypassing the described per-question fallback entirely.

## Fix
- `corpus.ts`: cache the in-flight fetch *promise*, not just the resolved value, so concurrent callers share one fetch. Reset the cached promise on failure so a later call can retry rather than caching a permanent rejection.
- `gauntlet/page.tsx`: switched `Promise.all` to `Promise.allSettled`, so a single failed hydration falls back to that question's summary (matching the comment's stated intent) instead of losing the whole session or throwing uncaught.

## Verification
Reproduced and fixed end-to-end with Playwright:
1. Before: starting a Gauntlet session fired 5x `GET /data/corpus.json` and threw an uncaught `Failed to fetch` (visible as Next.js's dev-mode error indicator).
2. Applied the fix, reran the identical repro script: exactly 1x `GET /data/corpus.json`, zero page errors.
3. Ran the full Gauntlet flow (setup → begin → question renders → reveal → dismiss "think longer?" guard dialog) — zero console/page errors, answer content renders correctly.
4. `tsc --noEmit` — clean. `vitest run` — 24 files / 131 tests passing. `npm run build` — production export succeeds.