### PR TITLE
fix(staffml): correct simulator training-time units and tablet nav overflow

### DIFF
--- a/interviews/staffml/src/components/Nav.tsx
+++ b/interviews/staffml/src/components/Nav.tsx
@@ -99,8 +99,11 @@ export default function Nav() {
             </span>
           </Link>
 
-          {/* Desktop primary nav */}
-          <div className="hidden md:flex items-center gap-0.5">
+          {/* Desktop primary nav. Uses the shared nav-lg (992px) breakpoint,
+              not Tailwind's default md (768px) — at 768px this row doesn't
+              fit (7 links + Tools dropdown) and forces horizontal overflow.
+              nav-lg matches EcosystemBar's collapse point above it. */}
+          <div className="hidden nav-lg:flex items-center gap-0.5">
             {primaryLinks.map(({ href, label, icon: Icon }) => (
               <Link
                 key={href}
@@ -170,7 +173,7 @@ export default function Nav() {
           {/* Mobile hamburger */}
           <button
             onClick={() => setMobileOpen(!mobileOpen)}
-            className="md:hidden p-2 text-textTertiary hover:text-textPrimary transition-colors"
+            className="nav-lg:hidden p-2 text-textTertiary hover:text-textPrimary transition-colors"
             aria-label="Toggle navigation menu"
             aria-haspopup="true"
             aria-expanded={mobileOpen}
@@ -183,7 +186,7 @@ export default function Nav() {
 
       {/* Mobile menu */}
       {mobileOpen && (
-        <div id="nav-mobile-menu" className="md:hidden border-t border-border bg-surface px-4 py-3 space-y-1">
+        <div id="nav-mobile-menu" className="nav-lg:hidden border-t border-border bg-surface px-4 py-3 space-y-1">
           {primaryLinks.map(({ href, label, icon: Icon }) => (
             <Link
               key={href}

--- a/interviews/staffml/src/lib/simulator.ts
+++ b/interviews/staffml/src/lib/simulator.ts
@@ -127,8 +127,11 @@ export function simulate(config: SimConfig): SimResult {
     Math.max(checkpointTimeMins, 0.5), clusterMtbfHours * 60
   );
 
-  // Training time (assume 1T tokens)
-  const totalFlops = FORMULAS.training_flops(model.params_b, 1);
+  // Training time (assume 1T tokens). training_flops() takes tokens_b in
+  // billions, so 1T tokens is 1000, not 1 -- passing 1 silently computed
+  // the time for 1B tokens (1/1000th of the labeled target), which rounds
+  // to "0 days" for any realistic throughput.
+  const totalFlops = FORMULAS.training_flops(model.params_b, 1000);
   const trainingTimeDays = totalFlops / (actualFlops * 86400);
 
   return {


### PR DESCRIPTION
## Summary

Two independent bugs found while manually stress-testing StaffML (both routes, forms, calculators, and viewport widths):

1. **Distributed Training Simulator always showed "0 days" for training time**, regardless of model or hardware config. `training_flops(params_b, tokens_b)` takes `tokens_b` in billions, but the simulator called it with `1` to mean "1T tokens" — 1 billion is 1/1000th of 1 trillion, so the computed time was always a fraction of a day, which `.toFixed(0)` rounded down to "0". Fixed by passing `1000` (1000 billion = 1 trillion) instead of `1`.

2. **The StaffML sub-nav overflowed horizontally at 768px** (tablet width) instead of collapsing into the hamburger menu, cutting off "Progress," "About," and "Tools." `Nav.tsx` used Tailwind's default `md` breakpoint (768px), but the codebase already has a purpose-built `nav-lg` (992px) breakpoint defined in `tailwind.config.js` specifically for this row, deliberately matching Bootstrap/Quarto's collapse point so StaffML's nav collapses at the same width as the rest of the ecosystem. `EcosystemBar.tsx` above it already uses `nav-lg` — `Nav.tsx` just missed it.

## Verification

- Simulator: healthy 595K tok/s config now correctly shows **19 days** instead of 0.
- Tablet (768px): `scrollWidth` now equals `clientWidth` on 5/5 pages tested (home, practice, explore, gauntlet, plans) — no more horizontal overflow.
- Desktop (1440px): full nav still renders identically, all 7 links + Tools dropdown visible.
- Mobile (390px): hamburger menu still renders correctly, unaffected.
- `npm test`: 140/140 passing
- `npm run lint`: 0 errors (94 pre-existing warnings, none in the touched files)
- `tsc --noEmit`: clean

## Test plan

- [ ] Visit `/simulator`, select any model/hardware combo that isn't OOM, confirm "Training Time (1T Tokens)" shows a realistic non-zero value
- [ ] Resize browser to 768px width (or use a tablet), confirm the StaffML sub-nav shows a hamburger menu instead of overflowing
- [ ] Confirm desktop (\>992px) and mobile (\<768px) nav behavior is unchanged