### PR TITLE
fix(tinytorch): tito setup ignores TINYTORCH_NON_INTERACTIVE, crashes with EOFError

### DIFF
--- a/tinytorch/tito/commands/setup.py
+++ b/tinytorch/tito/commands/setup.py
@@ -529,6 +529,16 @@ class SetupCommand(BaseCommand):
              self.console.print("\n[green]✅ You are already connected to the TinyTorch community.[/green]")
              return
 
+        # Unlike install.sh (which honors this for its own prompts), tito setup
+        # never checked this env var, so a fully unattended run (CI, scripted
+        # setup, no stdin) crashed here with "EOF when reading a line" instead
+        # of skipping the prompt like every other TINYTORCH_NON_INTERACTIVE=1
+        # invocation is supposed to.
+        if os.environ.get("TINYTORCH_NON_INTERACTIVE"):
+            self.console.print("\n[dim]Skipping community prompt (TINYTORCH_NON_INTERACTIVE set). "
+                                "You can join anytime with: tito community login[/dim]")
+            return
+
         self.console.print()
         self.console.print(Panel.fit(
             "[bold cyan]🌍 Join the TinyTorch Community[/bold cyan]\n\n"


### PR DESCRIPTION
## Bug

`install.sh` honors `TINYTORCH_NON_INTERACTIVE=1` to skip all prompts (for CI or scripted installs), but `tito setup` itself never checked this env var anywhere. A fully unattended run of `tito setup` (no piped stdin) still hit the interactive "Join the community?" prompt and crashed with "Setup failed: EOF when reading a line" instead of completing.

## Root cause

`prompt_community_registration()` calls `Confirm.ask()` unconditionally once a user isn't already logged in, with no check of `TINYTORCH_NON_INTERACTIVE` at all.

## Fix

Skip the prompt and print a short informational message (with the correct `tito community login` pointer) when `TINYTORCH_NON_INTERACTIVE` is set, before ever reaching `Confirm.ask()`.

## Testing

Verified against a fresh `dev` install:
```
TINYTORCH_NON_INTERACTIVE=1 tito setup < /dev/null
```
Before: crashed with "Setup failed: EOF when reading a line".
After: completes cleanly, printing "Skipping community prompt (TINYTORCH_NON_INTERACTIVE set). You can join anytime with: tito community login".

## Test plan

- [ ] `TINYTORCH_NON_INTERACTIVE=1 tito setup < /dev/null` on a fresh checkout, confirm it completes without crashing
- [ ] `tito setup` without the env var, confirm the interactive prompt still appears as before