### PR TITLE
test(tinytorch): regression coverage for architecture module gaps

### DIFF
--- a/tinytorch/tests/09_convolutions/test_convolutions_core.py
+++ b/tinytorch/tests/09_convolutions/test_convolutions_core.py
@@ -31,7 +31,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
-from tinytorch.core.spatial import Conv2d, MaxPool2d, AvgPool2d
+from tinytorch.core.spatial import Conv2d, MaxPool2d, AvgPool2d, BatchNorm2d
 from tinytorch.core.tensor import Tensor
 from tinytorch.core.autograd import enable_autograd
 
@@ -356,6 +356,111 @@ class TestConvGradientFlow:
             "Conv weights didn't receive gradients.\n"
             "This means the conv layer cannot learn."
         )
+
+
+class TestInputValidation:
+    """
+    Test that spatial layers reject malformed input shapes with clear errors.
+
+    CONCEPT: Conv2d, MaxPool2d, and AvgPool2d all require 4D NCHW input.
+    Passing the wrong number of dimensions should fail fast with ValueError,
+    not silently produce garbage output.
+    """
+
+    def test_conv2d_rejects_3d_input(self):
+        """WHAT: Conv2d.forward raises ValueError on a 3D input (missing batch dim)."""
+        conv = Conv2d(in_channels=1, out_channels=1, kernel_size=3)
+        x = Tensor(rng.standard_normal((1, 8, 8)))
+        with pytest.raises(ValueError):
+            conv.forward(x)
+
+    def test_maxpool2d_rejects_2d_input(self):
+        """WHAT: MaxPool2d.forward raises ValueError on a 2D input."""
+        pool = MaxPool2d(kernel_size=2, stride=2)
+        x = Tensor(rng.standard_normal((8, 8)))
+        with pytest.raises(ValueError):
+            pool.forward(x)
+
+    def test_avgpool2d_rejects_5d_input(self):
+        """WHAT: AvgPool2d.forward raises ValueError on a 5D input."""
+        pool = AvgPool2d(kernel_size=2, stride=2)
+        x = Tensor(rng.standard_normal((1, 1, 3, 8, 8)))
+        with pytest.raises(ValueError):
+            pool.forward(x)
+
+    def test_avgpool2d_rejects_1d_input(self):
+        """WHAT: AvgPool2d.forward raises ValueError on a 1D input."""
+        pool = AvgPool2d(kernel_size=2, stride=2)
+        x = Tensor(rng.standard_normal(8))
+        with pytest.raises(ValueError):
+            pool.forward(x)
+
+
+class TestConv2dNoGradPropagation:
+    """
+    Test that Conv2d does not attach gradient tracking when neither the
+    input nor the weight requires gradients.
+    """
+
+    def test_no_grad_when_weight_and_input_both_frozen(self):
+        enable_autograd()
+
+        conv = Conv2d(in_channels=1, out_channels=1, kernel_size=3)
+        conv.weight.requires_grad = False
+        x = Tensor(rng.standard_normal((1, 1, 8, 8)), requires_grad=False)
+
+        result = conv.forward(x)
+
+        assert result.requires_grad is False
+        assert getattr(result, "_grad_fn", None) is None
+
+
+class TestBatchNorm2d:
+    """
+    Test BatchNorm2d construction, forward pass, and input validation.
+
+    CONCEPT: BatchNorm2d normalizes each channel across the batch and
+    spatial dimensions, then applies a learnable scale (gamma) and shift
+    (beta).
+    """
+
+    def test_batchnorm2d_creation(self):
+        bn = BatchNorm2d(num_features=4)
+        assert bn.gamma.shape == (4,)
+        assert bn.beta.shape == (4,)
+        assert bn.training is True
+
+    def test_batchnorm2d_forward_valid_4d_input(self):
+        bn = BatchNorm2d(num_features=3)
+        x = Tensor(rng.standard_normal((2, 3, 4, 4)))
+        output = bn.forward(x)
+        assert output.shape == (2, 3, 4, 4)
+
+    def test_batchnorm2d_forward_normalizes_output(self):
+        """Per-channel mean should be near 0 and variance near 1 after normalization."""
+        bn = BatchNorm2d(num_features=2)
+        x = Tensor(rng.standard_normal((16, 2, 4, 4)))
+        output = bn.forward(x)
+        channel_mean = np.mean(output.data, axis=(0, 2, 3))
+        np.testing.assert_allclose(channel_mean, np.zeros(2), atol=1e-5)
+
+    def test_batchnorm2d_validate_input_rejects_3d(self):
+        bn = BatchNorm2d(num_features=3)
+        x = Tensor(rng.standard_normal((3, 4, 4)))
+        with pytest.raises(ValueError):
+            bn._validate_input(x)
+
+    def test_batchnorm2d_validate_input_rejects_2d(self):
+        bn = BatchNorm2d(num_features=3)
+        x = Tensor(rng.standard_normal((4, 4)))
+        with pytest.raises(ValueError):
+            bn._validate_input(x)
+
+    def test_batchnorm2d_validate_input_rejects_channel_mismatch(self):
+        bn = BatchNorm2d(num_features=3)
+        x = Tensor(rng.standard_normal((2, 5, 4, 4)))
+        with pytest.raises(ValueError):
+            bn._validate_input(x)
 
 
 if __name__ == "__main__":

