### PR TITLE
fix(tinytorch): tito package reset is unreachable

### DIFF
--- a/tinytorch/tito/commands/package/reset.py
+++ b/tinytorch/tito/commands/package/reset.py
@@ -22,6 +22,11 @@ class ResetCommand(BaseCommand):
         return "Reset package files or user progress data"
 
     def add_arguments(self, parser: ArgumentParser) -> None:
+        # Lets bare `tito package reset [--force]` (with no SUBCOMMAND token)
+        # reset the package directly, matching the "tito package reset --force"
+        # example in PackageCommand's own help text.
+        parser.add_argument("--force", action="store_true", help="Skip confirmation prompt (resets the package)")
+
         subparsers = parser.add_subparsers(
             dest='reset_command',
             help='Reset subcommands',
@@ -70,19 +75,22 @@ class ResetCommand(BaseCommand):
         console = self.console
 
         if not hasattr(args, 'reset_command') or not args.reset_command:
+            # No SUBCOMMAND given: default to resetting the package, matching
+            # PackageCommand's own documented "tito package reset --force"
+            # example and this command's top-level description ("Reset
+            # tinytorch package to clean state"). The other reset types
+            # (all/progress/milestones/config) are still reachable as
+            # tito package reset <type>, listed below for discoverability.
             console.print(Panel(
-                "[bold cyan]Reset Commands[/bold cyan]\n\n"
-                "Available subcommands:\n"
-                "  • [bold]package[/bold]     - Reset tinytorch package (remove exported files)\n"
-                "  • [bold]all[/bold]         - Reset all user progress (modules + milestones + config)\n"
-                "  • [bold]progress[/bold]    - Reset module completion tracking only\n"
-                "  • [bold]milestones[/bold]  - Reset milestone achievements only\n"
-                "  • [bold]config[/bold]      - Reset configuration to defaults\n\n"
-                "[dim]Example: tito reset progress --backup[/dim]",
+                "[dim]Other reset types available:[/dim]\n"
+                "[dim]  • tito package reset all         - Reset all user progress (modules + milestones + config)[/dim]\n"
+                "[dim]  • tito package reset progress    - Reset module completion tracking only[/dim]\n"
+                "[dim]  • tito package reset milestones  - Reset milestone achievements only[/dim]\n"
+                "[dim]  • tito package reset config      - Reset configuration to defaults[/dim]",
                 title="Reset Command Group",
                 border_style="bright_yellow"
             ))
-            return 0
+            return self._reset_package(args)
 
         # Execute the appropriate subcommand
         if args.reset_command == 'package':


### PR DESCRIPTION
## Bug

`tito package reset` (with or without piped input) does nothing but print a generic help panel every time, regardless of input. The documented example in `PackageCommand`'s own help text, `tito package reset --force`, silently does nothing at all.

## Root cause

`ResetCommand` was written as if it would be registered as its own top-level `tito reset <subcommand>` command: its `name` property returns `"reset"`, and its own help text says `tito reset progress --backup`. It is actually only ever mounted at `tito package reset`. By the time argparse reaches this class's own `add_subparsers()` call, both the `package` and `reset` tokens are already consumed by the parent parser, so a bare `tito package reset` never has a SUBCOMMAND token left to match, and `args.reset_command` is always unset. The only way to actually trigger a reset was the undocumented double-noun `tito package reset package --force`.

## Fix

- Added a `--force` argument directly on the reset parser itself (not just on each sub-subparser), so it's available for a bare invocation.
- Bare `tito package reset [--force]` (no SUBCOMMAND) now defaults to resetting the package, matching `PackageCommand`'s own documented example and this command's stated top-level purpose ("Reset tinytorch package to clean state"). It still shows the other reset types (`all`/`progress`/`milestones`/`config`) for discoverability, then proceeds with the actual package reset (still gated behind its own confirmation prompt unless `--force` is passed).
- `tito package reset package --force` (the old double-noun form) still works unchanged.

## Testing

Verified against a fresh `dev` install with all 20 modules exported:
- `tito package reset`, answering "n": shows the confirmation prompt and correctly cancels. Before the fix, this printed only the self-referential help panel and never reached a confirmation at all.
- `tito package reset --force`: correctly removes all 20 generated package files, matching the documented example exactly.
- `tito package reset package --force`: still works as before.

## Test plan

- [ ] `tito package reset`, confirm it shows a real confirmation prompt (not just a help panel)
- [ ] `tito package reset --force`, confirm it actually removes exported package files
- [ ] `tito package reset package --force`, confirm the old form still works