### PR TITLE
fix(mlsysim): surface load errors via last_load_error on DesignLedger

### DIFF
--- a/labs/tests/test_wasm_persistence.py
+++ b/labs/tests/test_wasm_persistence.py
@@ -46,6 +46,8 @@ from pathlib import Path
 
 import pytest
 
+import json
+
 STATE_PY = (
     Path(__file__).resolve().parents[2] / "mlsysim" / "mlsysim" / "labs" / "state.py"
 )
@@ -205,3 +207,145 @@ await ledger.save_async()
         f"from #1985 / PR #1988. A mocked test cannot catch this; only a "
         f"real Pyodide + IndexedDB check like this one can."
     )
+
+def test_load_async_corrupt_record_sets_last_load_error(served_dir):
+    """A stored record exists but is corrupt JSON -- json.loads() raising
+    is a Python-side failure independent of the JS resolve/reject shape,
+    so last_load_error must be populated regardless of #1988's status."""
+    from playwright.sync_api import sync_playwright
+
+    _, port = served_dir
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        context = browser.new_context()
+        try:
+            page = context.new_page()
+            init_errors: list[str] = []
+            page.on(
+                "pageerror",
+                lambda exc, errors=init_errors: errors.append(str(exc)),
+            )
+
+            page.goto(f"http://127.0.0.1:{port}/index.html")
+            page.wait_for_function(
+                "window.__ready === true || window.__initError", timeout=30_000
+            )
+            init_error = page.evaluate("window.__initError || null")
+            assert not init_error, f"Pyodide init failed: {init_error}"
+            assert not init_errors, f"Uncaught page errors during init: {init_errors}"
+
+            page.evaluate(
+                """
+                () => new Promise((resolve) => {
+                    const req = indexedDB.deleteDatabase("mlsys_ledger_db");
+                    req.onsuccess = req.onerror = req.onblocked = () => resolve();
+                })
+                """
+            )
+
+            # Seed a corrupt record directly at the storage layer.
+            page.evaluate(
+                """
+                () => new Promise((resolve, reject) => {
+                    const req = indexedDB.open("mlsys_ledger_db", 1);
+                    req.onupgradeneeded = (e) => {
+                        const db = e.target.result;
+                        if (!db.objectStoreNames.contains("ledger")) {
+                            db.createObjectStore("ledger");
+                        }
+                    };
+                    req.onsuccess = (e) => {
+                        const db = e.target.result;
+                        const tx = db.transaction("ledger", "readwrite");
+                        tx.objectStore("ledger").put("{not valid json", "mlsys_design_ledger");
+                        tx.oncomplete = () => { db.close(); resolve(); };
+                        tx.onerror = () => { db.close(); reject(tx.error); };
+                    };
+                    req.onerror = () => reject(req.error);
+                })
+                """
+            )
+
+            result = page.evaluate(
+                """
+                async () => {
+                    const pyodide = window.__pyodide;
+                    return await pyodide.runPythonAsync(`
+import json
+ledger = DesignLedger()
+await ledger.load_async()
+json.dumps({"error": ledger.last_load_error})
+`);
+                }
+                """
+            )
+            page.close()
+        finally:
+            context.close()
+            browser.close()
+
+    parsed = json.loads(result)
+    assert parsed["error"] is not None, (
+        "load_async() must surface a corrupt-JSON read failure via "
+        "last_load_error instead of silently returning a blank LedgerState()."
+    )
+
+
+def test_load_async_synchronous_indexeddb_open_throw_sets_last_load_error(served_dir):
+    """indexedDB.open() throwing synchronously must reject the Promise
+    (per the Promise constructor spec) and propagate to last_load_error --
+    true today even against the pre-#1988 resolve(null)-style onerror
+    handlers, since this never reaches those handlers at all."""
+    from playwright.sync_api import sync_playwright
+
+    _, port = served_dir
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        context = browser.new_context()
+        try:
+            page = context.new_page()
+            init_errors: list[str] = []
+            page.on(
+                "pageerror",
+                lambda exc, errors=init_errors: errors.append(str(exc)),
+            )
+
+            page.goto(f"http://127.0.0.1:{port}/index.html")
+            page.wait_for_function(
+                "window.__ready === true || window.__initError", timeout=30_000
+            )
+            init_error = page.evaluate("window.__initError || null")
+            assert not init_error, f"Pyodide init failed: {init_error}"
+            assert not init_errors, f"Uncaught page errors during init: {init_errors}"
+
+            page.evaluate(
+                """() => {
+                    window.indexedDB.open = () => {
+                        throw new Error('Simulated synchronous IndexedDB failure');
+                    };
+                }"""
+            )
+
+            result = page.evaluate(
+                """
+                async () => {
+                    const pyodide = window.__pyodide;
+                    return await pyodide.runPythonAsync(`
+import json
+ledger = DesignLedger()
+await ledger.load_async()
+json.dumps({"error": ledger.last_load_error})
+`);
+                }
+                """
+            )
+            page.close()
+        finally:
+            context.close()
+            browser.close()
+
+    parsed = json.loads(result)
+    assert parsed["error"] is not None
+    assert "Simulated synchronous IndexedDB failure" in parsed["error"]

