### PR TITLE
test(tinytorch): regression coverage for dataloader/training checkpoint gaps

### DIFF
--- a/tinytorch/tests/05_dataloader/test_dataloader_core.py
+++ b/tinytorch/tests/05_dataloader/test_dataloader_core.py
@@ -25,7 +25,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from tinytorch.core.tensor import Tensor
-from tinytorch.core.dataloader import TensorDataset, DataLoader
+from tinytorch.core.dataloader import TensorDataset, DataLoader, RandomHorizontalFlip
 
 
 class TestDataLoaderBasics:
@@ -114,6 +114,37 @@ class TestDataLoaderBasics:
             "Two independently-shuffled loaders produced identical first batches — "
             "shuffle may not be working"
         )
+
+
+class TestTensorDatasetValidation:
+    """Test TensorDataset construction validation."""
+
+    def test_tensor_dataset_zero_tensors_raises(self):
+        """
+        WHAT: TensorDataset() with zero tensor arguments raises.
+
+        WHY: A dataset must wrap at least one tensor. Constructing one
+        with no tensors would have no meaningful length or samples.
+
+        STUDENT LEARNING: TensorDataset enforces its precondition with
+        an assert, so the failure surfaces as AssertionError.
+        """
+        with pytest.raises(AssertionError):
+            TensorDataset()
+
+
+class TestRandomHorizontalFlipValidation:
+    """Test RandomHorizontalFlip probability validation."""
+
+    def test_random_horizontal_flip_negative_p_raises(self):
+        """RandomHorizontalFlip(p=-0.1) raises ValueError."""
+        with pytest.raises(ValueError):
+            RandomHorizontalFlip(p=-0.1)
+
+    def test_random_horizontal_flip_p_above_one_raises(self):
+        """RandomHorizontalFlip(p=1.1) raises ValueError."""
+        with pytest.raises(ValueError):
+            RandomHorizontalFlip(p=1.1)
 
 
 if __name__ == "__main__":

--- a/tinytorch/tests/08_training/test_training_core.py
+++ b/tinytorch/tests/08_training/test_training_core.py
@@ -170,6 +170,61 @@ class TestTrainingLoop:
             "Bias update did not match between accumulation and single batch."
         )
 
+    def test_gradient_accumulation_handles_trailing_partial_batch(self):
+        """
+        WHAT: With accumulation_steps=2 and an odd number of batches (5),
+        the last batch forms a leftover window of size 1.
+
+        WHY: The remainder window must still trigger an optimizer update,
+        otherwise the final batch's gradient is silently dropped.
+
+        STUDENT LEARNING: train_epoch flushes any leftover accumulated
+        gradients after the main loop, even if the window is not full.
+        """
+        from tinytorch.core.tensor import Tensor
+        from tinytorch.core.layers import Linear
+        from tinytorch.core.losses import MSELoss
+        from tinytorch.core.optimizers import SGD
+        from tinytorch.core.training import Trainer
+        from tinytorch.core.autograd import enable_autograd
+
+        enable_autograd()
+
+        layer = Linear(1, 1)
+        layer.weight.data = np.array([[1.0]], dtype=np.float32)
+        layer.bias.data = np.array([0.0], dtype=np.float32)
+
+        optimizer = SGD(layer.parameters(), lr=0.1)
+        trainer = Trainer(layer, optimizer, MSELoss())
+
+        # 5 batches, accumulation_steps=2: updates after batch 2, batch 4,
+        # and a trailing remainder update after batch 5.
+        x = Tensor([[1.0]])
+        y = Tensor([[2.0]])
+        data = [(x, y)] * 5
+
+        weights_before_full_pairs = layer.weight.data.copy()
+        trainer.train_epoch(data, accumulation_steps=2)
+        weights_after_all_batches = layer.weight.data.copy()
+
+        # Compare against only processing the first 4 batches (two full pairs,
+        # no remainder): the trailing batch must contribute an additional update.
+        layer2 = Linear(1, 1)
+        layer2.weight.data = np.array([[1.0]], dtype=np.float32)
+        layer2.bias.data = np.array([0.0], dtype=np.float32)
+        optimizer2 = SGD(layer2.parameters(), lr=0.1)
+        trainer2 = Trainer(layer2, optimizer2, MSELoss())
+        trainer2.train_epoch(data[:4], accumulation_steps=2)
+        weights_after_four_batches = layer2.weight.data.copy()
+
+        assert not np.allclose(weights_after_all_batches, weights_after_four_batches), (
+            "The trailing partial accumulation window (5th batch) should still "
+            "trigger an optimizer update, changing weights beyond the 4-batch case."
+        )
+        assert not np.allclose(weights_after_all_batches, weights_before_full_pairs), (
+            "Weights should have changed after training with a trailing partial batch."
+        )
+
 
 class TestTrainingUtilities:
     """Test training helper functions."""

