### PR TITLE
fix(tinytorch): milestone achievement panel claims autograd before it's built

### DIFF
--- a/tinytorch/tito/commands/milestone.py
+++ b/tinytorch/tito/commands/milestone.py
@@ -152,6 +152,44 @@ MILESTONE_SCRIPTS = {
     }
 }
 
+# "What makes this special" bullets for the achievement panel, tailored to
+# what each milestone's required_modules actually cover. Previously every
+# milestone showed the same 3 lines including "Every gradient: YOUR
+# autograd", which was wrong for 01 and 02 (forward-pass only, no autograd
+# module required at all).
+MILESTONE_ACHIEVEMENT_HIGHLIGHTS = {
+    "01": [
+        "Every line of code: YOUR implementations",
+        "Every tensor operation: YOUR Tensor class",
+        "Every forward pass: YOUR Layers (no autograd needed yet)",
+    ],
+    "02": [
+        "Every line of code: YOUR implementations",
+        "Every tensor operation: YOUR Tensor class",
+        "The exact limitation Minsky & Papert proved in 1969",
+    ],
+    "03": [
+        "Every line of code: YOUR implementations",
+        "Every tensor operation: YOUR Tensor class",
+        "Every gradient: YOUR autograd",
+    ],
+    "04": [
+        "Every line of code: YOUR implementations",
+        "Every convolution: YOUR Conv2d",
+        "Every gradient: YOUR autograd",
+    ],
+    "05": [
+        "Every line of code: YOUR implementations",
+        "Every attention weight: YOUR MultiHeadAttention",
+        "Every gradient: YOUR autograd",
+    ],
+    "06": [
+        "Every line of code: YOUR implementations",
+        "Every byte saved: YOUR quantization and compression",
+        "Every gradient: YOUR autograd",
+    ],
+}
+
 
 MODULE_EXPORT_CHECKS = {
     1: [("tinytorch", "Tensor"), ("tinytorch.core.tensor", "Tensor")],
@@ -1340,14 +1378,20 @@ class MilestoneCommand(BaseCommand):
                     f"  ✅ {name}" for name, _, _ in scripts_to_run
                 )
 
+            default_highlights = [
+                "Every line of code: YOUR implementations",
+                "Every tensor operation: YOUR Tensor class",
+                "Every gradient: YOUR autograd",
+            ]
+            highlights = MILESTONE_ACHIEVEMENT_HIGHLIGHTS.get(milestone_id, default_highlights)
+            highlights_text = "\n".join(f"• {line}" for line in highlights)
+
             console.print(Panel(
                 f"[bold green]🏆 MILESTONE ACHIEVED![/bold green]\n\n"
                 f"[green]You completed Milestone {milestone_id}: {milestone['name']}[/green]\n"
                 f"[yellow]{milestone['title']}[/yellow]{parts_text}\n\n"
                 f"[bold]What makes this special:[/bold]\n"
-                f"• Every line of code: YOUR implementations\n"
-                f"• Every tensor operation: YOUR Tensor class\n"
-                f"• Every gradient: YOUR autograd\n\n"
+                f"{highlights_text}\n\n"
                 f"[cyan]Achievement saved locally![/cyan]",
                 title="✨ Achievement Unlocked ✨",
                 border_style="bright_green",


### PR DESCRIPTION
## Bug

Every milestone's "Achievement Unlocked" panel showed the identical "What makes this special" text, including "Every gradient: YOUR autograd", regardless of which modules that milestone actually required. Milestones 01 (Perceptron) and 02 (XOR Crisis) only require modules 1-3 (Tensor, Activations, Layers) -- forward pass only, no autograd module at all -- so the panel claimed credit for code that doesn't exist yet at that point in the curriculum.

## Fix

Added `MILESTONE_ACHIEVEMENT_HIGHLIGHTS`, a per-milestone-ID set of 3 highlight bullets tailored to what each milestone's `required_modules` actually cover (forward-pass-only framing for 01/02, autograd-based framing for 03+, module-specific callouts for 04/05/06's convolutions/attention/quantization). The panel now looks up the milestone's own highlights, falling back to the original generic 3 lines for any milestone ID not in the mapping.

## Testing

Verified against a fresh `dev` install with all 20 modules completed:
- Milestone 01: panel now shows "Every forward pass: YOUR Layers (no autograd needed yet)" instead of the false autograd claim.
- Milestone 02: shows "The exact limitation Minsky & Papert proved in 1969" instead of the same generic autograd line.
- Confirmed the two panels are genuinely different from each other and from the old one-size-fits-all text.

## Test plan

- [ ] `tito milestone run 01`, confirm the achievement panel does not claim autograd credit
- [ ] `tito milestone run 03` (or later), confirm it still correctly shows the autograd line where it's accurate