### PR TITLE
fix(tinytorch): Trainer.load_checkpoint had no error handling for corrupted files

### DIFF
--- a/tinytorch/src/08_training/08_training.py
+++ b/tinytorch/src/08_training/08_training.py
@@ -1401,7 +1401,33 @@ def trainer_load_checkpoint(self, path: str):
     """
     ### BEGIN SOLUTION
     with open(path, 'rb') as f:
-        checkpoint = pickle.load(f)
+        try:
+            checkpoint = pickle.load(f)
+        except (pickle.UnpicklingError, EOFError) as e:
+            raise ValueError(
+                f"Checkpoint file appears corrupted or incomplete: {path}\n"
+                f"  This can happen if the save was interrupted (crash, disk full,\n"
+                f"  killed process) partway through writing the file.\n"
+                f"  Original error: {e}"
+            ) from e
+
+    if not isinstance(checkpoint, dict):
+        raise ValueError(
+            f"Checkpoint file does not contain the expected data: {path}\n"
+            f"  Expected a dict with keys like 'epoch', 'step', 'history',\n"
+            f"  got a {type(checkpoint).__name__} instead. Is this really a\n"
+            f"  TinyTorch checkpoint file?"
+        )
+
+    required_keys = ('epoch', 'step', 'history', 'training_mode')
+    missing_keys = [k for k in required_keys if k not in checkpoint]
+    if missing_keys:
+        raise ValueError(
+            f"Checkpoint file is missing required keys: {path}\n"
+            f"  Missing: {missing_keys}\n"
+            f"  This checkpoint may be from an incompatible version, or the\n"
+            f"  file may be corrupted."
+        )
 
     self.epoch = checkpoint['epoch']
     self.step = checkpoint['step']

--- a/tinytorch/tests/08_training/test_training_coverage.py
+++ b/tinytorch/tests/08_training/test_training_coverage.py
@@ -260,6 +260,76 @@ class TestCheckpointing:
             assert os.path.exists(path)
 
 
+class TestLoadCheckpointMalformedFile:
+    """
+    load_checkpoint previously had no error handling at all: a corrupted
+    or incompatible checkpoint file surfaced a raw pickle.UnpicklingError,
+    EOFError, or KeyError with no context. These confirm it now raises a
+    clear ValueError instead, for the specific corruption modes a checkpoint
+    file can realistically hit (interrupted write, wrong file, wrong
+    version).
+    """
+
+    def test_empty_file_raises_clear_error(self):
+        trainer, _ = simple_trainer()
+        with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as f:
+            path = f.name
+        try:
+            with pytest.raises(ValueError, match="corrupted or incomplete"):
+                trainer.load_checkpoint(path)
+        finally:
+            os.remove(path)
+
+    def test_garbage_bytes_raises_clear_error(self):
+        trainer, _ = simple_trainer()
+        with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as f:
+            f.write(b"not a pickle file at all, just garbage bytes")
+            path = f.name
+        try:
+            with pytest.raises(ValueError, match="corrupted or incomplete"):
+                trainer.load_checkpoint(path)
+        finally:
+            os.remove(path)
+
+    def test_wrong_type_raises_clear_error(self):
+        """A valid pickle, but not a dict at all (e.g. a bare list)."""
+        trainer, _ = simple_trainer()
+        with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as f:
+            pickle.dump([1, 2, 3], f)
+            path = f.name
+        try:
+            with pytest.raises(ValueError, match="does not contain the expected data"):
+                trainer.load_checkpoint(path)
+        finally:
+            os.remove(path)
+
+    def test_missing_required_keys_raises_clear_error(self):
+        """A valid dict, but missing the keys a real checkpoint always has."""
+        trainer, _ = simple_trainer()
+        with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as f:
+            pickle.dump({"unrelated_key": 1}, f)
+            path = f.name
+        try:
+            with pytest.raises(ValueError, match="missing required keys"):
+                trainer.load_checkpoint(path)
+        finally:
+            os.remove(path)
+
+    def test_valid_checkpoint_still_loads_normally(self):
+        """Regression guard: the new validation must not break the normal case."""
+        trainer, _ = simple_trainer()
+        trainer.epoch = 7
+        with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as f:
+            path = f.name
+        try:
+            trainer.save_checkpoint(path)
+            trainer.epoch = 0
+            trainer.load_checkpoint(path)
+            assert trainer.epoch == 7
+        finally:
+            os.remove(path)
+
+
 # ─────────────────────────────────────────────
 # Trainer.evaluate
 # ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Part of an ongoing testing effort tracked in #2046. `load_checkpoint`'s `pickle.load()` call had zero error handling: an empty file raised a raw `EOFError`, garbage bytes raised `pickle.UnpicklingError` with an unhelpful message (`"invalid load key, 'n'"`), and a checkpoint missing expected keys raised a bare `KeyError`. None of these gave any indication of what actually went wrong or how to fix it, unlike the rest of this codebase's well-designed error paths.

Wraps the unpickling in a try/except that raises a clear `ValueError` for a corrupted/incomplete file (interrupted save, disk full, killed process are the realistic causes), validates the loaded object is actually a dict before using it, and validates the expected top-level keys are present, raising a clear error naming what's missing rather than crashing deep inside attribute restoration.

Found while building a malformed-state-file test suite as a follow-up to the PyTorch cross-checking work (#2047, #2048), following the same "corrupted input must never crash confusingly" principle already applied to `.tito/progress.json` and `.tito/milestones.json` in #2049.

## Test plan
- [x] `pytest tests/08_training -q` passes locally (64 passed, 8 skipped)
- [x] New `TestLoadCheckpointMalformedFile` class covers an empty file, garbage bytes, a valid-pickle-wrong-type file, and a valid dict missing required keys, plus a regression guard confirming normal checkpoint round-trips still work
- [x] Confirmed each raw exception type reproduces on `dev` before the fix, and the clear `ValueError` replaces it after