### PR TITLE
docs(staffml): document cancel-in-progress badge behavior

### DIFF
--- a/.github/workflows/staffml-preview-dev.yml
+++ b/.github/workflows/staffml-preview-dev.yml
@@ -65,6 +65,17 @@ on:
       # went green, but preview-dev never re-ran, so the badge stayed red.
       - 'interviews/vault-cli/**'
 
+# NOTE on the README badge and cancel-in-progress (below):
+# The badge reads the *latest* run for branch=dev&event=push, and shields.io
+# renders any non-success completed conclusion, including "cancelled", as
+# red "failing". Because this workflow cancels in-progress runs on every new
+# push to dev, a burst of back-to-back merges (e.g. several dependabot PRs
+# landing minutes apart) can leave the newest run's predecessor "cancelled",
+# with no further push to re-trigger a clean run, so the badge stays red even
+# though nothing actually broke. Seen on 2026-08-10: PRs #1963, #1965, #1996,
+# and #1997 landed within ~2 hours and left the last completed run "cancelled".
+# A follow-up push (like this one) is the only way to clear it.
+
 permissions:
   contents: read
   actions: read


### PR DESCRIPTION
## Summary
- The StaffML README badge has been red since ~21:08 UTC on 2026-08-10, but the last few pushes to `dev` did not actually break anything: PRs #1963, #1965, #1996, #1997 landed within about two hours of each other, and `staffml-preview-dev.yml`'s `cancel-in-progress: true` group kept cancelling the in-flight run each time a newer push landed.
- The badge (`shields.io`, `event=push`) reports the latest run's conclusion, and it renders `cancelled` the same as a real failure, so the badge shows "failing" even though no job actually errored.
- Adds a comment next to the `paths:` trigger list explaining this, for the next person who sees a red badge and assumes something broke.
- Note: this workflow only triggers on `push` to `dev` (plus manual `workflow_dispatch`), not on pull requests, so this PR itself won't run it. Merging it will, since the changed file is in the trigger paths, and that push should leave a clean run on `dev` and clear the badge.

## Test plan
- [ ] After merge, confirm the `StaffML - Preview (Dev)` run on `dev` completes green and the README badge updates