### PR TITLE
fix(tinytorch): malformed-but-syntactically-valid progress/milestones JSON crashed

### DIFF
--- a/tinytorch/tests/milestones/test_malformed_state_files.py
+++ b/tinytorch/tests/milestones/test_malformed_state_files.py
@@ -1,0 +1,163 @@
+"""
+Malformed .tito state file tests.
+
+TinyTorch's progress/milestone tracking already had a defensive pattern
+in tito/commands/milestone.py: catch (json.JSONDecodeError, IOError) around
+every state-file read and fall back to sensible empty defaults rather than
+crashing. That pattern correctly handles a file that is not valid JSON at
+all (truncated, empty, binary garbage).
+
+It did not handle a file that IS valid JSON but the wrong shape (a bare
+list or string instead of the expected object), a real corruption mode:
+a bad merge conflict resolution, a manual edit gone wrong, or an
+interrupted write from something else can all produce syntactically valid
+JSON of the wrong type. json.load() succeeds, .get() on a list or string
+then raises a raw AttributeError with no useful message.
+
+These tests reproduce that class of corruption directly (crafting the
+state file's content in a temp .tito directory) rather than going through
+a full tito CLI invocation, so they stay fast and independent of any real
+project checkout.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from tito.commands.milestone import _load_completed_module_numbers, MilestoneSystem
+
+
+def _write(path: Path, content: str):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+class TestProgressJsonWrongType:
+    """progress.json is syntactically valid JSON, but not an object."""
+
+    def test_list_type_progress_json_does_not_crash(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write(Path(".tito/progress.json"), json.dumps(["01_tensor", "02_activations"]))
+
+        result = _load_completed_module_numbers()
+
+        assert result == set()
+
+    def test_string_type_progress_json_does_not_crash(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write(Path(".tito/progress.json"), json.dumps("not an object"))
+
+        result = _load_completed_module_numbers()
+
+        assert result == set()
+
+    def test_int_type_progress_json_does_not_crash(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write(Path(".tito/progress.json"), json.dumps(42))
+
+        result = _load_completed_module_numbers()
+
+        assert result == set()
+
+    def test_is_module_completed_with_wrong_type_progress_json(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write(Path(".tito/progress.json"), json.dumps(["01_tensor"]))
+        ms = MilestoneSystem(config=None)
+
+        result = ms._is_module_completed("01_tensor")
+
+        assert result is False
+
+    def test_valid_dict_progress_json_still_works(self, tmp_path, monkeypatch):
+        """Regression guard: the type check must not break the normal case."""
+        monkeypatch.chdir(tmp_path)
+        _write(
+            Path(".tito/progress.json"),
+            json.dumps({"completed_modules": ["01_tensor", "02_activations"]}),
+        )
+
+        result = _load_completed_module_numbers()
+
+        assert result == {1, 2}
+
+
+class TestMilestonesJsonWrongType:
+    """milestones.json is syntactically valid JSON, but not an object."""
+
+    def test_list_type_milestones_json_falls_back_to_default(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write(Path(".tito/milestones.json"), json.dumps([1, 2, 3]))
+        ms = MilestoneSystem(config=None)
+
+        result = ms._get_milestone_progress_data()
+
+        assert isinstance(result, dict)
+        assert result["unlocked_milestones"] == []
+        assert result["completed_milestones"] == []
+
+    def test_string_type_milestones_json_falls_back_to_default(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write(Path(".tito/milestones.json"), json.dumps("corrupted"))
+        ms = MilestoneSystem(config=None)
+
+        result = ms._get_milestone_progress_data()
+
+        assert isinstance(result, dict)
+        assert result["total_unlocked"] == 0
+
+    def test_valid_dict_milestones_json_still_works(self, tmp_path, monkeypatch):
+        """Regression guard: the type check must not break the normal case."""
+        monkeypatch.chdir(tmp_path)
+        stored = {
+            "completed_milestones": ["01"],
+            "completion_dates": {"01": "2026-01-01T00:00:00"},
+            "unlocked_milestones": ["01"],
+            "unlock_dates": {"01": "2026-01-01T00:00:00"},
+            "total_unlocked": 1,
+            "achievements": [],
+        }
+        _write(Path(".tito/milestones.json"), json.dumps(stored))
+        ms = MilestoneSystem(config=None)
+
+        result = ms._get_milestone_progress_data()
+
+        assert result == stored
+
+
+class TestTrulyMalformedJsonStillFallsBackCleanly:
+    """
+    Sanity check that the pre-existing (json.JSONDecodeError, IOError)
+    handling for genuinely invalid JSON, truncated, empty, binary garbage,
+    still works after adding the isinstance(dict) check alongside it.
+    """
+
+    def test_truncated_progress_json(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write(Path(".tito/progress.json"), '{"completed_modules": ["01_tensor"')
+
+        result = _load_completed_module_numbers()
+
+        assert result == set()
+
+    def test_empty_progress_json(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write(Path(".tito/progress.json"), "")
+
+        result = _load_completed_module_numbers()
+
+        assert result == set()
+
+    def test_binary_garbage_milestones_json(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        path = tmp_path / ".tito" / "milestones.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"\x00\x01\x02not json at all\xff\xfe")
+        ms = MilestoneSystem(config=None)
+
+        result = ms._get_milestone_progress_data()
+
+        assert isinstance(result, dict)
+        assert result["unlocked_milestones"] == []

--- a/tinytorch/tito/commands/milestone.py
+++ b/tinytorch/tito/commands/milestone.py
@@ -241,6 +241,11 @@ def _load_completed_module_numbers() -> set:
     except (json.JSONDecodeError, IOError):
         return completed
 
+    if not isinstance(progress_data, dict):
+        # Valid JSON but not the expected object shape (e.g. a bare list),
+        # treat it the same as a decode failure rather than crashing below.
+        return completed
+
     for module_value in progress_data.get("completed_modules", []):
         module_num = _module_progress_to_int(module_value)
         if module_num is not None:
@@ -507,6 +512,8 @@ class MilestoneSystem:
             try:
                 with open(progress_file, 'r') as f:
                     progress_data = json.load(f)
+                    if not isinstance(progress_data, dict):
+                        return False
                     module_num = _module_progress_to_int(module_name)
                     completed_nums = {
                         _module_progress_to_int(mod)
@@ -527,7 +534,9 @@ class MilestoneSystem:
         if progress_file.exists():
             try:
                 with open(progress_file, 'r') as f:
-                    return json.load(f)
+                    data = json.load(f)
+                if isinstance(data, dict):
+                    return data
             except (json.JSONDecodeError, IOError):
                 pass
 
@@ -1444,11 +1453,12 @@ class MilestoneCommand(BaseCommand):
                     try:
                         with open(progress_file, 'r') as f:
                             progress_data = json.load(f)
-                            for mod in progress_data.get("completed_modules", []):
-                                try:
-                                    completed_modules.append(int(mod.split("_")[0]))
-                                except (ValueError, IndexError):
-                                    pass
+                            if isinstance(progress_data, dict):
+                                for mod in progress_data.get("completed_modules", []):
+                                    try:
+                                        completed_modules.append(int(mod.split("_")[0]))
+                                    except (ValueError, IndexError):
+                                        pass
                     except (json.JSONDecodeError, IOError):
                         pass
 
@@ -1565,7 +1575,9 @@ class MilestoneCommand(BaseCommand):
         if progress_file.exists():
             try:
                 with open(progress_file, 'r') as f:
-                    return json.load(f)
+                    data = json.load(f)
+                if isinstance(data, dict):
+                    return data
             except (json.JSONDecodeError, IOError):
                 pass
 


### PR DESCRIPTION
## Summary

Part of an ongoing testing effort tracked in #2046. Every state-file reader in `tito/commands/milestone.py` already guarded against invalid JSON (truncated, empty, binary garbage) via `except (json.JSONDecodeError, IOError)`, falling back to sensible empty defaults. It didn't guard against JSON that parses successfully but isn't the expected object shape, a bare list, string, or number instead of a dict. A bad merge conflict resolution, a manual edit, or any other process writing the wrong structure to `.tito/progress.json` or `.tito/milestones.json` produced valid JSON that then crashed with a raw `AttributeError` (`'list' object has no attribute 'get'`) at the read site or later downstream, instead of the graceful fallback the surrounding code clearly intends.

Fixes all 5 affected call sites: `_load_completed_module_numbers`, `_is_module_completed`, both copies of `_get_milestone_progress_data` (`MilestoneSystem` and `MilestoneCommand`), and the "what's next" progress read in the milestone run command. Each now validates the loaded data is a dict before using it, treating a wrong-shaped file the same as a decode failure.

Found while building a malformed-state-file test suite as a follow-up to the PyTorch cross-checking work (#2047, #2048).

## Test plan
- [x] `pytest tests/cli/test_release_regressions.py tests/milestones -q` passes locally (40 passed, 13 pre-existing unrelated failures on this Windows environment, confirmed present on `dev` before this change too)
- [x] New `tests/milestones/test_malformed_state_files.py` covers wrong-type JSON for both files across all affected call sites, plus a sanity check that genuinely-invalid JSON still falls back correctly and that valid data still round-trips normally
- [x] Confirmed the `AttributeError` reproduces on `dev` before the fix at each of the 5 sites, and no longer reproduces after