--- a/labs/tests/test_wasm_persistence.py
+++ b/labs/tests/test_wasm_persistence.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 
 import functools
 import http.server
+import json
 import shutil
 import socketserver
 import threading
@@ -46,7 +47,6 @@ from pathlib import Path
 
 import pytest
 
-import json
 
 STATE_PY = (
     Path(__file__).resolve().parents[2] / "mlsysim" / "mlsysim" / "labs" / "state.py"
@@ -207,6 +207,7 @@ await ledger.save_async()
         f"from #1985 / PR #1988. A mocked test cannot catch this; only a "
         f"real Pyodide + IndexedDB check like this one can."
     )
+
 
 def test_load_async_corrupt_record_sets_last_load_error(served_dir):
     """A stored record exists but is corrupt JSON -- json.loads() raising

--- a/mlsysim/mlsysim/labs/state.py
+++ b/mlsysim/mlsysim/labs/state.py
@@ -31,6 +31,7 @@ class DesignLedger:
         self.file_path = self.config_dir / "ledger.json"
 
         self._state = LedgerState()
+        self._last_load_error: Optional[str] = None
 
         # WASM save tasks remain tracked until flush() observes them. Keeping
         # completed tasks lets a later flush() re-raise persistence failures.
@@ -48,6 +49,11 @@ class DesignLedger:
         if any.
         """
         return self._last_save_error
+
+    @property
+    def last_load_error(self) -> Optional[str]:
+        """Error message from the most recent failed load."""
+        return self._last_load_error
 
     @property
     def save_pending(self) -> bool:
@@ -75,6 +81,7 @@ class DesignLedger:
 
     def load(self) -> LedgerState:
         """Loads the ledger from the best available persistent storage."""
+        self._last_load_error = None
 
         # WASM loading is asynchronous, so synchronous load()
         # simply returns the current in-memory state.
@@ -88,10 +95,10 @@ class DesignLedger:
                     data = json.load(f)
 
                 data["history"] = self._parse_history(data)
-
                 self._state = LedgerState(**data)
 
-            except Exception:
+            except Exception as e:
+                self._last_load_error = f"{type(e).__name__}: {e}"
                 self._state = LedgerState()
 
         return self._state
@@ -100,6 +107,7 @@ class DesignLedger:
         """
         Async load for WASM environments using IndexedDB.
         """
+        self._last_load_error = None
 
         if not self.is_wasm:
             return self.load()
@@ -187,14 +195,12 @@ class DesignLedger:
 
             if raw:
                 data = json.loads(raw)
-
                 data["history"] = self._parse_history(data)
-
                 self._state = LedgerState(**data)
 
         except Exception as e:
+            self._last_load_error = f"{type(e).__name__}: {e}"
             print(f"Failed to load from IndexedDB: {e}")
-
             self._state = LedgerState()
 
         return self._state

--- a/mlsysim/tests/test_state.py
+++ b/mlsysim/tests/test_state.py
@@ -1,4 +1,5 @@
-"""Tests for DesignLedger persistence (mlsysim/labs/state.py).
+"""
+Tests for DesignLedger persistence (mlsysim/labs/state.py).
 
 Covers the WASM background-save failure path fixed in #1985: previously
 `save()` used `asyncio.create_task(...)` fire-and-forget, so IndexedDB
