### PR TITLE
fix(tinytorch): CrossEntropyLoss raised a raw numpy IndexError on bad targets

### DIFF
--- a/tinytorch/src/04_losses/04_losses.py
+++ b/tinytorch/src/04_losses/04_losses.py
@@ -634,7 +634,16 @@ class CrossEntropyLoss:
 
         # Step 2: Select log-probabilities for correct classes
         batch_size = logits.shape[0]
+        num_classes = logits.shape[-1]
         target_indices = targets.data.astype(int)
+
+        out_of_range = (target_indices < 0) | (target_indices >= num_classes)
+        if np.any(out_of_range):
+            bad_values = np.unique(target_indices[out_of_range])
+            raise ValueError(
+                f"CrossEntropyLoss target index out of range: {bad_values.tolist()}\n"
+                f"  Valid range for {num_classes} classes is [0, {num_classes - 1}]"
+            )
 
         # Select correct class log-probabilities using advanced indexing
         selected_log_probs = log_probs.data[np.arange(batch_size), target_indices]

--- a/tinytorch/src/06_autograd/06_autograd.py
+++ b/tinytorch/src/06_autograd/06_autograd.py
@@ -2944,7 +2944,17 @@ def enable_autograd(quiet=False):
 
             # Select log-probabilities for correct classes
             batch_size = logits.shape[0]
+            num_classes = logits.shape[-1]
             target_indices = targets.data.astype(int)
+
+            out_of_range = (target_indices < 0) | (target_indices >= num_classes)
+            if np.any(out_of_range):
+                bad_values = np.unique(target_indices[out_of_range])
+                raise ValueError(
+                    f"CrossEntropyLoss target index out of range: {bad_values.tolist()}\n"
+                    f"  Valid range for {num_classes} classes is [0, {num_classes - 1}]"
+                )
+
             selected_log_probs = log_probs.data[np.arange(batch_size), target_indices]
 
             # Return negative mean

--- a/tinytorch/tests/04_losses/test_losses_core.py
+++ b/tinytorch/tests/04_losses/test_losses_core.py
@@ -102,5 +102,48 @@ class TestCrossEntropyLoss:
         )
 
 
+class TestCrossEntropyLossOutOfRangeTargets:
+    """Test CrossEntropyLoss raises a clear error for invalid target indices."""
+
+    def test_target_equal_to_num_classes_raises_value_error(self):
+        """
+        WHAT: Verify a target index equal to num_classes (the first invalid
+        value, since valid indices are 0..num_classes-1) raises a clear
+        ValueError naming the problem, not a raw numpy IndexError.
+        """
+        loss_fn = CrossEntropyLoss()
+        logits = Tensor([[2.0, 1.0, 0.1]])  # 3 classes, valid range [0, 2]
+        target = Tensor([3])
+
+        with pytest.raises(ValueError, match="out of range"):
+            loss_fn(logits, target)
+
+    def test_negative_target_raises_value_error(self):
+        """
+        WHAT: Verify a negative target index raises the same clear
+        ValueError, rather than numpy's negative-indexing silently
+        selecting the wrong class.
+        """
+        loss_fn = CrossEntropyLoss()
+        logits = Tensor([[2.0, 1.0, 0.1]])
+        target = Tensor([-1])
+
+        with pytest.raises(ValueError, match="out of range"):
+            loss_fn(logits, target)
+
+    def test_valid_targets_still_work(self):
+        """
+        WHAT: Verify targets within the valid range are unaffected by the
+        new bounds check.
+        """
+        loss_fn = CrossEntropyLoss()
+        logits = Tensor([[2.0, 1.0, 0.1], [0.5, 1.5, 0.8]])
+        target = Tensor([0, 1])
+
+        loss = loss_fn(logits, target)
+
+        assert float(loss.data) > 0
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

`CrossEntropyLoss.forward` used target indices directly in numpy fancy indexing with no bounds check, so an out-of-range or negative target class index surfaced as a raw `"index N is out of bounds"` `IndexError` instead of a clear domain-specific error naming the actual problem (an invalid target index) and the valid range.

Module 06's `enable_autograd()` installs a second, separate implementation of cross-entropy forward (`tracked_ce_forward`) to add gradient tracking, which duplicated the same unchecked indexing. Both copies needed the same validation, otherwise the fix would silently stop applying the moment autograd is enabled, which is the normal case in any real training loop.

Both now raise a clear `ValueError` naming the invalid index and the valid class range before attempting the indexing.

Found via an MC/DC-focused audit of the module test suites, then reproduced and confirmed directly against a clean `dev` checkout before this fix was written.

## Test plan
- [x] `pytest tests/04_losses -q` passes locally, including new tests for an out-of-range target, a negative target, and valid targets
- [x] `pytest tests/06_autograd -q` still passes (49 passed, 18 skipped), confirming the duplicate autograd-path fix doesn't regress gradient tracking
- [x] Confirmed the raw `IndexError` reproduces on `dev` before the fix, both with and without `enable_autograd()` called