### PR TITLE
fix(tinytorch): fix big-picture layout escape, card alignment, and dark-mode table contrast

### DIFF
--- a/tinytorch/quarto/assets/styles/dark-mode.scss
+++ b/tinytorch/quarto/assets/styles/dark-mode.scss
@@ -267,6 +267,35 @@ div[role="doc-toc"] {
   border: 1px solid $border-color-dark;
 }
 
+// --- Learning-path cards in dark mode ---
+// These used to be inline-styled panels caught by the hex-normalisation
+// block below, which flattened all four tracks to the same #2d2d2d and
+// dropped their accent borders — the colour coding carried no information.
+// Because .path-card derives every fill from --path-accent, dark mode only
+// has to retune the mix ratios: each track keeps its hue at a low enough
+// saturation to sit on the #1a1a1a body.
+.path-card {
+  background: color-mix(in srgb, var(--path-accent) 14%, #232323);
+  border-color: color-mix(in srgb, var(--path-accent) 32%, transparent);
+
+  .path-title { color: #f1f5f9; }
+  .path-route { color: #cbd5e1; }
+  dt { color: #e2e8f0; }
+  dd { color: #cbd5e1; }
+
+  dl {
+    border-top-color: color-mix(in srgb, var(--path-accent) 28%, transparent);
+  }
+}
+
+.path-routes {
+  li {
+    border-left-color: color-mix(in srgb, #{$accent-dark} 45%, transparent);
+  }
+
+  strong { color: #f1f5f9; }
+}
+
 // --- Code block surface in dark mode ---
 // Quarto's default styles `div.sourceCode { background: rgba(233, 236, 239, 0.65) }`
 // — a LIGHT fill at 65% opacity. Over the #1a1a1a body that blends to a

--- a/tinytorch/quarto/assets/styles/style.scss
+++ b/tinytorch/quarto/assets/styles/style.scss
@@ -668,6 +668,84 @@ $callout-secondary-bg: rgba($callout-secondary, 0.08);
   background-color: rgba(255, 255, 255, 0.07);
 }
 
+// --- Table text colour in dark mode ---
+//
+// shared/styles/partials/_tables.scss hardcodes dark-on-light text: #495057
+// on th/td (and #5a6369 / #2c3e50 in the .table-container variant). Against
+// the #1a1a1a dark body that lands at roughly 1.9:1 contrast — well under
+// the WCAG AA 4.5:1 minimum, which is the washed-out grey seen in dark mode.
+//
+// Scoped to [data-bs-theme="dark"] to match the zebra-stripe override above,
+// so it covers both true dark mode and the hybrid state. Headers take a
+// brighter tone than body cells to preserve the original hierarchy rather
+// than flattening everything to one colour.
+[data-bs-theme="dark"] table {
+  th {
+    color: #f1f5f9;
+    background-color: transparent;
+    // Literal rather than $border-color-dark: that variable is declared in
+    // dark-mode.scss, which is not in scope when this file compiles into the
+    // light bundle.
+    border-bottom-color: #454d55;
+  }
+
+  td {
+    color: #dbe2ea;
+    border-bottom-color: rgba(255, 255, 255, 0.08);
+  }
+
+  // The shared partial gives the first column its own light fill + darker
+  // text as a row-header treatment; restate it for the dark surface so the
+  // column still reads as a header instead of inheriting a light background.
+  td:first-child,
+  th:first-child {
+    color: #f1f5f9;
+    background-color: transparent;
+    border-right-color: rgba(255, 255, 255, 0.08);
+  }
+
+  caption {
+    color: #cbd5e1;
+  }
+}
+
+// Quarto renders the table caption as a sibling <figcaption> outside the
+// <table>, so the `caption` rule above never reaches it. The shared partial
+// colours it #495057, which is the same sub-AA grey on a dark body.
+[data-bs-theme="dark"] figcaption.quarto-float-caption {
+  color: #cbd5e1 !important;
+}
+
+// The shared partial tints the first column as a row-header block. With the
+// zebra stripe now drawn as a white overlay, that extra fill reads as a
+// stray rectangle butting into the middle of the table; the column already
+// reads as a header from its brighter text weight alone.
+[data-bs-theme="dark"] table tbody tr:nth-child(even) td:first-child {
+  background-color: transparent;
+}
+
+// --- Table horizontal alignment with body prose ---
+//
+// The base `table` rule sets `width: 100%` with cell padding of 16px, but
+// the leading cell's *text* then starts flush at the container's left edge
+// (measured: first th/td at x=0 while surrounding prose text starts at the
+// content margin). The table reads as full-bleed next to the paragraphs
+// above it even though the container widths match.
+//
+// Zeroing the outer edge padding and letting the table inherit the prose
+// margin keeps column text on the same vertical line as body copy.
+table {
+  th:first-child,
+  td:first-child {
+    padding-left: 0;
+  }
+
+  th:last-child,
+  td:last-child {
+    padding-right: 0;
+  }
+}
+
 @media (max-width: 768px) {
   .action-cards {
     grid-template-columns: 1fr;
@@ -728,5 +806,121 @@ pre.mermaid svg {
 @media (max-width: 768px) {
   .who-grid {
     grid-template-columns: 1fr;
+  }
+}
+
+// Learning-path cards on big-picture.qmd ("Choose Your Learning Path").
+//
+// Replaces the inline `style="background: #e3f2fd; ..."` panels this section
+// used to carry. Those were flattened to a single grey by the inline-hex
+// normalisation block in dark-mode.scss, which erased the per-track colour
+// coding; driving the fills from `--path-accent` here lets dark mode retint
+// each track instead of overriding it.
+.path-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.25rem;
+  margin: 1.5rem 0;
+  align-items: stretch;
+}
+
+.path-card {
+  // Per-card accent, set inline via `style="--path-accent: ..."` on each card.
+  // Fills derive from it so a track only ever declares one colour.
+  --path-accent: #{$accent};
+
+  display: flex;
+  flex-direction: column;
+  padding: 1.25rem 1.25rem 1.35rem;
+  border: 1px solid color-mix(in srgb, var(--path-accent) 24%, transparent);
+  border-top: 3px solid var(--path-accent);
+  border-radius: 0.5rem;
+  background: color-mix(in srgb, var(--path-accent) 7%, #fff);
+
+  // Title
+  .path-title {
+    margin: 0;
+    font-size: 1.05rem;
+    font-weight: 600;
+    line-height: 1.3;
+    color: #1e293b;
+  }
+
+  // Module-range subtitle. min-height reserves two lines so the <dl> below
+  // starts at the same y-offset in every card even when one subtitle wraps
+  // and its neighbour does not — the misalignment the inline markup had.
+  .path-route {
+    display: block;
+    margin: 0.3rem 0 0 0;
+    min-height: 2.6em;
+    font-size: 0.875rem;
+    line-height: 1.3;
+    color: #475569;
+  }
+
+  // Body: a two-column definition list so the Best for / Time / Outcome
+  // values align on a shared label column across all four cards.
+  dl {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.3rem 0.5rem;
+    margin: 0.9rem 0 0 0;
+    padding-top: 0.9rem;
+    border-top: 1px solid color-mix(in srgb, var(--path-accent) 18%, transparent);
+    font-size: 0.925rem;
+    line-height: 1.45;
+  }
+
+  dt {
+    font-weight: 600;
+    color: #334155;
+    white-space: nowrap;
+  }
+
+  dd {
+    margin: 0;
+    color: #475569;
+  }
+}
+
+// Flexible-paths route list, directly above the cards. Presents the three
+// routes as compact rows rather than loose bullets so it reads as a summary
+// of the grid that follows.
+.path-routes {
+  margin: 1rem 0 1.75rem;
+  padding: 0;
+  list-style: none;
+
+  // A small indent keeps the accent bar inside the content column (a
+  // negative pull would clip it at the page edge) while the route text
+  // still sits close to the surrounding prose margin.
+  li {
+    padding: 0.5rem 0 0.5rem 0.85rem;
+    border-left: 3px solid color-mix(in srgb, #{$accent} 35%, transparent);
+    line-height: 1.5;
+
+    + li {
+      margin-top: 0.4rem;
+    }
+  }
+
+  strong {
+    color: #1e293b;
+  }
+}
+
+// Below ~560px the label column crowds the value text; stack the pairs.
+@media (max-width: 560px) {
+  .path-card dl {
+    grid-template-columns: 1fr;
+    gap: 0.15rem;
+  }
+
+  .path-card dd + dt {
+    margin-top: 0.45rem;
+  }
+
+  .path-card .path-route {
+    min-height: 0;
   }
 }

--- a/tinytorch/quarto/big-picture.qmd
+++ b/tinytorch/quarto/big-picture.qmd
@@ -412,9 +412,6 @@ TinyTorch takes you from a bare tensor to a production-style ML system in twenty
 **TinyTorch Module Flow.** The 20 modules progress through three tiers: Foundation (blue) builds core ML primitives, Architecture (green) applies them to vision and language tasks, and Optimization (orange) makes systems production-ready.
 :::
 
-</div>
-
-
 **Flexible paths:**
 
 - **Vision focus** — Foundation (01-08) → Convolutions (09) → Optimization (14-19)

--- a/tinytorch/quarto/big-picture.qmd
+++ b/tinytorch/quarto/big-picture.qmd
@@ -414,9 +414,25 @@ TinyTorch takes you from a bare tensor to a production-style ML system in twenty
 
 **Flexible paths:**
 
+::: {.content-visible when-format="html"}
+
+```{=html}
+<ul class="path-routes">
+<li><strong>Vision focus</strong> &mdash; Foundation (01&ndash;08) &rarr; Convolutions (09) &rarr; Optimization (14&ndash;19)</li>
+<li><strong>Language focus</strong> &mdash; Foundation (01&ndash;08) &rarr; Tokenization &rarr; Embeddings &rarr; Attention &rarr; Transformers (10&ndash;13) &rarr; Optimization (14&ndash;19)</li>
+<li><strong>Full course</strong> &mdash; Both paths &rarr; Capstone (20)</li>
+</ul>
+```
+
+:::
+
+::: {.content-visible when-format="pdf"}
+
 - **Vision focus** — Foundation (01-08) → Convolutions (09) → Optimization (14-19)
 - **Language focus** — Foundation (01-08) → Tokenization → Embeddings → Attention → Transformers (10-13) → Optimization (14-19)
 - **Full course** — Both paths → Capstone (20)
+
+:::
 
 ## Milestones You'll Unlock
 
@@ -459,54 +475,46 @@ Pick the route that matches your goals and available time.
 ::: {.content-visible when-format="html"}
 
 ```{=html}
-<div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1.25rem; margin: 1.5rem 0;">
+<div class="path-grid">
 
-<div style="background: #e3f2fd; padding: 1.25rem; border-radius: 0.5rem; border-left: 4px solid #1976d2;">
-<strong>Sequential Builder</strong><br/>
-
-<span style="font-size: 0.9rem; color: #555;">Complete all 20 modules in order</span>
-<p style="margin: 0.75rem 0 0 0; font-size: 0.95rem;">
-<strong>Best for:</strong> Students, career transitioners, deep understanding<br/>
-<strong>Time:</strong> 60-80 hours (8-12 weeks part-time)<br/>
-<strong>Outcome:</strong> Complete mental model of ML systems
-
-</p>
+<div class="path-card" style="--path-accent: #1976d2;">
+<p class="path-title">Sequential Builder</p>
+<span class="path-route">Complete all 20 modules in order</span>
+<dl>
+<dt>Best for</dt><dd>Students, career transitioners, deep understanding</dd>
+<dt>Time</dt><dd>60&ndash;80 hours (8&ndash;12 weeks part-time)</dd>
+<dt>Outcome</dt><dd>Complete mental model of ML systems</dd>
+</dl>
 </div>
 
-<div style="background: #f3e5f5; padding: 1.25rem; border-radius: 0.5rem; border-left: 4px solid #7b1fa2;">
-<strong>Vision Track</strong><br/>
-
-<span style="font-size: 0.9rem; color: #555;">01-09 → 14-19 (CNNs + optimization)</span>
-<p style="margin: 0.75rem 0 0 0; font-size: 0.95rem;">
-<strong>Best for:</strong> Computer vision focus, MLOps practitioners<br/>
-<strong>Time:</strong> 40-50 hours<br/>
-<strong>Outcome:</strong> CNN architectures + production optimization
-
-</p>
+<div class="path-card" style="--path-accent: #7b1fa2;">
+<p class="path-title">Vision Track</p>
+<span class="path-route">01&ndash;09 &rarr; 14&ndash;19 (CNNs + optimization)</span>
+<dl>
+<dt>Best for</dt><dd>Computer vision focus, MLOps practitioners</dd>
+<dt>Time</dt><dd>40&ndash;50 hours</dd>
+<dt>Outcome</dt><dd>CNN architectures + production optimization</dd>
+</dl>
 </div>
 
-<div style="background: #fff3e0; padding: 1.25rem; border-radius: 0.5rem; border-left: 4px solid #f57c00;">
-<strong>Language Track</strong><br/>
-
-<span style="font-size: 0.9rem; color: #555;">01-08 → 10-13 (transformers + GPT)</span>
-<p style="margin: 0.75rem 0 0 0; font-size: 0.95rem;">
-<strong>Best for:</strong> NLP focus, research engineers<br/>
-<strong>Time:</strong> 35-45 hours<br/>
-<strong>Outcome:</strong> Complete GPT model with text generation
-
-</p>
+<div class="path-card" style="--path-accent: #f57c00;">
+<p class="path-title">Language Track</p>
+<span class="path-route">01&ndash;08 &rarr; 10&ndash;13 (transformers + GPT)</span>
+<dl>
+<dt>Best for</dt><dd>NLP focus, research engineers</dd>
+<dt>Time</dt><dd>35&ndash;45 hours</dd>
+<dt>Outcome</dt><dd>Complete GPT model with text generation</dd>
+</dl>
 </div>
 
-<div style="background: #e8f5e9; padding: 1.25rem; border-radius: 0.5rem; border-left: 4px solid #388e3c;">
-<strong>Instructor Sampler</strong><br/>
-
-<span style="font-size: 0.9rem; color: #555;">Read: 01, 03, 05, 07, 12 (key concepts)</span>
-<p style="margin: 0.75rem 0 0 0; font-size: 0.95rem;">
-<strong>Best for:</strong> Evaluating for course adoption<br/>
-<strong>Time:</strong> 8-12 hours (reading, not building)<br/>
-<strong>Outcome:</strong> Assessment of pedagogical approach
-
-</p>
+<div class="path-card" style="--path-accent: #388e3c;">
+<p class="path-title">Instructor Sampler</p>
+<span class="path-route">Read: 01, 03, 05, 07, 12 (key concepts)</span>
+<dl>
+<dt>Best for</dt><dd>Evaluating for course adoption</dd>
+<dt>Time</dt><dd>8&ndash;12 hours (reading, not building)</dd>
+<dt>Outcome</dt><dd>Assessment of pedagogical approach</dd>
+</dl>
 </div>
 
 </div>


### PR DESCRIPTION
## Summary

Three rendering fixes for the lower half of the TinyTorch **Big Picture** page (`mlsysbook.ai/tinytorch/big-picture.html`). Split into two commits — the first is an independent structural bug, the second is the design work.

## 1. Stray `</div>` closed `<main>` early

An unbalanced `</div>` sat between the module-flow figure and the "Flexible paths" list, taking the page's div depth to `-1`.

Quarto emits its own `<main class="content">` wrapper, so the orphan closed it early. **Everything from "Flexible paths:" to the end of the page** — the learning-path cards, the outcomes table, and all closing sections — was emitted *after* `</main>`, outside the layout grid's body-content track. Two visible consequences:

- That content rendered edge-to-edge with no page margins.
- Quarto only indexes headings inside `<main>`, so the "On this page" TOC silently dropped every section below the figure.

Both `:::` fences above the tag already close their own containers, so it closed nothing opened in this file. Deleting it restores a balanced tree, the page margins, and the full six-entry TOC.

## 2. Ragged card alignment

Each card laid out its body as `<strong>` labels separated by `<br/>`, so the Best for / Time / Outcome rows started at whatever height the module-range subtitle ended at — one line in some cards, two in others. Replaced with a two-column `<dl>` plus a reserved two-line subtitle, so every card's rows share a baseline.

## 3. Dark mode: colour coding erased, table unreadable

**Cards.** The inline `style="background: #e3f2fd"` fills were caught by the hex-normalisation block in `dark-mode.scss`, which flattens those exact strings to a blanket `#2d2d2d !important`. All four tracks rendered as the same grey with accent borders dropped, so the colour carried no information. Each card now declares one `--path-accent` and derives its fills via `color-mix()`, letting dark mode retint per track. This is the refactor that block's own comment asks for — *"Until every page is refactored to `.who-card` / `.callout-note`"*.

**Table.** `shared/styles/partials/_tables.scss` hardcodes dark-on-light text (`#495057` / `#5a6369`) with no dark counterpart, landing at **~1.9:1** on the `#1a1a1a` body — well under the WCAG AA 4.5:1 minimum.

| Element | Before | After |
|---|---|---|
| Header / row label | 1.9:1 | **15.89:1** |
| Body cells | 1.9:1 | **13.33:1** |
| Caption | 1.9:1 | **11.72:1** |

The caption needed its own rule because Quarto renders it as a sibling `<figcaption>`, outside the `<table>`. Light mode is unchanged at 8.18:1.

Table cells also started flush at the container's left edge while prose started at the content margin; zeroing the outer-edge cell padding puts table text on the same line as body copy.

## Scope

- Overrides live in tinytorch's own stylesheets, **not** the shared partial (consumed by every volume).
- They reuse the existing `[data-bs-theme="dark"]` scoping, so they cover both true dark mode and the hybrid state.
- New `.path-*` classes are used only by `big-picture.qmd`.
- PDF output keeps its original markdown via `content-visible` blocks.

One note for reviewers: the table cell-padding rule is intentionally unscoped, so it applies to all TinyTorch tables. I checked `datasets.html` — no regression, and it picks up the same dark-mode contrast improvement. Happy to scope it to this page instead if you'd prefer.

## Verification

Measured in the rendered DOM (not by eye) in light + dark at 1900 / 1280 / 390px:

- All six section headings inside `<main>`; TOC lists all six.
- Prose, cards, and table share the body-content offset (`576` / `301` / `38.3`), no horizontal overflow.
- All four card `<dl>` elements start at an identical offset from their card top.
- Contrast ratios as tabled above.
