### PR TITLE
fix(socratiq): enable AI companion bundle on vol1 and vol2

### DIFF
--- a/book/quarto/config/_quarto-html-vol1.yml
+++ b/book/quarto/config/_quarto-html-vol1.yml
@@ -58,6 +58,7 @@ project:
   resources:
     - assets/images/covers/*
     - assets/downloads/*
+    - tools/scripts/socratiQ/*.js
 
   post-render:
     - scripts/clean_svgs.py
@@ -272,8 +273,7 @@ format:
                The publish workflow drops release-manifest.json at
                /vol1/release-manifest.json before deploy. -->
           <meta name="release-manifest" content="/vol1/release-manifest.json">
-          <!-- SocratiQ bundle disabled pending quiz regeneration: -->
-          <!-- <script type="module" src="/tools/scripts/socratiQ/bundle.js" defer></script> -->
+          <script type="module" src="/tools/scripts/socratiQ/bundle.js" defer></script>
           <script src="/assets/scripts/sidebar-auto-collapse.js" defer></script>
           <script src="/assets/scripts/version-link.js" defer></script>
           <script src="/assets/scripts/subscribe-modal.js" defer></script>

--- a/book/quarto/config/_quarto-html-vol2.yml
+++ b/book/quarto/config/_quarto-html-vol2.yml
@@ -13,6 +13,7 @@ project:
   resources:
     - assets/images/covers/*
     - assets/downloads/*
+    - tools/scripts/socratiQ/*.js
 
   # Full render manifest (vol2 HTML). An explicit list is required here: the
   # project index (index.qmd) and the website homepage (index-vol2.qmd) BOTH
@@ -284,8 +285,7 @@ format:
                The publish workflow drops release-manifest.json at
                /vol2/release-manifest.json before deploy. -->
           <meta name="release-manifest" content="/vol2/release-manifest.json">
-          <!-- SocratiQ bundle disabled pending quiz regeneration: -->
-          <!-- <script type="module" src="/tools/scripts/socratiQ/bundle.js" defer></script> -->
+          <script type="module" src="/tools/scripts/socratiQ/bundle.js" defer></script>
           <script src="/assets/scripts/sidebar-auto-collapse.js" defer></script>
           <script src="/assets/scripts/version-link.js" defer></script>
           <script src="/assets/scripts/subscribe-modal.js" defer></script>


### PR DESCRIPTION
Follow-up to #1978. **Holding for @profvjreddi's sign-off — please don't merge until he's weighed in.**

### Why this is needed

#1978 merged the `Ctrl + /` shortcut fix and the load-flash fix, but the bundle enable was deliberately pulled out in 06895ddd5 per @Shashank-Tripathi-07's review, pending sign-off from @profvjreddi (who disabled it in d0a2bd109a, "pending quiz regeneration").

The consequence is that **the merged fixes are inert on staging**. With `bundle.js` still commented out of both HTML configs, the widget never initializes, so `shortcutKeys()` never binds its listeners, and `Ctrl + /` falls through to Quarto's search box. The originally reported bug still reproduces on staging today — the fix is on `dev`, it just isn't reachable.

### What this changes

Exactly what 06895ddd5 reverted, and nothing else — 4 lines across 2 files:

- Uncomment the `bundle.js` script tag in `_quarto-html-vol1.yml` and `_quarto-html-vol2.yml`
- Restore the `tools/scripts/socratiQ/*.js` resources glob so the bundle is copied into the build output

The standalone `socratiq-search-shortcut-fix.js` shim is **not** restored. 06895ddd5 folded that logic into `shortcutKeys()` in `open_close_menu.js` behind an `isActiveWidget()` guard — a better shape, already on `dev`, and it works standalone once the widget loads.

### Scope

This enables the SocratiQ **chat widget only**. It does not re-enable `inject_quizzes.lua` and does not touch the `*_quizzes.json` data — that's a separate system, consistent with @Shashank-Tripathi-07's analysis in #1978 that SocratiQ's chat doesn't read those files.

### On the quiz-regeneration blocker

Recording @Shashank-Tripathi-07's findings from #1978 so the decision has them in one place — this is his research, not independent verification on my part:

- Quiz regeneration appears complete (`quiz/vol1-pass` / `quiz/vol2-pass` merged, last correction 2026-07-16)
- SocratiQ chat doesn't touch the stale `*_quizzes.json` files

@profvjreddi — you disabled this, so it's your call. Happy to close this if you'd rather it wait, or adjust the scope. cc @dekasthiti, who asked in #1978 about timing.
