### PR TITLE
fix(tinytorch): tito login does not exist, real command is tito community login

### DIFF
--- a/tinytorch/tito/commands/community.py
+++ b/tinytorch/tito/commands/community.py
@@ -103,7 +103,7 @@ class CommunityCommand(BaseCommand):
             self.console.print(Panel(
                 "[yellow]You are currently not logged in.[/yellow]\n\n"
                 "To join the leaderboard and sync progress:\n"
-                "  [bold green]tito login[/bold green]",
+                "  [bold green]tito community login[/bold green]",
                 title="❌ Not Authenticated",
                 border_style="red",
                 box=box.ROUNDED
@@ -118,7 +118,7 @@ class CommunityCommand(BaseCommand):
         'tito community sync' to push their current progress.json at any time.
         """
         if not auth.is_logged_in():
-            self.console.print("[yellow]You are not logged in.[/yellow] Run [bold green]tito login[/bold green] first, then sync.")
+            self.console.print("[yellow]You are not logged in.[/yellow] Run [bold green]tito community login[/bold green] first, then sync.")
             return 1
 
         handler = SubmissionHandler(self.config, self.console)

--- a/tinytorch/tito/core/submission.py
+++ b/tinytorch/tito/core/submission.py
@@ -167,7 +167,7 @@ class SubmissionHandler:
         """
         token = self.auth_handler.get_token()
         if not token:
-            self.console.print("❌ [bold red]You are not logged in.[/bold red] Please run 'tito login' first.")
+            self.console.print("❌ [bold red]You are not logged in.[/bold red] Please run 'tito community login' first.")
             return SyncResult(ok=False, error="not logged in")
 
         if not is_retry:
@@ -252,11 +252,11 @@ class SubmissionHandler:
                     return self.sync_progress(total_modules=total_modules, is_retry=True)
                 else:
                     self.console.print("❌ [bold red]Token refresh failed.[/bold red]")
-                    self.console.print("   Run 'tito login --force' to refresh.")
+                    self.console.print("   Run 'tito community login --force' to refresh.")
                     return SyncResult(ok=False, error="token refresh failed")
             elif e.code == 401 and is_retry:
                 self.console.print("❌ [bold red]Unauthorized.[/bold red] Your session may have expired.")
-                self.console.print("   Run 'tito login --force' to refresh.")
+                self.console.print("   Run 'tito community login --force' to refresh.")
                 return SyncResult(ok=False, error="unauthorized after refresh")
             else:
                 self.console.print(f"❌ [red]Upload failed (HTTP {e.code}): {e.reason}[/red]")
@@ -328,7 +328,7 @@ def auto_sync_after_completion(config: CLIConfig, console: Console, *,
         return None
 
     if not auth.is_logged_in():
-        console.print("[dim]💡 Run 'tito login' to sync your progress to the TinyTorch website.[/dim]")
+        console.print("[dim]💡 Run 'tito community login' to sync your progress to the TinyTorch website.[/dim]")
         return None
 
     if runtime.is_interactive():


### PR DESCRIPTION
## Bug

Every module and milestone completion (20+ times in a full run) prints "Run 'tito login' to sync your progress" or similar. Running that exact command fails with "'login' is not a valid command." The real, registered command is `tito community login`.

## Root cause

Six call sites across `commands/community.py` and `core/submission.py` hardcode the string `tito login` in user-facing messages, none of which match the actual command tree (`login` is a subcommand of `community`, not a top-level command).

## Fix

Updated all six occurrences to `tito community login` (including the `--force` variant used for token refresh messages), matching the command that actually exists and already works.

## Testing

Verified against a fresh `dev` install: `tito community status` and `tito module complete N` now correctly print `tito community login` in their hints. Confirmed via grep that zero `tito login` references remain anywhere in `tinytorch/tito/`.

## Test plan

- [ ] `tito community status` while logged out, confirm the hint says `tito community login`
- [ ] `tito module complete N`, confirm the closing hint says `tito community login`
- [ ] `grep -rn "tito login" tinytorch/tito/` returns nothing