--- a/tinytorch/tests/08_training/test_training_coverage.py
+++ b/tinytorch/tests/08_training/test_training_coverage.py
@@ -259,6 +259,37 @@ class TestCheckpointing:
             trainer.save_checkpoint(path)
             assert os.path.exists(path)
 
+    def test_momentum_buffers_restored_on_fresh_optimizer(self):
+        """Momentum buffers survive a save/load round trip onto a brand new Trainer."""
+        model = simple_model()
+        opt = SGD(model.parameters(), lr=0.1, momentum=0.9)
+        trainer = Trainer(model, opt, MSELoss())
+
+        data = [(Tensor([[1.0, 0.5]]), Tensor([[2.0]]))]
+        trainer.train_epoch(data)
+
+        original_buffers = [buf.copy() for buf in opt.get_momentum_state()]
+        assert any(np.any(buf != 0) for buf in original_buffers), (
+            "Momentum buffers should be non-zero after a training step"
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as f:
+            path = f.name
+        try:
+            trainer.save_checkpoint(path)
+
+            fresh_model = simple_model()
+            fresh_opt = SGD(fresh_model.parameters(), lr=0.1, momentum=0.9)
+            fresh_trainer = Trainer(fresh_model, fresh_opt, MSELoss())
+            fresh_trainer.load_checkpoint(path)
+
+            restored_buffers = fresh_opt.get_momentum_state()
+            assert len(restored_buffers) == len(original_buffers)
+            for original, restored in zip(original_buffers, restored_buffers):
+                np.testing.assert_allclose(restored, original)
+        finally:
+            os.remove(path)
+
 
 # ─────────────────────────────────────────────
 # Trainer.evaluate
@@ -383,6 +414,36 @@ class TestSchedulerIntegration:
         expected_lr = scheduler.get_lr(0)
         trainer.train_epoch(data)
         assert abs(trainer.optimizer.lr - expected_lr) < 1e-9
+
+    def test_scheduler_state_restored_after_checkpoint_round_trip(self):
+        """Scheduler config and trainer.epoch combine to reproduce the same LR after reload."""
+        scheduler = CosineSchedule(max_lr=0.2, min_lr=0.02, total_epochs=10)
+        trainer, _ = simple_trainer(lr=0.2, scheduler=scheduler)
+        data = [(Tensor([[1.0, 0.5]]), Tensor([[2.0]]))]
+
+        for _ in range(3):
+            trainer.train_epoch(data)
+
+        lr_before_save = scheduler.get_lr(trainer.epoch)
+
+        with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as f:
+            path = f.name
+        try:
+            trainer.save_checkpoint(path)
+
+            fresh_scheduler = CosineSchedule(max_lr=999.0, min_lr=999.0, total_epochs=999)
+            fresh_trainer, _ = simple_trainer(lr=0.2, scheduler=fresh_scheduler)
+            fresh_trainer.load_checkpoint(path)
+
+            assert fresh_trainer.epoch == trainer.epoch
+            assert fresh_scheduler.max_lr == scheduler.max_lr
+            assert fresh_scheduler.min_lr == scheduler.min_lr
+            assert fresh_scheduler.total_epochs == scheduler.total_epochs
+
+            lr_after_load = fresh_scheduler.get_lr(fresh_trainer.epoch)
+            assert abs(lr_after_load - lr_before_save) < 1e-9
+        finally:
+            os.remove(path)
 
     def test_lr_decreases_over_epochs(self):
         scheduler = CosineSchedule(max_lr=0.1, min_lr=0.01, total_epochs=20)


### PR DESCRIPTION
## Summary

Adds regression tests for dataloader and training checkpoint gaps found by an MC/DC-focused audit of the module test suites. Independent of the other companion PRs in this series, each covers a different module group and can be reviewed/merged in any order.

Covered gaps (each verified correct against a clean dev checkout before the test was added, these are not bug fixes):
- `TensorDataset()` with zero tensors raises correctly
- `RandomHorizontalFlip`'s probability-bounds validation (both out-of-range directions)
- `Trainer`'s momentum checkpoint save/restore round trip
- `Trainer`'s scheduler-state checkpoint round trip
- Gradient accumulation's trailing partial-batch flush when batch count doesn't evenly divide `accumulation_steps`

No source or package files touched, tests only.

## Test plan
- [x] `pytest tests/05_dataloader tests/08_training -q` passes locally, including all new cases
- [x] Verified each new test's target behavior directly against a clean dev checkout before adding it