@@ -122,3 +123,122 @@ def test_asave_raises_on_failure_directly(tmp_path, monkeypatch):
             await ledger.asave(step=2, design={"x": 1})
 
     asyncio.run(run())
+
+"""
+DesignLedger persistence — read-path error handling (#1994).
+
+DesignLedger.load() previously reset to a blank LedgerState() on any read
+failure -- missing file, corrupt JSON, permissions error -- with no way
+for calling code to distinguish "first run, nothing saved yet" (expected)
+from "a save file exists but couldn't be read" (real data loss). This
+mirrors the write-path fix in #1988/last_save_error: last_load_error now
+surfaces read failures instead of silently discarding them.
+
+This file covers the native/local-filesystem path only. The WASM/
+IndexedDB path is covered separately in labs/tests/test_wasm_persistence.py,
+since that failure mode requires a real browser and can't be meaningfully
+mocked here.
+
+Usage
+-----
+    python3 -m pytest mlsysim/tests/test_state.py -v
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+from mlsysim.labs.state import DesignLedger, LedgerState
+
+
+@pytest.fixture
+def ledger(tmp_path, monkeypatch):
+    """A DesignLedger whose config_dir/file_path live under a throwaway
+    tmp_path instead of the real ~/.mlsys, so tests never touch (or race
+    against) a developer's actual saved progress."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    return DesignLedger()
+
+
+def test_init_does_not_raise(tmp_path, monkeypatch):
+    """Regression guard: last_load_error is a read-only @property backed
+    by _last_load_error. Assigning self.last_load_error = ... anywhere
+    (including __init__) raises AttributeError immediately, since the
+    property has no setter. This is the exact bug that would otherwise
+    only surface at runtime, not at review time."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    DesignLedger()  # must not raise
+
+
+def test_load_missing_file_is_not_an_error(ledger):
+    """First run for a student -- no ledger.json exists yet. This is
+    expected, not a failure, and must not populate last_load_error."""
+    state = ledger.load()
+    assert isinstance(state, LedgerState)
+    assert ledger.last_load_error is None
+
+
+def test_load_corrupt_file_sets_last_load_error(ledger):
+    """A save file exists but isn't valid JSON -- e.g. truncated by a
+    crash mid-write. Must fail safe (blank state, no crash) but the
+    failure must be visible via last_load_error, not silently discarded."""
+    ledger.config_dir.mkdir(exist_ok=True)
+    ledger.file_path.write_text("{not valid json")
+
+    state = ledger.load()
+
+    assert isinstance(state, LedgerState)
+    assert ledger.last_load_error is not None
+    assert "json" in ledger.last_load_error.lower() or "JSON" in ledger.last_load_error
+
+
+def test_load_corrupt_file_resets_to_blank_state(ledger):
+    """A corrupt file must not leave stale/partial in-memory state around
+    -- the fallback is a fresh LedgerState(), not a half-populated one."""
+    ledger.config_dir.mkdir(exist_ok=True)
+    ledger.file_path.write_text("{not valid json")
+
+    state = ledger.load()
+
+    assert state.track is None
+    assert state.current_step == 0
+    assert state.history == {}
+
+
+def test_load_valid_file_clears_previous_error(ledger):
+    """last_load_error must reset on a subsequent successful load --
+    it's a snapshot of the *most recent* attempt, not sticky forever."""
+    ledger.config_dir.mkdir(exist_ok=True)
+    ledger.file_path.write_text("{not valid json")
+    ledger.load()
+    assert ledger.last_load_error is not None
+
+    ledger.file_path.write_text(json.dumps({
+        "track": "edge",
+        "current_step": 3,
+        "history": {},
+        "last_updated": "2026-08-10T00:00:00",
+    }))
+    state = ledger.load()
+
+    assert ledger.last_load_error is None
+    assert state.track == "edge"
+    assert state.current_step == 3
+
+
+def test_load_valid_file_round_trips_history(ledger):
+    """Sanity check that the happy path (already-existing behavior)
+    wasn't broken by the error-handling changes."""
+    ledger.config_dir.mkdir(exist_ok=True)
+    ledger.file_path.write_text(json.dumps({
+        "track": "cloud",
+        "current_step": 5,
+        "history": {"1": {"choice": "gpu"}, "5": {"choice": "spot"}},
+        "last_updated": "2026-08-10T00:00:00",
+    }))
+
+    state = ledger.load()
+
+    assert ledger.last_load_error is None
+    assert state.history[1] == {"choice": "gpu"}
+    assert state.history[5] == {"choice": "spot"}

