### PR TITLE
fix(tinytorch): Optimizer.__init__ silently discarded a pre-existing param.grad

### DIFF
--- a/tinytorch/src/07_optimizers/07_optimizers.py
+++ b/tinytorch/src/07_optimizers/07_optimizers.py
@@ -257,11 +257,14 @@ class Optimizer:
         # Store parameters
         self.params = params
 
-        # Ensure parameters participate in autograd once it is enabled
+        # Ensure parameters participate in autograd once it is enabled.
+        # Only initialize grad if it isn't set yet, a caller may have already
+        # computed and assigned a gradient before constructing the optimizer.
         for param in self.params:
             if isinstance(param, Tensor):
                 param.requires_grad = True
-                param.grad = None
+                if not hasattr(param, 'grad'):
+                    param.grad = None
         self.step_count = 0  # For algorithms that need step counting
         ### END SOLUTION
 

--- a/tinytorch/tests/07_optimizers/test_optimizer_core.py
+++ b/tinytorch/tests/07_optimizers/test_optimizer_core.py
@@ -283,5 +283,42 @@ class TestMultipleParameters:
             )
 
 
+class TestOptimizerPreservesExistingGrad:
+    """Test Optimizer construction doesn't discard a gradient set beforehand."""
+
+    def test_pre_existing_grad_survives_optimizer_construction(self):
+        """
+        WHAT: Verify a gradient assigned to a parameter before the optimizer
+        is constructed is not silently wiped by __init__.
+
+        WHY: A caller who computes gradients (e.g. via backward()) before
+        building the optimizer should not have that work discarded just
+        because SGD(params, ...) happened to run afterward. The optimizer
+        should only guarantee params are grad-tracked, not reset state that
+        already exists.
+        """
+        param = Tensor(np.array([1.0, 2.0, 3.0]), requires_grad=True)
+        param.grad = np.array([0.1, 0.2, 0.3])
+
+        SGD([param], lr=0.01)
+
+        assert param.grad is not None
+        assert np.allclose(param.grad, np.array([0.1, 0.2, 0.3]))
+
+    def test_param_without_grad_still_gets_grad_attribute(self):
+        """
+        WHAT: Verify a parameter with no grad attribute yet still ends up
+        with one (set to None) after optimizer construction.
+        """
+        param = Tensor(np.array([1.0, 2.0, 3.0]))
+        if hasattr(param, 'grad'):
+            del param.grad
+
+        SGD([param], lr=0.01)
+
+        assert hasattr(param, 'grad')
+        assert param.grad is None
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

`Optimizer.__init__` unconditionally set `param.grad = None` for every parameter, so a gradient a caller computed and assigned before constructing the optimizer was silently wiped with no warning.

Only sets `grad` when the attribute isn't present yet, preserving any gradient a caller already assigned while still guaranteeing every param has a `grad` attribute for tensors created before autograd was enabled.

Found via an MC/DC-focused audit of the module test suites, then reproduced and confirmed directly against a clean `dev` checkout before this fix was written.

## Test plan
- [x] `pytest tests/07_optimizers -q` passes locally, including the new tests covering both a pre-existing grad and a param with no grad attribute yet
- [x] Confirmed the bug reproduces on `dev` before the fix, and no longer reproduces after