### PR TITLE
fix(tinytorch): tito system health's Module Status section shows the wrong thing

### DIFF
--- a/tinytorch/tito/commands/system/health.py
+++ b/tinytorch/tito/commands/system/health.py
@@ -240,17 +240,31 @@ class HealthCommand(BaseCommand):
         console.print(struct_table)
         console.print()
 
-        # Module implementations
-        console.print(Panel("📋 Implementation Status",
-                           title="Module Status", border_style="bright_blue"))
+        # Module implementations. This used to reinvoke InfoCommand here,
+        # which just reprints the System Details table above a second time
+        # (Python version, disk space, memory) -- nothing module-related --
+        # instead of actual per-module status. Read the real completion
+        # data directly instead.
+        from ..module.workflow import ModuleWorkflowCommand
+        from ...core.modules import get_module_mapping
 
-        # Import and run the info command to show module status
-        from .info import InfoCommand
-        info_cmd = InfoCommand(self.config)
-        info_args = ArgumentParser()
-        info_cmd.add_arguments(info_args)
-        info_args = info_args.parse_args([])  # Empty args for info
-        return info_cmd.run(info_args)
+        module_mapping = get_module_mapping()
+        progress = ModuleWorkflowCommand(self.config).get_progress_data()
+        completed = progress.get('completed_modules', [])
+        completed_count = len(completed)
+        total_count = len(module_mapping)
+
+        status_text = f"[bold]{completed_count}/{total_count}[/bold] modules completed"
+        if completed_count < total_count:
+            next_modules = [m for m in sorted(module_mapping) if m not in completed]
+            if next_modules:
+                status_text += f"\n[dim]Next: tito module start {next_modules[0]}[/dim]"
+        else:
+            status_text += "\n[dim]All modules complete![/dim]"
+
+        console.print(Panel(status_text,
+                           title="📋 Module Status", border_style="bright_blue"))
+        return 0
 
     def _check_jupyter_kernel(self):
         """Check if a TinyTorch Jupyter kernel is registered."""


### PR DESCRIPTION
## Bug

`tito system health`'s final section is titled "Module Status" / "Implementation Status", but instead of showing per-module status it imports and reruns `InfoCommand` (`tito system info`), printing a full duplicate of the unrelated System Details table (Python version, disk space, memory) a second time in the same command's output. Nothing module-related is actually shown.

## Fix

Replaced the `InfoCommand` call with a real, concise module-completion summary: read `.tito/progress.json` directly (via the same `get_progress_data()` method `tito module status` itself uses) and show completed/total counts plus the next module to start, or a "All modules complete!" message once done.

## Testing

Verified against a fresh `dev` install with all 20 modules completed: before, the Module Status section printed a second full System Details table (Python 3.14.4, disk space, memory, etc.) instead of anything module-related. After, it correctly shows "20/20 modules completed / All modules complete!".

## Test plan

- [ ] `tito system health` on a checkout with some modules complete, confirm the final section shows a real completion count, not a duplicate System Info table
- [ ] Same on a checkout with all 20 modules complete, confirm "All modules complete!" shows correctly