--- a/mlsysim/tests/test_state.py
+++ b/mlsysim/tests/test_state.py
@@ -12,7 +12,10 @@ import asyncio
 
 import pytest
 
-from mlsysim.labs.state import DesignLedger
+import json
+from pathlib import Path
+
+from mlsysim.labs.state import DesignLedger, LedgerState
 import mlsysim.labs.state as state_mod
 
 
@@ -124,41 +127,9 @@ def test_asave_raises_on_failure_directly(tmp_path, monkeypatch):
 
     asyncio.run(run())
 
-"""
-DesignLedger persistence — read-path error handling (#1994).
 
-DesignLedger.load() previously reset to a blank LedgerState() on any read
-failure -- missing file, corrupt JSON, permissions error -- with no way
-for calling code to distinguish "first run, nothing saved yet" (expected)
-from "a save file exists but couldn't be read" (real data loss). This
-mirrors the write-path fix in #1988/last_save_error: last_load_error now
-surfaces read failures instead of silently discarding them.
-
-This file covers the native/local-filesystem path only. The WASM/
-IndexedDB path is covered separately in labs/tests/test_wasm_persistence.py,
-since that failure mode requires a real browser and can't be meaningfully
-mocked here.
-
-Usage
------
-    python3 -m pytest mlsysim/tests/test_state.py -v
-"""
-import json
-from pathlib import Path
-
-import pytest
-
-from mlsysim.labs.state import DesignLedger, LedgerState
-
-
-@pytest.fixture
-def ledger(tmp_path, monkeypatch):
-    """A DesignLedger whose config_dir/file_path live under a throwaway
-    tmp_path instead of the real ~/.mlsys, so tests never touch (or race
-    against) a developer's actual saved progress."""
-    monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    return DesignLedger()
-
+"""--- Read-path error handling (#1994) ---
+Native/local-filesystem path only. WASM/IndexedDB is covered separately in labs/tests/test_wasm_persistence.py."""
 
 def test_init_does_not_raise(tmp_path, monkeypatch):
     """Regression guard: last_load_error is a read-only @property backed
@@ -166,22 +137,23 @@ def test_init_does_not_raise(tmp_path, monkeypatch):
     (including __init__) raises AttributeError immediately, since the
     property has no setter. This is the exact bug that would otherwise
     only surface at runtime, not at review time."""
-    monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    DesignLedger()  # must not raise
+    _ledger_with_home(monkeypatch, tmp_path)  # must not raise
 
 
-def test_load_missing_file_is_not_an_error(ledger):
+def test_load_missing_file_is_not_an_error(tmp_path, monkeypatch):
     """First run for a student -- no ledger.json exists yet. This is
-    expected, not a failure, and must not populate last_load_error."""
+        expected, not a failure, and must not populate last_load_error."""
+    ledger = _ledger_with_home(monkeypatch, tmp_path)
     state = ledger.load()
     assert isinstance(state, LedgerState)
     assert ledger.last_load_error is None
 
 
-def test_load_corrupt_file_sets_last_load_error(ledger):
+def test_load_corrupt_file_sets_last_load_error(tmp_path, monkeypatch):
     """A save file exists but isn't valid JSON -- e.g. truncated by a
     crash mid-write. Must fail safe (blank state, no crash) but the
     failure must be visible via last_load_error, not silently discarded."""
+    ledger = _ledger_with_home(monkeypatch, tmp_path)
     ledger.config_dir.mkdir(exist_ok=True)
     ledger.file_path.write_text("{not valid json")
 
@@ -189,12 +161,13 @@ def test_load_corrupt_file_sets_last_load_error(ledger):
 
     assert isinstance(state, LedgerState)
     assert ledger.last_load_error is not None
-    assert "json" in ledger.last_load_error.lower() or "JSON" in ledger.last_load_error
+    assert "json" in ledger.last_load_error.lower()
 
 
-def test_load_corrupt_file_resets_to_blank_state(ledger):
+def test_load_corrupt_file_resets_to_blank_state(tmp_path, monkeypatch):
     """A corrupt file must not leave stale/partial in-memory state around
     -- the fallback is a fresh LedgerState(), not a half-populated one."""
+    ledger = _ledger_with_home(monkeypatch, tmp_path)
     ledger.config_dir.mkdir(exist_ok=True)
     ledger.file_path.write_text("{not valid json")
 
@@ -205,9 +178,10 @@ def test_load_corrupt_file_resets_to_blank_state(ledger):
     assert state.history == {}
 
 
-def test_load_valid_file_clears_previous_error(ledger):
+def test_load_valid_file_clears_previous_error(tmp_path, monkeypatch):
     """last_load_error must reset on a subsequent successful load --
     it's a snapshot of the *most recent* attempt, not sticky forever."""
