### PR TITLE
fix(tinytorch): stop module start/resume dead-ending on tracking/disk desync

### DIFF
--- a/tinytorch/tito/commands/module/workflow.py
+++ b/tinytorch/tito/commands/module/workflow.py
@@ -265,11 +265,19 @@ class ModuleWorkflowCommand(BaseCommand):
         module_name = module_mapping[normalized]
         module_num = int(normalized)
 
-        # Check if already started
+        # Check if already started. Tracking (started_modules) and the
+        # notebook on disk can desync, e.g. `tito system reset
+        # --keep-progress` clears modules/ but intentionally preserves
+        # started_modules/completed_modules. If that's happened, don't
+        # dead-end the student on "already started"; fall through to the
+        # recreate-from-src/ logic below instead.
         if self.is_module_started(normalized):
-            self.console.print(f"[yellow]⚠️  Module {normalized} already started[/yellow]")
-            self.console.print(f"💡 Did you mean: [bold cyan]tito module resume {normalized}[/bold cyan]")
-            return 1
+            if (self.config.project_root / "modules" / module_name).exists():
+                self.console.print(f"[yellow]⚠️  Module {normalized} already started[/yellow]")
+                self.console.print(f"💡 Did you mean: [bold cyan]tito module resume {normalized}[/bold cyan]")
+                return 1
+            self.console.print(f"[yellow]⚠️  Module {normalized} was started before, but its notebook is missing[/yellow]")
+            self.console.print(f"[cyan]🔁 Recreating it from source...[/cyan]")
 
         # Check prerequisites - all previous modules must be completed
         progress = self.get_progress_data()
@@ -491,6 +499,21 @@ class ModuleWorkflowCommand(BaseCommand):
             self.console.print(f"[yellow]⚠️  Module {normalized} not started yet[/yellow]")
             self.console.print(f"💡 Start with: [bold cyan]tito module start {normalized}[/bold cyan]")
             return 1
+
+        # Tracking says started, but the notebook itself may be missing,
+        # e.g. `tito system reset --keep-progress` clears modules/ while
+        # intentionally preserving started_modules/completed_modules.
+        # Recreate it from src/ instead of dead-ending inside _open_jupyter
+        # with "directory not found" and no way forward.
+        module_dir = self.config.project_root / "modules" / module_name
+        if not module_dir.exists():
+            self.console.print(f"[yellow]⚠️  Module {normalized} was started before, but its notebook is missing[/yellow]")
+            self.console.print(f"[cyan]🔁 Recreating it from source...[/cyan]")
+            if not self._create_module_from_src(module_name):
+                self.console.print(f"[red]❌ Could not recreate module {module_name}[/red]")
+                self.console.print(f"💡 Try: [bold cyan]tito module reset {normalized} --force[/bold cyan]")
+                return 1
+            self.console.print(f"[green]✅ Module {normalized} ready![/green]")
 
         # Update last worked
         self.update_last_worked(normalized)


### PR DESCRIPTION
## Summary
`tito module start` and `tito module resume` can deadlock each other when `.tito/progress.json`'s tracking (`started_modules`) desyncs from the actual notebook on disk under `modules/`. Each command's own failure message points at the other, and neither ever mentions the actual fix.

## Area
- [ ] Book (textbook content, figures, exercises)
- [ ] StaffML (interview questions, challenges)
- [ ] Kits (hardware labs)
- [ ] Infrastructure (CI/CD, scripts, config)
- [x] TinyTorch (modules, tests, milestones)

## Changes
- `tito/commands/module/workflow.py`: `start_module` now checks whether the notebook directory actually exists before trusting the `is_module_started` flag, and recreates it from `src/` when it doesn't, instead of refusing with 'already started'.
- `resume_module` now does the same check before calling `_open_jupyter`, recreating the notebook from `src/` instead of dead-ending inside `_open_jupyter` with 'directory not found'.
- The normal case (notebook genuinely present) is unchanged in both commands.

## Testing
- [ ] Rendered the book locally (`quarto render`)
- [ ] Ran tests (`pytest tests/`)
- [ ] Ran `tito module test NN` for affected module(s)
- [x] Manual verification (describe below)

Reproduced the exact desync on a real, install.sh-created TinyTorch environment: started module 01, then deleted `modules/01_tensor/` while leaving `.tito/progress.json` untouched (the same state `tito system reset --keep-progress` produces). Before the fix: `tito module start 01` refused with 'already started', `tito module resume 01` then failed with 'Module directory not found: 01_tensor', a closed loop with no escape mentioned in either message. After the fix: both commands detect the missing notebook, print a clear 'was started before, but its notebook is missing, recreating it from source' message, regenerate the notebook via the same `_create_module_from_src` path used for a genuinely new module, and proceed normally (`resume` goes on to open Jupyter Lab, confirmed via a real running server). Also confirmed the untouched case: starting an already-started module whose notebook genuinely still exists still correctly refuses and points to `resume`, unchanged from before.

## Related Issues
None filed. Found while auditing every `tito` command against a real, isolated TinyTorch install to check which work correctly.

---
*By submitting this PR, you agree to release your contribution under the project's license.*