### PR TITLE
fix(tinytorch): tito milestone info duplicates the year in its title

### DIFF
--- a/tinytorch/tito/commands/milestone.py
+++ b/tinytorch/tito/commands/milestone.py
@@ -1362,7 +1362,7 @@ class MilestoneCommand(BaseCommand):
             if next_id in MILESTONE_SCRIPTS:
                 next_milestone = MILESTONE_SCRIPTS[next_id]
                 console.print(f"\n[bold yellow]🎯 What's Next:[/bold yellow]")
-                console.print(f"[dim]Milestone {next_id}: {next_milestone['name']} ({next_milestone['year']})[/dim]")
+                console.print(f"[dim]Milestone {next_id}: {next_milestone['name']}[/dim]")
 
                 # Get completed modules for checking next milestone
                 progress_file = Path(".tito") / "progress.json"

--- a/tinytorch/tito/commands/milestone.py
+++ b/tinytorch/tito/commands/milestone.py
@@ -1420,7 +1420,7 @@ class MilestoneCommand(BaseCommand):
 
         # Display detailed info
         info_text = (
-            f"[bold cyan]{milestone['emoji']} {milestone['name']} ({milestone['year']})[/bold cyan]\n\n"
+            f"[bold cyan]{milestone['emoji']} {milestone['name']}[/bold cyan]\n\n"
             f"[bold]{milestone['title']}[/bold]\n\n"
             f"[yellow]📚 Historical Context:[/yellow]\n"
             f"{milestone['historical_context']}\n\n"


### PR DESCRIPTION
## Bug

`tito milestone info 01` renders the title as "Perceptron (1958) (1958)".

## Root cause

`_handle_info_command` builds the title as `"{milestone['name']} ({milestone['year']})"`, but `milestone['name']` already includes the year (e.g. "Perceptron (1958)") in `MILESTONE_SCRIPTS`, so it gets appended a second time.

## Fix

Drop the redundant `({milestone['year']})` suffix; `milestone['name']` already carries it.

## Testing

Verified: `tito milestone info 01` now shows "Perceptron (1958)" once, not twice.

## Test plan

- [ ] `tito milestone info 01` (or any milestone), confirm the year appears only once in the title