### PR TITLE
fix: restore broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,11 +436,11 @@ Yes. Both volumes are free to read online at [mlsysbook.ai](https://mlsysbook.ai
       <td width="50%" align="center">
         <b>Star the repo</b><br>
         Stars signal to universities and foundations that this work matters. They directly fund workshops and hardware kits for underserved classrooms.<br><br>
-        <a href="https://star-history.com/#harvard-edge/cs249r_book&Date">
+        <a href="https://star-history.dera.page/#harvard-edge/cs249r_book&Date">
           <picture>
-            <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=harvard-edge/cs249r_book&type=date&theme=dark&legend=top-left">
-            <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=harvard-edge/cs249r_book&type=date&legend=top-left">
-            <img src="https://api.star-history.com/chart?repos=harvard-edge/cs249r_book&type=date&legend=top-left" alt="Star History Chart" width="400">
+            <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=harvard-edge/cs249r_book&type=date&theme=dark&legend=top-left">
+            <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=harvard-edge/cs249r_book&type=date&legend=top-left">
+            <img src="https://star-history.dera.page/svg?repos=harvard-edge/cs249r_book&type=date&legend=top-left" alt="Star History Chart" width="400">
           </picture>
         </a><br>
         100 → 1,000 → <b>10,000</b> → 100,000 → <b>1M learners by 2030</b>

--- a/README/README_ja.md
+++ b/README/README_ja.md
@@ -211,11 +211,11 @@ AIは稲妻のように速く変わりますが、それを動かすエンジニ
 
 [![Stars](https://img.shields.io/github/stars/harvard-edge/cs249r_book?style=for-the-badge&logo=github&color=gold)](https://github.com/harvard-edge/cs249r_book/stargazers)
 
-<a href="https://star-history.com/#harvard-edge/cs249r_book&Date">
+<a href="https://star-history.dera.page/#harvard-edge/cs249r_book&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=harvard-edge/cs249r_book&type=date&legend=top-left&theme=dark">
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=harvard-edge/cs249r_book&type=date&legend=top-left">
-    <img src="https://api.star-history.com/chart?repos=harvard-edge/cs249r_book&type=date&legend=top-left" alt="Star History Chart">
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=harvard-edge/cs249r_book&type=date&legend=top-left&theme=dark">
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=harvard-edge/cs249r_book&type=date&legend=top-left">
+    <img src="https://star-history.dera.page/svg?repos=harvard-edge/cs249r_book&type=date&legend=top-left" alt="Star History Chart">
   </picture>
 </a>
 

--- a/README/README_ko.md
+++ b/README/README_ko.md
@@ -211,11 +211,11 @@ AI는 번개처럼 빠르게 변하지만, 이를 작동하게 하는 엔지니�
 
 [![Stars](https://img.shields.io/github/stars/harvard-edge/cs249r_book?style=for-the-badge&logo=github&color=gold)](https://github.com/harvard-edge/cs249r_book/stargazers)
 
-<a href="https://star-history.com/#harvard-edge/cs249r_book&Date">
+<a href="https://star-history.dera.page/#harvard-edge/cs249r_book&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=harvard-edge/cs249r_book&type=date&legend=top-left&theme=dark">
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=harvard-edge/cs249r_book&type=date&legend=top-left">
-    <img src="https://api.star-history.com/chart?repos=harvard-edge/cs249r_book&type=date&legend=top-left" alt="Star History Chart">
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=harvard-edge/cs249r_book&type=date&legend=top-left&theme=dark">
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=harvard-edge/cs249r_book&type=date&legend=top-left">
+    <img src="https://star-history.dera.page/svg?repos=harvard-edge/cs249r_book&type=date&legend=top-left" alt="Star History Chart">
   </picture>
 </a>
 

--- a/README/README_zh.md
+++ b/README/README_zh.md
@@ -211,11 +211,11 @@ AI 的发展速度如闪电般，但支撑其运行的工程模块并不会像�
 
 [![Stars](https://img.shields.io/github/stars/harvard-edge/cs249r_book?style=for-the-badge&logo=github&color=gold)](https://github.com/harvard-edge/cs249r_book/stargazers)
 
-<a href="https://star-history.com/#harvard-edge/cs249r_book&Date">
+<a href="https://star-history.dera.page/#harvard-edge/cs249r_book&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=harvard-edge/cs249r_book&type=date&legend=top-left&theme=dark">
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=harvard-edge/cs249r_book&type=date&legend=top-left">
-    <img src="https://api.star-history.com/chart?repos=harvard-edge/cs249r_book&type=date&legend=top-left" alt="Star History Chart">
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=harvard-edge/cs249r_book&type=date&legend=top-left&theme=dark">
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=harvard-edge/cs249r_book&type=date&legend=top-left">
+    <img src="https://star-history.dera.page/svg?repos=harvard-edge/cs249r_book&type=date&legend=top-left" alt="Star History Chart">
   </picture>
 </a>
 


### PR DESCRIPTION
The star history chart on the README is currently broken and no longer renders because the upstream service is affected by GitHub stargazer API restrictions.

This change points the chart (and its localized versions) to a working mirror, so the chart displays again for all visitors. No other content is modified.