### PR TITLE
fix(tinytorch): tito module start/view falsely report success on a missing notebook

### DIFF
--- a/tinytorch/tito/commands/module/workflow.py
+++ b/tinytorch/tito/commands/module/workflow.py
@@ -323,9 +323,15 @@ class ModuleWorkflowCommand(BaseCommand):
                 return 1
 
         # Prerequisites met! Check if module needs to be created from src/
-        # Notebooks are in modules/ directory, not src/ (which is modules_dir in config)
+        # Notebooks are in modules/ directory, not src/ (which is modules_dir in config).
+        # Check for the notebook file itself, not just the directory: a directory
+        # can exist but be empty if a previous conversion attempt failed partway
+        # (e.g. jupytext wasn't on PATH yet), and directory-existence alone would
+        # then make this look already done, silently skipping regeneration.
         module_dir = self.config.project_root / "modules" / module_name
-        if not module_dir.exists():
+        short_name = module_name.split("_", 1)[1] if "_" in module_name else module_name
+        notebook_file = module_dir / f"{short_name}.ipynb"
+        if not notebook_file.exists():
             # Create module from src/ using export
             src_dir = self.config.project_root / "src" / module_name
             if not src_dir.exists():
@@ -407,10 +413,15 @@ class ModuleWorkflowCommand(BaseCommand):
             return 1
 
         module_name = module_mapping[normalized]
-        # Notebooks are in modules/ directory, not src/ (which is modules_dir in config)
+        # Notebooks are in modules/ directory, not src/ (which is modules_dir in config).
+        # Check for the notebook file itself, not just the directory: see the
+        # matching comment in start_module for why directory-existence alone is
+        # not a reliable signal that a notebook actually exists.
         module_dir = self.config.project_root / "modules" / module_name
+        short_name = module_name.split("_", 1)[1] if "_" in module_name else module_name
+        notebook_file = module_dir / f"{short_name}.ipynb"
 
-        if not module_dir.exists():
+        if not notebook_file.exists():
             self.console.print(f"[yellow]⚠️  Module {normalized} not started yet[/yellow]")
             self.console.print(f"💡 Run: [bold cyan]tito module start {normalized}[/bold cyan]")
             return 1


### PR DESCRIPTION
## Bug

If `tito module start N`'s notebook conversion fails partway (e.g. jupytext not yet on PATH because the venv wasn't activated), a retry after fixing the real problem silently reports "Module ready (notebook created)" with no notebook actually written. `tito module complete N` then fails confusingly with "Notebook not found." `tito module view N` on the same broken module opens a blank Jupyter Lab shell instead of telling the student anything is wrong.

## Root cause

`convert_py_to_notebook` (`export_utils.py`) creates `modules/<name>/` via `mkdir(parents=True, exist_ok=True)` before jupytext is invoked or its result is checked, so the directory persists even when conversion fails. `start_module` and `view_module` (`workflow.py`) both used `module_dir.exists()` as their "is this module already set up" check. Directory-existence stopped being a reliable signal for "the notebook was actually created" the moment a failed attempt left an empty directory behind.

## Fix

Check for the actual notebook file (`module_dir / f"{short_name}.ipynb"`) instead of just the containing directory, in both `start_module` and `view_module`.

## Testing

Verified against a fresh `dev` install with all 20 modules completed, by deleting a module's notebook file while leaving its directory in place (simulating a partial failure):
- `tito module start N`: before the fix, reported "Module ready (notebook created)" with no file written. After the fix, correctly detects the missing notebook, regenerates it via `_create_module_from_src`, and the file genuinely exists afterward.
- `tito module view N`: before the fix, opened Jupyter Lab with no notebook loaded. After the fix, reports "Module not started yet" and points at `tito module start N`, consistent with a module that was never set up.

## Test plan

- [ ] Delete a module's `.ipynb` while keeping its directory, run `tito module start N`, confirm it regenerates the notebook instead of falsely reporting success
- [ ] Same setup, run `tito module view N`, confirm it reports "not started yet" instead of opening a blank Jupyter shell