### PR TITLE
fix(tito): prevent setup hang by respecting skip-profile flag

### DIFF
--- a/tinytorch/tito/commands/setup.py
+++ b/tinytorch/tito/commands/setup.py
@@ -658,8 +658,9 @@ class SetupCommand(BaseCommand):
                 self.console.print("[green]✅ Setup completed successfully![/green]")
                 self.console.print("💡 Try: [bold]tito module start 01[/bold]")
 
-            # Prompt to join community
-            self.prompt_community_registration()
+            # Prompt to join community only if skip_profile wasn't passed
+            if not args.skip_profile:
+                self.prompt_community_registration()
 
             return 0
 


### PR DESCRIPTION
## Summary

This PR fixes a bug where `tito setup --skip-profile` hangs indefinitely in non-interactive environments by correctly respecting the `skip_profile` argument before prompting for community registration. 

@Shashank-Tripathi-07 I am submitting this fix while we investigate the larger solution leak issue in `module start`.

## Area

<!-- Check the area(s) this PR affects: -->

- [ ] Book (textbook content, figures, exercises)
- [x] TinyTorch (modules, tests, milestones)
- [ ] StaffML (interview questions, challenges)
- [ ] Kits (hardware labs)
- [ ] Infrastructure (CI/CD, scripts, config)

## Changes

<!-- What changed and why? Bullet points are fine. -->

- `tito/commands/setup.py`: Fixed an indentation bug that caused methods to fall outside the `SetupCommand` class scope.
- `tito/commands/setup.py`: Wrapped the final `self.prompt_community_registration()` call at the end of the `run()` method in an `if not args.skip_profile:` check.
- **Why:** Previously, the script successfully skipped Step 3, but blindly triggered a blocking `Confirm.ask()` I/O prompt at the very end of the setup process, causing automated setups to hang forever waiting on `stdin`.

## Testing

<!-- How did you test this? -->

- Cloned `dev` branch and installed `tito` via `pip install -e .`
- Ran `tito setup --skip-profile` in a fresh terminal.
- Verified that the setup process completes entirely and exits `0` without blocking on the `Join the community? [y/n]` prompt.