### PR TITLE
fix(tinytorch): validate_submission_schema was never exported to the package

### DIFF
--- a/tinytorch/src/20_capstone/20_capstone.py
+++ b/tinytorch/src/20_capstone/20_capstone.py
@@ -1423,6 +1423,7 @@ This test validates submissions conform to the required schema.
 """
 
 # %% nbgrader={"grade": true, "grade_id": "test-submission-schema", "locked": true, "points": 10}
+#| export
 def validate_submission_schema(submission: Dict[str, Any]) -> bool:
     """
     Validate submission JSON conforms to required schema.

--- a/tinytorch/tests/20_capstone/test_capstone_core.py
+++ b/tinytorch/tests/20_capstone/test_capstone_core.py
@@ -174,5 +174,68 @@ class TestEndToEndIntegration:
         )
 
 
+class TestValidateSubmissionSchema:
+    """Test validate_submission_schema is importable and rejects bad input.
+
+    This function previously wasn't exported to the built tinytorch package
+    at all (missing #| export marker), so it was unreachable from pytest or
+    from anything outside the source notebook. These tests both confirm the
+    import path works and exercise its actual validation logic, which had
+    never been tested against malformed input before.
+    """
+
+    def _valid_submission(self):
+        from tinytorch.olympics import validate_submission_schema
+        return validate_submission_schema, {
+            'tinytorch_version': '0.1.0',
+            'submission_type': 'capstone_benchmark',
+            'timestamp': '2026-01-01T00:00:00',
+            'system_info': {'platform': 'test', 'python_version': '3.11'},
+            'baseline': {
+                'model_name': 'baseline_model',
+                'metrics': {
+                    'parameter_count': 1024,
+                    'model_size_mb': 4.0,
+                    'accuracy': 0.9,
+                    'latency_ms_mean': 12.5,
+                },
+            },
+        }
+
+    def test_importable_from_package(self):
+        """WHAT: Verify the function can actually be imported from tinytorch.olympics."""
+        from tinytorch.olympics import validate_submission_schema
+        assert validate_submission_schema is not None
+
+    def test_valid_submission_passes(self):
+        """WHAT: Verify a well-formed submission validates successfully."""
+        validate_submission_schema, submission = self._valid_submission()
+        assert validate_submission_schema(submission) is True
+
+    def test_missing_required_field_raises(self):
+        """WHAT: Verify a submission missing a required top-level field is rejected."""
+        validate_submission_schema, submission = self._valid_submission()
+        del submission['tinytorch_version']
+
+        with pytest.raises(AssertionError):
+            validate_submission_schema(submission)
+
+    def test_accuracy_above_valid_range_raises(self):
+        """WHAT: Verify an out-of-range accuracy value (> 1) is rejected."""
+        validate_submission_schema, submission = self._valid_submission()
+        submission['baseline']['metrics']['accuracy'] = 1.5
+
+        with pytest.raises(AssertionError):
+            validate_submission_schema(submission)
+
+    def test_accuracy_below_valid_range_raises(self):
+        """WHAT: Verify an out-of-range accuracy value (< 0) is rejected."""
+        validate_submission_schema, submission = self._valid_submission()
+        submission['baseline']['metrics']['accuracy'] = -0.1
+
+        with pytest.raises(AssertionError):
+            validate_submission_schema(submission)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

`validate_submission_schema` was missing the `#| export` marker every other public function in this module has, so it never made it into the built `tinytorch` package (`tinytorch/olympics.py`). The capstone's only submission validation function was unreachable from anywhere outside the source notebook, including pytest, meaning its negative-path behavior (rejecting malformed submissions) had never actually been exercised by CI.

Adds the export marker so it ships in the package, and adds direct tests covering both the valid-submission path and the negative paths (missing required field, out-of-range accuracy in both directions).

Found via an MC/DC-focused audit of the module test suites, then reproduced and confirmed directly against a clean `dev` checkout before this fix was written.

## Test plan
- [x] `pytest tests/20_capstone/test_capstone_core.py -q` passes locally, including new tests importing the function from `tinytorch.olympics` and exercising both valid and invalid submissions
- [x] Confirmed the function was unreachable via `from tinytorch.olympics import validate_submission_schema` on `dev` before the fix