### PR TITLE
test(tinytorch): regression coverage for milestone grading/gating logic

### DIFF
--- a/tinytorch/tests/cli/test_release_regressions.py
+++ b/tinytorch/tests/cli/test_release_regressions.py
@@ -4,11 +4,13 @@ Release regression tests for student-facing CLI and API correctness.
 
 import importlib.util
 import io
+import json
 import os
 import subprocess
 import sys
 from argparse import Namespace
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 from rich.console import Console
@@ -16,6 +18,9 @@ from rich.console import Console
 from tito.commands.export_utils import find_source_file_for_export
 from tito.commands.milestone import (
     MILESTONE_SCRIPTS,
+    MilestoneCommand,
+    MilestoneSystem,
+    _module_progress_to_int,
     _required_modules_for,
     _validate_required_exports,
 )
@@ -193,3 +198,104 @@ def test_generated_warning_points_to_current_export_command():
 
     assert "tito module complete XX" in text
     assert "tito module complete <module_name>" not in text
+
+
+def _write_milestone_progress_files(tmp_path, completed_modules, unlocked_milestones=None):
+    tito_dir = tmp_path / ".tito"
+    tito_dir.mkdir(exist_ok=True)
+    (tito_dir / "progress.json").write_text(json.dumps({"completed_modules": completed_modules}))
+    (tito_dir / "milestones.json").write_text(json.dumps({
+        "completed_milestones": [],
+        "completion_dates": {},
+        "unlocked_milestones": unlocked_milestones or [],
+        "unlock_dates": {},
+        "total_unlocked": len(unlocked_milestones or []),
+        "achievements": [],
+    }))
+
+
+def test_can_unlock_true_when_required_and_trigger_complete_and_not_unlocked(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    _write_milestone_progress_files(tmp_path, completed_modules=[1, 2, 3])
+
+    system = MilestoneSystem(CLIConfig.from_project_root(TINYTORCH_ROOT))
+    status = system.get_milestone_status()
+
+    assert status["milestones"]["01"]["can_unlock"] is True
+
+
+def test_can_unlock_false_when_already_unlocked(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    _write_milestone_progress_files(tmp_path, completed_modules=[1, 2, 3], unlocked_milestones=["01"])
+
+    system = MilestoneSystem(CLIConfig.from_project_root(TINYTORCH_ROOT))
+    status = system.get_milestone_status()
+
+    assert status["milestones"]["01"]["can_unlock"] is False
+
+
+def test_can_unlock_false_when_nothing_completed(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    _write_milestone_progress_files(tmp_path, completed_modules=[])
+
+    system = MilestoneSystem(CLIConfig.from_project_root(TINYTORCH_ROOT))
+    status = system.get_milestone_status()
+
+    assert status["milestones"]["01"]["can_unlock"] is False
+
+
+def test_module_progress_to_int_accepts_int():
+    assert _module_progress_to_int(6) == 6
+
+
+def test_module_progress_to_int_parses_numeric_prefix_string():
+    assert _module_progress_to_int("06_autograd") == 6
+
+
+def test_module_progress_to_int_rejects_unparseable_string():
+    assert _module_progress_to_int("abc") is None
+
+
+def test_module_progress_to_int_rejects_wrong_type():
+    assert _module_progress_to_int(None) is None
+    assert _module_progress_to_int(3.5) is None
+
+
+def test_export_validator_reports_import_error(monkeypatch):
+    monkeypatch.setitem(sys.modules, "tinytorch.core.tensor", None)
+
+    failures = _validate_required_exports([1])
+
+    assert any(
+        failure.startswith("tinytorch.core.tensor.Tensor: import failed")
+        for failure in failures
+    )
+
+
+def test_run_command_stops_after_first_failure_when_noninteractive(monkeypatch):
+    monkeypatch.chdir(TINYTORCH_ROOT)
+    command = MilestoneCommand(CLIConfig.from_project_root(TINYTORCH_ROOT))
+    command.console = Console(file=io.StringIO(), width=120)
+
+    args = Namespace(milestone_id="06", part=None, skip_checks=True)
+
+    run_calls = []
+
+    def fake_run(cmd, **kwargs):
+        run_calls.append(cmd)
+        result = MagicMock()
+        result.returncode = 1
+        return result
+
+    with patch("tito.commands.milestone.subprocess.run", side_effect=fake_run), \
+         patch("sys.stdin") as mock_stdin, \
+         patch("sys.stdout") as mock_stdout, \
+         patch("builtins.input") as mock_input:
+        mock_stdin.isatty.return_value = False
+        mock_stdout.isatty.return_value = False
+
+        returncode = command._handle_run_command(args)
+
+    assert returncode == 1
+    assert len(run_calls) == 1
+    mock_input.assert_not_called()

--- a/tinytorch/tests/milestones/test_milestone_grading_logic.py
+++ b/tinytorch/tests/milestones/test_milestone_grading_logic.py
@@ -1,0 +1,80 @@
+"""
+Regression tests for milestone-05's final grading logic.
+
+Milestone 05 (milestones/05_2017_transformer/01_vaswani_attention.py) decides
+pass/fail via `print_final_results`, which combines three challenge results
+with `passed1 and passed2 and passed3`. This has no direct test coverage
+today, so these tests lock in the existing (audited, correct) behavior.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+TINYTORCH_ROOT = Path(__file__).resolve().parents[2]
+MILESTONE_05_SCRIPT = TINYTORCH_ROOT / "milestones" / "05_2017_transformer" / "01_vaswani_attention.py"
+
+sys.path.insert(0, str(TINYTORCH_ROOT))
+sys.path.insert(0, str(TINYTORCH_ROOT / "milestones"))
+
+
+def _import_milestone_05():
+    spec = importlib.util.spec_from_file_location(MILESTONE_05_SCRIPT.stem, MILESTONE_05_SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_print_final_results_all_challenges_passing(capsys):
+    module = _import_milestone_05()
+
+    results = {
+        "reversal": (True, 96.0),
+        "copying": (True, 97.5),
+        "mixed": (True, 91.0),
+    }
+
+    returncode = module.print_final_results(results)
+
+    captured = capsys.readouterr()
+    assert returncode == 0
+    assert "MILESTONE 05 COMPLETE" in captured.out
+    assert "CHALLENGES FAILED" not in captured.out
+
+
+def test_print_final_results_only_one_challenge_passing(capsys):
+    module = _import_milestone_05()
+
+    results = {
+        "reversal": (True, 96.0),
+        "copying": (False, 40.0),
+        "mixed": (False, 30.0),
+    }
+
+    returncode = module.print_final_results(results)
+
+    captured = capsys.readouterr()
+    assert returncode == 1
+    assert "CHALLENGES FAILED" in captured.out
+    assert "Copying" in captured.out
+    assert "Mixed Tasks" in captured.out
+    assert "Reversal" not in captured.out.split("CHALLENGES FAILED")[1].split("\n")[0]
+
+
+def test_print_final_results_all_challenges_failing(capsys):
+    module = _import_milestone_05()
+
+    results = {
+        "reversal": (False, 10.0),
+        "copying": (False, 20.0),
+        "mixed": (False, 5.0),
+    }
+
+    returncode = module.print_final_results(results)
+
+    captured = capsys.readouterr()
+    assert returncode == 1
+    assert "CHALLENGES FAILED" in captured.out
+    assert "Reversal" in captured.out.split("CHALLENGES FAILED")[1].split("\n")[0]
+    assert "Copying" in captured.out.split("CHALLENGES FAILED")[1].split("\n")[0]
+    assert "Mixed Tasks" in captured.out.split("CHALLENGES FAILED")[1].split("\n")[0]


### PR DESCRIPTION
## Summary

Adds regression tests for the milestone system's grading/gating logic, found by an MC/DC-focused audit to be correct but previously exercised only by slow end-to-end runs that couldn't isolate individual conditions. Independent of the other companion PRs in this series, each covers a different module group and can be reviewed/merged in any order.

Covered gaps (each verified correct against a clean dev checkout before the test was added, these are not bug fixes):
- The `can_unlock` gate (`MilestoneSystem`)
- `_module_progress_to_int`'s four input-type paths
- `_validate_required_exports`'s `ImportError` branch
- `_handle_run_command`'s non-interactive continue-on-failure abort path
- Milestone 05's `passed1`/`passed2`/`passed3` grading logic in `print_final_results`

No source or package files touched, tests only.

## Test plan
- [x] `pytest tests/cli/test_release_regressions.py tests/milestones -q` passes locally, including all new cases
- [x] Verified each new test's target behavior directly against a clean dev checkout before adding it