### PR TITLE
tests: extend conftest export validation to all 20 modules

### DIFF
--- a/tinytorch/tests/conftest.py
+++ b/tinytorch/tests/conftest.py
@@ -107,10 +107,10 @@ def _check_module_exported(num, title, export_file, import_path, key_symbol):
                     f"{import_path}.{key_symbol} is None "
                     f"(exported but symbol is missing or failed silently)"
                 )
-        except ImportError as exc:
+        except Exception as exc:
             errors.append(
                 f"Module {num:02d} ({title}): "
-                f"cannot import {import_path} — {exc}"
+                f"error importing {import_path} — {type(exc).__name__}: {exc}"
             )
 
     return errors

--- a/tinytorch/tests/conftest.py
+++ b/tinytorch/tests/conftest.py
@@ -38,57 +38,155 @@ os.environ['TINYTORCH_QUIET'] = '1'
 # This runs BEFORE any tests to ensure the package is properly built.
 # Without this, tests would silently pass because imports return None.
 
-def _validate_package_exported():
+# ---------------------------------------------------------------------------
+# Module registry: maps each of the 20 TinyTorch modules to
+#   - the file path it exports to  (relative to tinytorch/tinytorch/)
+#   - a key symbol that must be importable and non-None after export
+#   - whether its absence is a hard failure (foundational) or a warning
+#     (progressive — student may not have completed the module yet)
+#
+# Export paths come directly from each src file's
+# `#| default_exp <path>` directive (e.g. 09_convolutions → core.spatial).
+# ---------------------------------------------------------------------------
+_MODULE_REGISTRY = [
+    # (module_num, title,          export_file,              import_path,                    key_symbol,   required)
+    ( 1, "Tensor",          "core/tensor.py",          "tinytorch.core.tensor",         "Tensor",               True),
+    ( 2, "Activations",     "core/activations.py",     "tinytorch.core.activations",    "ReLU",                 True),
+    ( 3, "Layers",          "core/layers.py",          "tinytorch.core.layers",         "Linear",               True),
+    ( 4, "Losses",          "core/losses.py",          "tinytorch.core.losses",         "MSELoss",              True),
+    ( 5, "DataLoader",      "core/dataloader.py",      "tinytorch.core.dataloader",     "DataLoader",           False),
+    ( 6, "Autograd",        "core/autograd.py",        "tinytorch.core.autograd",       "enable_autograd",      False),
+    ( 7, "Optimizers",      "core/optimizers.py",      "tinytorch.core.optimizers",     "SGD",                  False),
+    ( 8, "Training",        "core/training.py",        "tinytorch.core.training",       "Trainer",              False),
+    # Module 09 exports to core.spatial — not core.convolutions
+    ( 9, "Convolutions",    "core/spatial.py",         "tinytorch.core.spatial",        "Conv2d",               False),
+    (10, "Tokenization",    "core/tokenization.py",    "tinytorch.core.tokenization",   "CharTokenizer",        False),
+    (11, "Embeddings",      "core/embeddings.py",      "tinytorch.core.embeddings",     "Embedding",            False),
+    (12, "Attention",       "core/attention.py",       "tinytorch.core.attention",      "MultiHeadAttention",   False),
+    (13, "Transformers",    "core/transformers.py",    "tinytorch.core.transformers",   "TransformerBlock",     False),
+    # Modules 14-19 live in the perf sub-package
+    (14, "Profiling",       "perf/profiling.py",       "tinytorch.perf.profiling",      "Profiler",             False),
+    (15, "Quantization",    "perf/quantization.py",    "tinytorch.perf.quantization",   "Quantizer",            False),
+    (16, "Compression",     "perf/compression.py",     "tinytorch.perf.compression",    "Compressor",           False),
+    (17, "Acceleration",    "perf/acceleration.py",    "tinytorch.perf.acceleration",   "vectorized_matmul",    False),
+    (18, "Memoization",     "perf/memoization.py",     "tinytorch.perf.memoization",    "KVCache",              False),
+    (19, "Benchmarking",    "perf/benchmarking.py",    "tinytorch.perf.benchmarking",   "Benchmark",            False),
+    # Module 20 exports to the top-level olympics package
+    (20, "Capstone",        "olympics/__init__.py",    "tinytorch.olympics",            None,                   False),
+]
+
+
+def _check_module_exported(num, title, export_file, import_path, key_symbol):
     """
-    Validate that tinytorch package is properly exported.
+    Check a single module: file exists + symbol is importable and non-None.
 
-    This prevents a critical bug where tests pass because:
-    1. tinytorch/__init__.py uses try/except for imports
-    2. Missing exports result in Tensor = None (not ImportError)
-    3. Tests import None and may pass vacuously
-
-    Returns tuple: (is_valid, error_message)
+    Returns a list of error strings (empty = all good).
     """
     errors = []