+    ledger = _ledger_with_home(monkeypatch, tmp_path)
     ledger.config_dir.mkdir(exist_ok=True)
     ledger.file_path.write_text("{not valid json")
     ledger.load()
@@ -226,9 +200,10 @@ def test_load_valid_file_clears_previous_error(ledger):
     assert state.current_step == 3
 
 
-def test_load_valid_file_round_trips_history(ledger):
+def test_load_valid_file_round_trips_history(tmp_path, monkeypatch):
     """Sanity check that the happy path (already-existing behavior)
     wasn't broken by the error-handling changes."""
+    ledger = _ledger_with_home(monkeypatch, tmp_path)
     ledger.config_dir.mkdir(exist_ok=True)
     ledger.file_path.write_text(json.dumps({
         "track": "cloud",


### PR DESCRIPTION
## Summary

Fixes #1994. `DesignLedger.load()`/`load_async()` previously reset silently
to a blank `LedgerState()` on any read failure (missing file, corrupt JSON,
IndexedDB error), with no way for calling code to distinguish "first run,
nothing saved yet" from "a save exists but couldn't be read" — a silent
data-loss bug on the read path. Adds `last_load_error`, mirroring the
`last_save_error` pattern #1988 established on the write path.

## Area

- [ ] Book (textbook content, figures, exercises)
- [ ] TinyTorch (modules, tests, milestones)
- [ ] StaffML (interview questions, challenges)
- [ ] Kits (hardware labs)
- [x] Infrastructure (CI/CD, scripts, config)

(No box above quite fits `mlsysim`/Co-Labs specifically — checking
Infrastructure as the closest match. Actual area: `mlsysim/mlsysim/labs/`
and `labs/tests/`.)

## Changes

- `mlsysim/mlsysim/labs/state.py`: add `_last_load_error` + read-only
  `last_load_error` property; set it in `load()` and `load_async()`'s
  except blocks instead of discarding the exception.
- `mlsysim/tests/test_state.py`: add native-path regression tests
  (missing file is not an error, corrupt file sets `last_load_error` and
  falls back to blank state, error clears on next successful load).
- `labs/tests/test_wasm_persistence.py`: add two real-browser
  (Playwright + Chromium + Pyodide) regression tests for `load_async()` —
  corrupt IndexedDB record, and `indexedDB.open()` throwing synchronously —
  reusing the `served_dir` fixture #1988 introduced.

Rebased cleanly onto `dev` after #1988 merged; no leftover conflicts.

## Testing

<!-- How did you verify this works? -->

- [ ] Rendered the book locally (`quarto render`)
- [x] Ran tests (`pytest tests/`)
- [ ] Ran `tito module test NN` for affected module(s)
- [ ] Manual verification (describe below)

Ran explicitly:
```
python -m pytest mlsysim/tests/test_state.py -v      # 11 passed
python -m pytest labs/tests/test_wasm_persistence.py -v   # 3 passed (real Chromium)
```