--- a/tinytorch/tests/10_tokenization/test_tokenization_core.py
+++ b/tinytorch/tests/10_tokenization/test_tokenization_core.py
@@ -23,7 +23,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
-from tinytorch.core.tokenization import CharTokenizer
+from tinytorch.core.tokenization import CharTokenizer, create_tokenizer, tokenize_dataset
 
 
 class TestTokenizerBasics:
@@ -94,6 +94,38 @@ class TestTokenizerBasics:
         assert isinstance(vocab_size, int) and vocab_size > 0, (
             "Tokenizer should have positive vocab_size"
         )
+
+
+class TestTokenizeDataset:
+    """Test tokenize_dataset behavior around max_length."""
+
+    def test_no_truncation_when_max_length_omitted(self):
+        """
+        WHAT: With no max_length argument, long sequences are preserved in full.
+
+        WHY: Truncation should only happen when the caller explicitly asks
+        for it. Silent truncation would drop data users didn't opt into
+        losing.
+        """
+        tokenizer = CharTokenizer()
+        long_text = "abcdefghij" * 20  # 200 characters
+        tokenizer.build_vocab([long_text])
+
+        full_length = len(tokenizer.encode(long_text))
+        tokenized = tokenize_dataset([long_text], tokenizer)
+
+        assert len(tokenized[0]) == full_length, (
+            "tokenize_dataset without max_length should not truncate the sequence"
+        )
+
+
+class TestCreateTokenizer:
+    """Test create_tokenizer factory validation."""
+
+    def test_unsupported_strategy_raises_value_error(self):
+        """WHAT: An unsupported strategy string raises ValueError."""
+        with pytest.raises(ValueError):
+            create_tokenizer("word", corpus=["hello world"])
 
 
 if __name__ == "__main__":

--- a/tinytorch/tests/11_embeddings/test_embeddings_core.py
+++ b/tinytorch/tests/11_embeddings/test_embeddings_core.py
@@ -112,5 +112,53 @@ class TestPositionalEncoding:
         )
 
 
+class TestEmbeddingValidation:
+    """Test Embedding index validation."""
+
+    def test_index_at_or_above_vocab_size_raises(self):
+        """WHAT: An index >= vocab_size raises ValueError."""
+        embed = Embedding(vocab_size=10, embed_dim=4)
+        with pytest.raises(ValueError):
+            embed.forward(Tensor([15]))
+
+    def test_negative_index_raises(self):
+        """WHAT: A negative index raises ValueError."""
+        embed = Embedding(vocab_size=10, embed_dim=4)
+        with pytest.raises(ValueError):
+            embed.forward(Tensor([-1]))
+
+
+class TestPositionalEncodingValidation:
+    """Test PositionalEncoding input validation."""
+
+    def test_2d_input_missing_batch_dim_raises(self):
+        """WHAT: A 2D input (missing batch dim) raises ValueError."""
+        pos_enc = PositionalEncoding(max_seq_len=100, embed_dim=64)
+        x = Tensor(rng.standard_normal((50, 64)))
+        with pytest.raises(ValueError):
+            pos_enc.forward(x)
+
+    def test_seq_len_exceeding_max_raises(self):
+        """WHAT: seq_len > max_seq_len raises ValueError."""
+        pos_enc = PositionalEncoding(max_seq_len=10, embed_dim=64)
+        x = Tensor(rng.standard_normal((2, 20, 64)))
+        with pytest.raises(ValueError):
+            pos_enc.forward(x)
+
+    def test_wrong_ndim_input_raises(self):
+        """WHAT: A non-3D input (e.g. 4D) raises ValueError."""
+        pos_enc = PositionalEncoding(max_seq_len=100, embed_dim=64)
+        x = Tensor(rng.standard_normal((2, 3, 50, 64)))
+        with pytest.raises(ValueError):
+            pos_enc.forward(x)
+
+    def test_embed_dim_mismatch_raises(self):
+        """WHAT: An embed_dim mismatch between input and config raises ValueError."""
+        pos_enc = PositionalEncoding(max_seq_len=100, embed_dim=64)
+        x = Tensor(rng.standard_normal((2, 50, 32)))
+        with pytest.raises(ValueError):
+            pos_enc.forward(x)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tinytorch/tests/12_attention/test_attention_core.py
+++ b/tinytorch/tests/12_attention/test_attention_core.py
@@ -228,6 +228,70 @@ class TestMultiHeadAttention:
             # 64 is not divisible by 5
             MultiHeadAttention(embed_dim=64, num_heads=5)
 
