### PR TITLE
fix(tinytorch): test_sequential_layer_composition tested a shadowed mock, not the real class

### DIFF
--- a/tinytorch/tests/03_layers/test_layers_core.py
+++ b/tinytorch/tests/03_layers/test_layers_core.py
@@ -28,7 +28,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
-from tinytorch.core.layers import Layer
+from tinytorch.core.layers import Layer, Sequential
 from tinytorch.core.tensor import Tensor
 
 
@@ -373,14 +373,6 @@ class TestLayerComposition:
         STUDENT LEARNING: Sequential is like a list of layers.
         forward() runs each layer in order on the input.
         """
-        class Sequential(Layer):
-            def __init__(self, layers):
-                self.layers = layers
-            def forward(self, x):
-                for layer in self.layers:
-                    x = layer(x)
-                return x
-
         class LinearLayer(Layer):
             def __init__(self, weights):
                 self.weights = Tensor(weights)


### PR DESCRIPTION
## Summary

`test_sequential_layer_composition` defined a local `class Sequential(Layer)` that shadowed the `tinytorch.core.layers.Sequential` import, so the test never actually exercised the real container class despite its name and docstring both claiming to test `Sequential` composition.

Removes the local mock and imports the real `Sequential` instead. The real class has a slightly different constructor (`Sequential(*layers)` supporting both `Sequential(l1, l2)` and `Sequential([l1, l2])`, rather than the mock's `Sequential(layers)`-only signature), but the existing call site here already used the list form, so no test logic changed.

Found via an MC/DC-focused audit of the module test suites.

## Test plan
- [x] `pytest tests/03_layers/test_layers_core.py -q` passes locally, now genuinely exercising `tinytorch.core.layers.Sequential`