+    pkg_dir = project_root / "tinytorch"
 
-    # Check 1: Core module files exist
-    core_dir = project_root / "tinytorch" / "core"
-    required_modules = [
-        "tensor.py",
-        "activations.py",
-        "layers.py",
-        "losses.py",
-    ]
+    # File-existence check
+    file_path = pkg_dir / export_file
+    if not file_path.exists():
+        errors.append(
+            f"Module {num:02d} ({title}): missing exported file "
+            f"tinytorch/{export_file}"
+        )
+        # No point checking the import if the file isn't there
+        return errors
 
-    for module in required_modules:
-        module_path = core_dir / module
-        if not module_path.exists():
-            errors.append(f"Missing: tinytorch/core/{module}")
+    # Import + non-None symbol check (only when a key symbol is specified)
+    if key_symbol is not None:
+        try:
+            import importlib
+            mod = importlib.import_module(import_path)
+            obj = getattr(mod, key_symbol, None)
+            if obj is None:
+                errors.append(
+                    f"Module {num:02d} ({title}): "
+                    f"{import_path}.{key_symbol} is None "
+                    f"(exported but symbol is missing or failed silently)"
+                )
+        except ImportError as exc:
+            errors.append(
+                f"Module {num:02d} ({title}): "
+                f"cannot import {import_path} — {exc}"
+            )
 
-    # Check 2: Tensor class is actually importable (not None)
+    return errors
+
+
+def _validate_package_exported():
+    """
+    Validate that the tinytorch package is properly exported for all 20 modules.
+
+    Two-tier strategy matching TinyTorch's progressive pedagogy:
+
+    - **Foundational modules (01–04)** — required=True
+        Hard failures: if these are missing, nothing else can run.
+        Students must export at least these before the test suite starts.
+
+    - **Progressive modules (05–20)** — required=False
+        Soft warnings: printed to stderr but do NOT block test execution.
+        A student working on Module 06 should still be able to run the
+        Module 01–05 tests without the later modules being present.
+
+    This prevents the silent-pass bug where tinytorch/__init__.py
+    catches ImportError and sets symbols to None, causing tests to
+    import None and vacuously pass.
+
+    Returns:
+        tuple[bool, list[str]]: (is_valid, hard_error_messages)
+        Soft warnings are printed directly to stderr here.
+    """
+    import sys
+
+    hard_errors = []
+    soft_warnings = []
+
+    for num, title, export_file, import_path, key_symbol, required in _MODULE_REGISTRY:
+        module_errors = _check_module_exported(
+            num, title, export_file, import_path, key_symbol
+        )
+        if module_errors:
+            if required:
+                hard_errors.extend(module_errors)
+            else:
+                soft_warnings.extend(module_errors)
+
+    # Additionally verify that the Tensor class is actually instantiable,
+    # not just importable — guards against empty stub implementations.
     try:
         from tinytorch import Tensor
         if Tensor is None:
-            errors.append("Tensor is None (import failed silently)")
-    except ImportError as e:
-        errors.append(f"Cannot import Tensor: {e}")
-
-    # Check 3: Verify Tensor is actually the class, not a stub
-    try:
-        from tinytorch import Tensor
-        if Tensor is not None:
-            # Try to instantiate - this catches incomplete implementations
+            hard_errors.append(
+                "tinytorch.Tensor is None after import "
+                "(export failed silently — run: tito dev export --all)"
+            )
+        else:
             t = Tensor([1, 2, 3])