+    def test_multihead_accepts_4d_mask_matching_3d_result(self):
+        """
+        WHAT: A mask already shaped (batch, 1, seq, seq) gives the same
+        output as the equivalent (batch, seq, seq) mask.
+
+        WHY: forward() only reshapes 3D masks to 4D for broadcasting across
+        heads. A caller who already supplies the 4D shape should get an
+        identical result, not be silently mishandled.
+        """
+        batch, seq, embed_dim = 2, 5, 32
+        num_heads = 4
+
+        mha = MultiHeadAttention(embed_dim, num_heads)
+        x = Tensor(rng.standard_normal((batch, seq, embed_dim)))
+
+        mask_data = np.tril(np.ones((seq, seq)))
+        mask_3d = Tensor(np.broadcast_to(mask_data, (batch, seq, seq)).copy())
+        mask_4d = Tensor(mask_3d.data.reshape(batch, 1, seq, seq))
+
+        out_3d = mha.forward(x, mask_3d)
+        out_4d = mha.forward(x, mask_4d)
+
+        assert np.allclose(out_3d.data, out_4d.data), (
+            "MultiHeadAttention should produce identical output for an "
+            "equivalent 3D and pre-reshaped 4D mask."
+        )
+
+    def test_multihead_accepts_2d_mask_matching_3d_result(self):
+        """
+        WHAT: A 2D mask shaped (seq, seq) broadcasts the same way as the
+        equivalent per-batch 3D mask.
+
+        WHY: forward() leaves 2D masks untouched (no explicit reshape),
+        relying on numpy broadcasting through _apply_mask. This must still
+        produce the same attention output as passing the mask per-batch.
+        """
+        batch, seq, embed_dim = 2, 5, 32
+        num_heads = 4
+
+        mha = MultiHeadAttention(embed_dim, num_heads)
+        x = Tensor(rng.standard_normal((batch, seq, embed_dim)))
+
+        mask_data = np.tril(np.ones((seq, seq)))
+        mask_2d = Tensor(mask_data.copy())
+        mask_3d = Tensor(np.broadcast_to(mask_data, (batch, seq, seq)).copy())
+
+        out_2d = mha.forward(x, mask_2d)
+        out_3d = mha.forward(x, mask_3d)
+
+        assert np.allclose(out_2d.data, out_3d.data), (
+            "MultiHeadAttention should produce identical output for an "
+            "equivalent 2D and 3D mask."
+        )
+
+    def test_multihead_embed_dim_mismatch_raises(self):
+        """
+        WHAT: Input whose last dim doesn't match the configured embed_dim
+        raises ValueError.
+        """
+        mha = MultiHeadAttention(embed_dim=32, num_heads=4)
+        x = Tensor(rng.standard_normal((2, 5, 16)))
+        with pytest.raises(ValueError):
+            mha.forward(x)
+
 
 class TestAttentionGradientFlow:
     """

--- a/tinytorch/tests/13_transformers/test_transformer_gradient_flow.py
+++ b/tinytorch/tests/13_transformers/test_transformer_gradient_flow.py
@@ -86,6 +86,22 @@ def test_layernorm_gradient_flow():
     print("✅ LayerNorm gradient flow works correctly")
 
 
+def test_layernorm_no_grad_when_all_inputs_frozen():
+    """LayerNorm should not attach gradient tracking when gamma, beta,
+    and x all have requires_grad=False."""
+    batch_size, seq_len, embed_dim = 2, 8, 16
+
+    ln = LayerNorm(embed_dim)
+    ln.gamma.requires_grad = False
+    ln.beta.requires_grad = False
+
+    x = Tensor(rng.standard_normal((batch_size, seq_len, embed_dim)), requires_grad=False)
+    output = ln.forward(x)
+
+    assert output.requires_grad is False
+    assert getattr(output, "_grad_fn", None) is None
+
+
 def test_mlp_gradient_flow():
     """Test that MLP parameters receive gradients."""
     print("Testing MLP gradient flow...")


### PR DESCRIPTION
## Summary

Adds regression tests for architecture module gaps found by an MC/DC-focused audit: convolutions, tokenization, embeddings, attention, and transformers. Independent of the other companion PRs in this series, each covers a different module group and can be reviewed/merged in any order.

Covered gaps (each verified correct against a clean dev checkout before the test was added, these are not bug fixes):
- Non-4D input validation for `Conv2d`/`MaxPool2d`/`AvgPool2d`
- `Conv2d`'s `requires_grad` propagation when neither operand needs gradients
- `BatchNorm2d`'s standalone pytest coverage (previously zero)
- `tokenize_dataset`'s default no-truncation path, `create_tokenizer`'s invalid-strategy error
- `Embedding`'s out-of-range and negative index validation
- `PositionalEncoding`'s four shape-validation checks
- `MultiHeadAttention`'s non-3D mask handling and `embed_dim` mismatch check
- `LayerNorm`'s all-frozen `requires_grad` branch

No source or package files touched, tests only.

## Test plan
- [x] `pytest tests/09_convolutions tests/10_tokenization tests/11_embeddings tests/12_attention tests/13_transformers -q` passes locally, including all new cases
- [x] Verified each new test's target behavior directly against a clean dev checkout before adding it