### PR TITLE
docs(tinytorch): update outdated export commands

### DIFF
--- a/tinytorch/src/02_activations/02_activations.py
+++ b/tinytorch/src/02_activations/02_activations.py
@@ -82,7 +82,7 @@ Module 01 (Tensor) → Module 02 (Activations) → Module 03 (Layers)
 **Import Strategy**:
 This module imports directly from the TinyTorch package (`from tinytorch.core.*`).
 **Assumption**: Module 01 (Tensor) has been completed and exported to the package.
-If you see import errors, ensure you've run `tito export` after completing Module 01.
+If you see import errors, ensure you've run `tito module complete 01`.
 """
 
 # %% nbgrader={"grade": false, "grade_id": "setup", "solution": true}

--- a/tinytorch/src/04_losses/04_losses.py
+++ b/tinytorch/src/04_losses/04_losses.py
@@ -89,7 +89,7 @@ Module 01 (Tensor) → Module 02 (Activations) → Module 03 (Layers) → Module
 **Import Strategy**:
 This module imports directly from the TinyTorch package (`from tinytorch.core.*`).
 **Assumption**: Modules 01 (Tensor), 02 (Activations), and 03 (Layers) have been completed and exported to the package.
-If you see import errors, ensure you've run `tito export` after completing previous modules.
+If you see import errors, make sure you've run `tito module complete` for each previous module.
 """
 
 # %% nbgrader={"grade": false, "grade_id": "setup", "solution": true}


### PR DESCRIPTION
## Summary

I ran into this while starting Module 02 because it still says to run `tito export`, but that command no longer exists. Students now export their work through `tito module complete`.

## Area

- [ ] Book (textbook content, figures, exercises)
- [x] TinyTorch (modules, tests, milestones)
- [ ] StaffML (interview questions, challenges)
- [ ] Kits (hardware labs)
- [ ] Infrastructure (CI/CD, scripts, config)

## Changes

- Update Module 02 to point to `tito module complete 01`.
- Update Module 04 to tell students to run `tito module complete` for each previous module.

## Testing

- [ ] Rendered the book locally (`quarto render`)
- [ ] Ran tests (`pytest tests/`)
- [ ] Ran `tito module test NN` for affected module(s)
- [x] Manual verification: searched the TinyTorch module sources for remaining `tito export` instructions and ran `git diff --check`.

## Related Issues

#1134 documents the removal of the old module export command.

---
*By submitting this PR, you agree to release your contribution under the project's license.*