-            if not hasattr(t, 'data'):
-                errors.append("Tensor missing 'data' attribute")
-            if not hasattr(t, 'shape'):
-                errors.append("Tensor missing 'shape' attribute")
-    except Exception as e:
-        errors.append(f"Tensor instantiation failed: {e}")
+            for attr in ("data", "shape", "size", "dtype"):
+                if not hasattr(t, attr):
+                    hard_errors.append(
+                        f"Tensor is missing required attribute '{attr}'"
+                    )
+    except ImportError as exc:
+        hard_errors.append(f"Cannot import tinytorch.Tensor: {exc}")
+    except Exception as exc:
+        hard_errors.append(f"Tensor([1, 2, 3]) raised unexpectedly: {exc}")
 
-    if errors:
-        return False, errors
-    return True, []
+    # Print soft warnings so students see what's not yet exported
+    if soft_warnings:
+        print(
+            "\n[tinytorch] Modules not yet exported (OK for progressive "
+            "builds — export when you reach that module):",
+            file=sys.stderr,
+        )
+        for w in soft_warnings:
+            print(f"  ⚠  {w}", file=sys.stderr)
+        print("", file=sys.stderr)
+
+    return (not hard_errors), hard_errors
 
 
 def pytest_configure(config):

--- a/tinytorch/tests/environment/test_conftest_validation.py
+++ b/tinytorch/tests/environment/test_conftest_validation.py
@@ -1,0 +1,397 @@
+"""
+Conftest Export Validation Unit Tests
+
+Tests the _MODULE_REGISTRY table and _check_module_exported helper that were
+added to conftest.py to extend export validation from 4 hardcoded filenames to
+all 20 TinyTorch modules.
+
+The validation logic in conftest.py runs before every test session and is the
+last line of defence against the silent-pass bug, where missing exports cause
+tinytorch/__init__.py to set symbols to None and tests to pass vacuously.
+Like any critical gatekeeper, the gatekeeper itself must be tested.
+
+Usage:
+    pytest tests/environment/test_conftest_validation.py -v
+
+    Or via TITO:
+    tito system health --verify
+
+Categories:
+    -k registry        # _MODULE_REGISTRY completeness and schema
+    -k paths           # export-file path invariants
+    -k flags           # required=True/False split
+    -k check           # _check_module_exported helper behaviour
+    -k soft_vs_hard    # two-tier warning vs hard-failure routing
+
+What we test:
+    1. Registry completeness  - all 20 modules have an entry
+    2. Registry schema        - every row has correct field types (int, str, str, str, str|None, bool)
+    3. Export paths           - forward slashes, .py extension, correct sub-package prefix
+    4. Required flags         - exactly modules 01-04 are marked required=True
+    5. Key-symbol naming      - symbols are valid Python identifiers
+    6. _check_module_exported - file-missing, symbol-None, no-symbol-needed cases
+    7. Soft warning routing   - optional module failures warn to stderr, not hard-fail
+"""
+
+import sys
+import importlib
+import tempfile
+import types
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Pull symbols directly out of conftest.py without triggering pytest_configure
+# (which would run the full export check and potentially abort the session).
+# ---------------------------------------------------------------------------
+_TESTS_DIR = Path(__file__).parent.parent
+sys.path.insert(0, str(_TESTS_DIR))
+
+# Import only the validation helpers — not the full module (avoids hook side-effects)
+import importlib.util as _ilu
+
+_conftest_path = _TESTS_DIR / "conftest.py"
+_spec = _ilu.spec_from_file_location("_conftest_under_test", _conftest_path)
+_conftest = _ilu.module_from_spec(_spec)
+# Patch pytest so pytest_configure doesn't run during import
+import unittest.mock as _mock
+with _mock.patch.dict("sys.modules", {"pytest": pytest}):
+    _spec.loader.exec_module(_conftest)
+
+_MODULE_REGISTRY      = _conftest._MODULE_REGISTRY
+_check_module_exported = _conftest._check_module_exported
+_validate_package_exported = _conftest._validate_package_exported
+
+
+# ===========================================================================
+# 1. Registry completeness
+# ===========================================================================
+
+class TestRegistryCompleteness:
+    """_MODULE_REGISTRY must cover exactly all 20 modules."""
+
+    def test_has_20_entries(self):
+        assert len(_MODULE_REGISTRY) == 20, (
+            f"Expected 20 module entries, got {len(_MODULE_REGISTRY)}.\n"
+            "Add a row for every new module or remove orphan rows."
+        )
+
+    def test_module_numbers_are_1_to_20(self):
+        """Module numbers must be exactly 1..20 with no gaps or duplicates."""
+        nums = [entry[0] for entry in _MODULE_REGISTRY]
+        assert sorted(nums) == list(range(1, 21)), (
+            f"Module numbers are not contiguous 1-20: {sorted(nums)}"
+        )
+
+    def test_module_numbers_are_unique(self):
+        nums = [entry[0] for entry in _MODULE_REGISTRY]
+        assert len(nums) == len(set(nums)), (
+            f"Duplicate module numbers found: "
+            f"{[n for n in nums if nums.count(n) > 1]}"
+        )
+
+
+# ===========================================================================
+# 2. Registry schema
+# ===========================================================================
+
+class TestRegistrySchema:
+    """Every row must have (int, str, str, str, str|None, bool)."""
+
+    @pytest.mark.parametrize("entry", _MODULE_REGISTRY,
+                             ids=[f"module_{e[0]:02d}_{e[1]}" for e in _MODULE_REGISTRY])
+    def test_entry_types(self, entry):
+        num, title, export_file, import_path, key_symbol, required = entry
+        assert isinstance(num, int),          f"num must be int, got {type(num)}"
+        assert isinstance(title, str),        f"title must be str, got {type(title)}"
+        assert isinstance(export_file, str),  f"export_file must be str, got {type(export_file)}"
+        assert isinstance(import_path, str),  f"import_path must be str, got {type(import_path)}"
+        assert key_symbol is None or isinstance(key_symbol, str), (
+            f"key_symbol must be str or None, got {type(key_symbol)}"
+        )
+        assert isinstance(required, bool),    f"required must be bool, got {type(required)}"
+
+    @pytest.mark.parametrize("entry", _MODULE_REGISTRY,
+                             ids=[f"module_{e[0]:02d}_{e[1]}" for e in _MODULE_REGISTRY])
+    def test_non_empty_strings(self, entry):
+        num, title, export_file, import_path, key_symbol, required = entry
+        assert title.strip(),       f"Module {num:02d}: title must not be empty"
+        assert export_file.strip(), f"Module {num:02d}: export_file must not be empty"
+        assert import_path.strip(), f"Module {num:02d}: import_path must not be empty"
+        if key_symbol is not None:
+            assert key_symbol.strip(), f"Module {num:02d}: key_symbol must not be empty"
+
+
+# ===========================================================================
+# 3. Export paths
+# ===========================================================================
+
+class TestExportPaths:
+    """export_file values must follow the known sub-package layout."""
+
+    VALID_PREFIXES = ("core/", "perf/", "olympics/")
+
+    @pytest.mark.parametrize("entry", _MODULE_REGISTRY,
+                             ids=[f"module_{e[0]:02d}_{e[1]}" for e in _MODULE_REGISTRY])
+    def test_export_file_prefix(self, entry):
+        num, title, export_file, *_ = entry
+        assert any(export_file.startswith(p) for p in self.VALID_PREFIXES), (
+            f"Module {num:02d} ({title}): export_file '{export_file}' must start "
+            f"with one of {self.VALID_PREFIXES}"
+        )
+
+    @pytest.mark.parametrize("entry", _MODULE_REGISTRY,
+                             ids=[f"module_{e[0]:02d}_{e[1]}" for e in _MODULE_REGISTRY])
+    def test_export_file_uses_forward_slashes(self, entry):
+        num, title, export_file, *_ = entry
+        assert "\\" not in export_file, (
+            f"Module {num:02d}: export_file must use forward slashes, got '{export_file}'"
+        )
+
+    @pytest.mark.parametrize("entry", _MODULE_REGISTRY,
+                             ids=[f"module_{e[0]:02d}_{e[1]}" for e in _MODULE_REGISTRY])
+    def test_export_file_ends_with_py(self, entry):
+        num, title, export_file, *_ = entry
+        assert export_file.endswith(".py"), (
+            f"Module {num:02d}: export_file '{export_file}' must end with .py"
+        )
+
+    def test_module_09_exports_to_spatial_not_convolutions(self):
+        """Module 09 exports to core.spatial (non-obvious — must not drift)."""
+        entry = _MODULE_REGISTRY[8]  # 0-indexed, module 09
+        assert entry[0] == 9
+        assert "spatial" in entry[2], (
+            f"Module 09 should export to core/spatial.py, got '{entry[2]}'"
+        )
+
+    def test_module_20_exports_to_olympics(self):
+        """Module 20 exports to the top-level olympics package."""
+        entry = _MODULE_REGISTRY[19]  # 0-indexed, module 20
+        assert entry[0] == 20
+        assert entry[2].startswith("olympics/"), (
+            f"Module 20 should export to olympics/, got '{entry[2]}'"
+        )
+
+    def test_modules_14_to_19_export_to_perf(self):
+        """Performance modules (14-19) must export under perf/."""
+        for entry in _MODULE_REGISTRY:
+            num = entry[0]
+            export_file = entry[2]
+            if 14 <= num <= 19:
+                assert export_file.startswith("perf/"), (
+                    f"Module {num:02d} should export to perf/, got '{export_file}'"
+                )
+
+
+# ===========================================================================
+# 4. Required flags
+# ===========================================================================
+
+class TestRequiredFlags:
+    """Exactly modules 01-04 must be required=True; 05-20 must be False."""
+
+    def test_foundational_modules_are_required(self):
+        """Modules 01-04 (Tensor, Activations, Layers, Losses) must be required."""
+        for entry in _MODULE_REGISTRY:
+            num, title, _, _, _, required = entry
+            if 1 <= num <= 4:
+                assert required is True, (
+                    f"Module {num:02d} ({title}) is foundational and must be "
+                    f"required=True, but required={required}"
+                )
+
+    def test_progressive_modules_are_not_required(self):
+        """Modules 05-20 are optional (student may not have reached them yet)."""
+        for entry in _MODULE_REGISTRY:
+            num, title, _, _, _, required = entry
+            if num >= 5:
+                assert required is False, (
+                    f"Module {num:02d} ({title}) is progressive and must be "
+                    f"required=False, but required={required}"
+                )
+
+    def test_exactly_four_required_modules(self):
+        required_count = sum(1 for e in _MODULE_REGISTRY if e[5] is True)
+        assert required_count == 4, (
+            f"Expected exactly 4 required modules (01-04), got {required_count}"
+        )
+
+
+# ===========================================================================
+# 5. Key-symbol naming (must be valid Python identifiers)
+# ===========================================================================
+
+class TestKeySymbols:
+
+    @pytest.mark.parametrize("entry", _MODULE_REGISTRY,
+                             ids=[f"module_{e[0]:02d}_{e[1]}" for e in _MODULE_REGISTRY])
+    def test_key_symbol_is_valid_identifier(self, entry):
+        num, title, _, _, key_symbol, _ = entry
+        if key_symbol is None:
+            return  # Module 20 has no specific symbol — that's fine
+        assert key_symbol.isidentifier(), (
+            f"Module {num:02d} ({title}): key_symbol '{key_symbol}' is not a "
+            f"valid Python identifier"
+        )
+
+
+# ===========================================================================
+# 6. _check_module_exported behaviour
+# ===========================================================================
+
+class TestCheckModuleExported:
+    """Verify _check_module_exported detects missing files and bad symbols."""
+
+    def test_returns_error_when_file_missing(self, tmp_path):
+        """A non-existent export file must produce an error entry."""
+        # Temporarily redirect project_root to tmp_path
+        original_root = _conftest.project_root
+        _conftest.project_root = tmp_path
+
+        try:
+            errors = _check_module_exported(
+                99, "Ghost", "core/ghost.py",
+                "tinytorch.core.ghost", "Ghost"
+            )
+        finally:
+            _conftest.project_root = original_root
+
+        assert len(errors) == 1
+        assert "Ghost" in errors[0]
+        assert "missing exported file" in errors[0]
+
+    def test_returns_empty_when_file_exists_and_symbol_found(self, tmp_path):
+        """A file that exists with the expected symbol must return no errors."""
+        # Create a fake module file
+        pkg_root = tmp_path / "tinytorch"
+        core_dir = pkg_root / "core"
+        core_dir.mkdir(parents=True)
+        mod_file = core_dir / "fake.py"
+        mod_file.write_text("class FakeThing: pass\n", encoding="utf-8")
+
+        # Register the fake module so importlib can find it
+        fake_mod = types.ModuleType("tinytorch.core.fake")
+        fake_mod.FakeThing = type("FakeThing", (), {})
+        sys.modules["tinytorch.core.fake"] = fake_mod
+
+        original_root = _conftest.project_root
+        _conftest.project_root = tmp_path
+
+        try:
+            errors = _check_module_exported(
+                99, "Fake", "core/fake.py",
+                "tinytorch.core.fake", "FakeThing"
+            )
+        finally:
+            _conftest.project_root = original_root
+            sys.modules.pop("tinytorch.core.fake", None)
+
+        assert errors == [], f"Expected no errors, got: {errors}"
+
+    def test_detects_symbol_set_to_none(self, tmp_path):
+        """A symbol that exists but is None must be reported."""
+        pkg_root = tmp_path / "tinytorch"
+        core_dir = pkg_root / "core"
+        core_dir.mkdir(parents=True)
+        mod_file = core_dir / "nullmod.py"
+        mod_file.write_text("NullThing = None\n", encoding="utf-8")
+
+        null_mod = types.ModuleType("tinytorch.core.nullmod")
+        null_mod.NullThing = None
+        sys.modules["tinytorch.core.nullmod"] = null_mod
+
+        original_root = _conftest.project_root
+        _conftest.project_root = tmp_path
+
+        try:
+            errors = _check_module_exported(
+                99, "NullMod", "core/nullmod.py",
+                "tinytorch.core.nullmod", "NullThing"
+            )
+        finally:
+            _conftest.project_root = original_root
+            sys.modules.pop("tinytorch.core.nullmod", None)
+
+        assert len(errors) == 1
+        assert "is None" in errors[0]
+
+    def test_no_error_when_key_symbol_is_none(self, tmp_path):
+        """When key_symbol=None (Module 20 style), only file existence is checked."""
+        pkg_root = tmp_path / "tinytorch"
+        olympics_dir = pkg_root / "olympics"
+        olympics_dir.mkdir(parents=True)
+        (olympics_dir / "__init__.py").write_text("", encoding="utf-8")
+
+        original_root = _conftest.project_root
+        _conftest.project_root = tmp_path
+
+        try:
+            errors = _check_module_exported(
+                20, "Capstone", "olympics/__init__.py",
+                "tinytorch.olympics", None
+            )
+        finally:
+            _conftest.project_root = original_root
+
+        assert errors == [], f"No symbol check should mean no errors: {errors}"
+
+
+# ===========================================================================
+# 7. _validate_package_exported: soft warning vs hard failure split
+# ===========================================================================
+
+class TestValidatePackageSoftVsHard:
+    """
+    The two-tier strategy must route errors correctly.
+    We patch _check_module_exported to inject controlled failures.
+    """
+
+    def test_required_module_failure_causes_hard_error(self, monkeypatch):
+        """A failure in a required (01-04) module must appear in hard_errors."""
+        def fake_check(num, title, export_file, import_path, key_symbol):
+            if num == 1:  # Tensor — required
+                return [f"Module 01 (Tensor): missing exported file tinytorch/core/tensor.py"]
+            return []
+
+        monkeypatch.setattr(_conftest, "_check_module_exported", fake_check)
+        # Also patch Tensor import to avoid unrelated errors
+        import unittest.mock as mock
+        with mock.patch("builtins.__import__", wraps=__builtins__.__import__ if hasattr(__builtins__, "__import__") else __import__):
+            is_valid, hard_errors = _conftest._validate_package_exported()
+
+        assert not is_valid, "A required module failure should make is_valid=False"
+        assert any("Module 01" in e for e in hard_errors)
+
+    def test_optional_module_failure_does_not_hard_fail(self, monkeypatch, capsys):
+        """A failure in a non-required module (05-20) must NOT produce hard errors."""
+        def fake_check(num, title, export_file, import_path, key_symbol):
+            if num == 15:  # Quantization — optional
+                return [f"Module 15 (Quantization): missing exported file tinytorch/perf/quantization.py"]
+            return []
+
+        monkeypatch.setattr(_conftest, "_check_module_exported", fake_check)
+
+        # Patch Tensor import so the instantiation check passes
+        import unittest.mock as mock
+        mock_tensor = mock.MagicMock()
+        mock_tensor_instance = mock.MagicMock(spec=["data", "shape", "size", "dtype"])
+        mock_tensor.return_value = mock_tensor_instance
+
+        with mock.patch.dict("sys.modules", {"tinytorch": mock.MagicMock(Tensor=mock_tensor)}):
+            is_valid, hard_errors = _conftest._validate_package_exported()
+
+        # Module 15 is optional — no hard failure
+        assert not any("Module 15" in e for e in hard_errors), (
+            "Optional module failures must not appear in hard_errors"
+        )
+
+        # Warning should have been printed to stderr
+        captured = capsys.readouterr()
+        assert "Module 15" in captured.err, (
+            "Optional module failures must produce a stderr warning"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tinytorch/tests/environment/test_conftest_validation.py
+++ b/tinytorch/tests/environment/test_conftest_validation.py
@@ -34,8 +34,6 @@ What we test:
 """
 
 import sys
-import importlib
-import tempfile
 import types
 from pathlib import Path
 
@@ -159,16 +157,14 @@ class TestExportPaths:
 
     def test_module_09_exports_to_spatial_not_convolutions(self):
         """Module 09 exports to core.spatial (non-obvious — must not drift)."""
-        entry = _MODULE_REGISTRY[8]  # 0-indexed, module 09
-        assert entry[0] == 9
+        entry = next(e for e in _MODULE_REGISTRY if e[0] == 9)
         assert "spatial" in entry[2], (
             f"Module 09 should export to core/spatial.py, got '{entry[2]}'"
         )
 
     def test_module_20_exports_to_olympics(self):
         """Module 20 exports to the top-level olympics package."""
-        entry = _MODULE_REGISTRY[19]  # 0-indexed, module 20
-        assert entry[0] == 20
+        entry = next(e for e in _MODULE_REGISTRY if e[0] == 20)
         assert entry[2].startswith("olympics/"), (
             f"Module 20 should export to olympics/, got '{entry[2]}'"
         )


### PR DESCRIPTION
## Summary

Extends the pre-test export validation in `conftest.py` from 4 hardcoded filenames
to all 20 TinyTorch modules, and adds a unit test suite to prevent regressions in
the registry and validation logic.

## Area

- [ ] Book (textbook content, figures, exercises)
- [x] TinyTorch (modules, tests, milestones)
- [ ] StaffML (interview questions, challenges)
- [ ] Kits (hardware labs)
- [ ] Infrastructure (CI/CD, scripts, config)

## Changes

- `conftest.py` previously checked only 4 files, leaving modules 05–20 unvalidated.
  The silent-pass bug (where `tinytorch/__init__.py` catches `ImportError` and sets
  symbols to `None`, causing tests to pass vacuously) was active for the majority of
  the framework.
- Introduces `_MODULE_REGISTRY`: a table mapping all 20 modules to their export file
  path (sourced from each file's `#| default_exp` directive), importable module path,
  and a key symbol to probe.
- Adds `_check_module_exported()`: performs file-existence, import, and non-`None`
  symbol checks. Catches all exceptions so a broken module produces a collected error
  string rather than aborting the session.
- Two-tier validation strategy: modules 01–04 hard-fail and block the session;
  modules 05–20 warn to stderr without blocking, matching TinyTorch's progressive
  structure where a student may not have exported all modules yet.
- Adds `tests/environment/test_conftest_validation.py` with 135 tests covering
  registry completeness, schema, export path invariants, required-flag split, key
  symbol naming, helper behavior, and two-tier routing.

## Testing

- [ ] Rendered the book locally (`quarto render`)
- [x] Ran tests (`pytest tests/`)
- [ ] Ran `tito module test NN` for affected module(s)
- [x] Manual verification

```bash
TINYTORCH_SKIP_EXPORT_CHECK=1 pytest tests/environment/test_conftest_validation.py -v
# 135 passed in 0.46s
```

Existing environment test suite shows no regressions.

## Related Issues

No formal issue was opened before this PR. While studying the codebase to find
contribution opportunities, I noticed that `conftest.py` itself contains a comment
explaining the silent-pass bug — where `tinytorch/__init__.py` catches `ImportError`
and sets symbols to `None`, causing tests to import `None` and pass vacuously. The
comment treats this as the primary motivation for the validation check, yet the
implementation only protected 4 out of 20 modules, leaving the remaining 16 entirely
exposed to the exact bug it was designed to prevent. That gap between the documented
risk and the actual coverage was the reason for this change.
