### PR TITLE
fix(tinytorch): several arithmetic operators bypassed Module 01's own implementation

### DIFF
--- a/tinytorch/src/06_autograd/06_autograd.py
+++ b/tinytorch/src/06_autograd/06_autograd.py
@@ -2505,19 +2505,24 @@ def enable_autograd(quiet=False):
         # Ensure self has gradient attributes
         _ensure_grad_attrs(self)
 
-        # Convert scalar to Tensor if needed
+        # Keep a Tensor-typed copy for grad bookkeeping, but call the
+        # original with `other` in its original form (matching
+        # tracked_mul's pattern) so _original_add's own scalar branch
+        # stays reachable instead of always seeing a pre-converted Tensor.
         if not isinstance(other, Tensor):
-            other = Tensor(other)
-        _ensure_grad_attrs(other)
+            other_tensor = Tensor(other)
+        else:
+            other_tensor = other
+        _ensure_grad_attrs(other_tensor)
 
         # Call original operation
         result = _original_add(self, other)
         _ensure_grad_attrs(result)
 
         # Track gradient if needed
-        if _get_requires_grad(self) or _get_requires_grad(other):
+        if _get_requires_grad(self) or _get_requires_grad(other_tensor):
             result.requires_grad = True
-            result._grad_fn = AddBackward(self, other)
+            result._grad_fn = AddBackward(self, other_tensor)
 
         return result
 
@@ -2641,19 +2646,24 @@ def enable_autograd(quiet=False):
         """
         _ensure_grad_attrs(self)
 
-        # Convert scalar to Tensor if needed
+        # Keep a Tensor-typed copy for grad bookkeeping, but call the
+        # original with `other` in its original form (matching
+        # tracked_mul's pattern) so _original_sub's own scalar branch
+        # stays reachable instead of always seeing a pre-converted Tensor.
         if not isinstance(other, Tensor):
-            other = Tensor(other)
-        _ensure_grad_attrs(other)
+            other_tensor = Tensor(other)
+        else:
+            other_tensor = other
+        _ensure_grad_attrs(other_tensor)
 
         # Call original operation
         result = _original_sub(self, other)
         _ensure_grad_attrs(result)
 
         # Track gradient if needed
-        if _get_requires_grad(self) or _get_requires_grad(other):
+        if _get_requires_grad(self) or _get_requires_grad(other_tensor):
             result.requires_grad = True
-            result._grad_fn = SubBackward(self, other)
+            result._grad_fn = SubBackward(self, other_tensor)
 
         return result
 
@@ -2695,19 +2705,24 @@ def enable_autograd(quiet=False):
         """
         _ensure_grad_attrs(self)
 
-        # Convert scalar to Tensor if needed
+        # Keep a Tensor-typed copy for grad bookkeeping, but call the
+        # original with `other` in its original form (matching
+        # tracked_mul's pattern) so _original_div's own scalar branch
+        # stays reachable instead of always seeing a pre-converted Tensor.
         if not isinstance(other, Tensor):
-            other = Tensor(other)
-        _ensure_grad_attrs(other)
+            other_tensor = Tensor(other)
+        else:
+            other_tensor = other
+        _ensure_grad_attrs(other_tensor)
 
         # Call original operation
         result = _original_div(self, other)
         _ensure_grad_attrs(result)
 
         # Track gradient if needed
-        if _get_requires_grad(self) or _get_requires_grad(other):
+        if _get_requires_grad(self) or _get_requires_grad(other_tensor):
             result.requires_grad = True
-            result._grad_fn = DivBackward(self, other)
+            result._grad_fn = DivBackward(self, other_tensor)
 
         return result
 

--- a/tinytorch/src/06_autograd/06_autograd.py
+++ b/tinytorch/src/06_autograd/06_autograd.py
@@ -2460,10 +2460,15 @@ def enable_autograd(quiet=False):
     # Store original operations
     # These are guaranteed to exist from Module 01 (Tensor class)
     _original_add = Tensor.__add__
+    _original_radd = Tensor.__radd__
     _original_sub = Tensor.__sub__
+    _original_rsub = Tensor.__rsub__
     _original_mul = Tensor.__mul__
+    _original_rmul = Tensor.__rmul__
     _original_div = Tensor.__truediv__
+    _original_rdiv = Tensor.__rtruediv__
     _original_getitem = Tensor.__getitem__
+    _original_sum = Tensor.sum
 
     # These methods are also guaranteed from Module 01 - trust Single Tensor Class
     _original_matmul = Tensor.matmul
@@ -2517,8 +2522,18 @@ def enable_autograd(quiet=False):
         return result
 
     def tracked_radd(self, other):
-        """Scalar-left addition with gradient tracking."""
-        return tracked_add(self, other)
+        """
+        Scalar-left addition with gradient tracking.
+
+        Delegates to the original __radd__ from Module 01 (which itself
+        calls self.__add__(other)) rather than calling tracked_add
+        directly, so Module 01's own __radd__ source actually executes.
+        Addition is commutative, so this produces the same result either
+        way, self.__add__ resolves to tracked_add regardless, since
+        that's the currently-installed __add__ by the time this runs.
+        """
+        _ensure_grad_attrs(self)
+        return _original_radd(self, other)
 
     def tracked_mul(self, other):
         """
@@ -2546,8 +2561,14 @@ def enable_autograd(quiet=False):
         return result
 
     def tracked_rmul(self, other):
-        """Scalar-left multiplication with gradient tracking."""
-        return tracked_mul(self, other)
+        """
+        Scalar-left multiplication with gradient tracking.
+
+        Delegates to the original __rmul__ from Module 01 (which itself
+        calls self.__mul__(other)), same reasoning as tracked_radd above.
+        """
+        _ensure_grad_attrs(self)
+        return _original_rmul(self, other)
 
     def tracked_matmul(self, other):
         """
@@ -2637,10 +2658,33 @@ def enable_autograd(quiet=False):
         return result
 
     def tracked_rsub(self, other):
-        """Scalar-left subtraction with gradient tracking."""
+        """
+        Scalar-left subtraction with gradient tracking.
+
+        Unlike __radd__/__rmul__, __rsub__ computes a genuinely different
+        formula (other - self, not self - other), so it can't just
+        forward to tracked_sub without ever running Module 01's actual
+        __rsub__ body. Calls the original directly (with other in
+        whatever form the caller passed, so both its Tensor and
+        non-Tensor branches stay reachable) to get the value, then
+        attaches gradient tracking the same way tracked_sub(other, self)
+        already did.
+        """
+        _ensure_grad_attrs(self)
+
+        # Call original __rsub__ from Module 01: computes other - self
+        result = _original_rsub(self, other)
+        _ensure_grad_attrs(result)
+
         if not isinstance(other, Tensor):
             other = Tensor(other)
-        return tracked_sub(other, self)
+        _ensure_grad_attrs(other)
+
+        if _get_requires_grad(self) or _get_requires_grad(other):
+            result.requires_grad = True
+            result._grad_fn = SubBackward(other, self)
+
+        return result
 
     def tracked_div(self, other):
         """
@@ -2668,10 +2712,31 @@ def enable_autograd(quiet=False):
         return result
 
     def tracked_rdiv(self, other):
-        """Scalar-left division with gradient tracking."""
+        """
+        Scalar-left division with gradient tracking.
+
+        Same reasoning as tracked_rsub: __rtruediv__ computes a
+        genuinely different formula (other / self, not self / other),
+        so it calls the original directly to get the value (keeping
+        both its Tensor and non-Tensor branches reachable), then
+        attaches gradient tracking the same way tracked_div(other, self)
+        already did.
+        """
+        _ensure_grad_attrs(self)
+
+        # Call original __rtruediv__ from Module 01: computes other / self
+        result = _original_rdiv(self, other)
+        _ensure_grad_attrs(result)
+
         if not isinstance(other, Tensor):
             other = Tensor(other)
-        return tracked_div(other, self)
+        _ensure_grad_attrs(other)
+
+        if _get_requires_grad(self) or _get_requires_grad(other):
+            result.requires_grad = True
+            result._grad_fn = DivBackward(other, self)
+
+        return result
 
     def tracked_getitem(self, key):
         """
@@ -2697,13 +2762,14 @@ def enable_autograd(quiet=False):
         """
         Sum operation with gradient tracking.
 
-        Creates a new sum method that builds computation graphs
-        when requires_grad=True.
+        Delegates to the original .sum() from Module 01 for the actual
+        computation, rather than reimplementing it, so Module 01's own
+        sum() source stays reachable and testable.
         """
         _ensure_grad_attrs(self)
 
-        result_data = np.sum(self.data, axis=axis, keepdims=keepdims)
-        result = Tensor(result_data)
+        result = _original_sum(self, axis=axis, keepdims=keepdims)
+        _ensure_grad_attrs(result)
 
         if _get_requires_grad(self):
             result.requires_grad = True

--- a/tinytorch/tests/06_autograd/test_autograd_gradient_flow.py
+++ b/tinytorch/tests/06_autograd/test_autograd_gradient_flow.py
@@ -148,6 +148,55 @@ def test_reshape_gradient_flow():
     print("✅ Reshape gradient flow works correctly")
 
 
+def test_reflected_operator_gradients():
+    """
+    Gradient-level regression for __radd__/__rsub__/__rmul__/__rtruediv__
+    and sum(). These previously computed their result via a duplicate
+    formula inside the autograd monkeypatch (tracked_radd/rsub/rmul/rdiv,
+    sum_op) instead of calling Module 01's own methods, so a bug
+    introduced into Module 01's source would never have been caught by
+    any test exercising the built package. They now delegate to the
+    original implementations, this locks in both the value and the
+    gradient for each.
+    """
+    # __radd__: 5 + x
+    x = Tensor(np.array([1.0, 2.0]), requires_grad=True)
+    y = 5 + x
+    y.sum().backward()
+    assert np.allclose(y.data, [6.0, 7.0])
+    assert np.allclose(x.grad, [1.0, 1.0])
+
+    # __rsub__: 10 - x
+    x = Tensor(np.array([1.0, 2.0, 3.0]), requires_grad=True)
+    y = 10 - x
+    y.sum().backward()
+    assert np.allclose(y.data, [9.0, 8.0, 7.0])
+    assert np.allclose(x.grad, [-1.0, -1.0, -1.0])
+
+    # __rmul__: 3 * x
+    x = Tensor(np.array([1.0, 2.0]), requires_grad=True)
+    y = 3 * x
+    y.sum().backward()
+    assert np.allclose(y.data, [3.0, 6.0])
+    assert np.allclose(x.grad, [3.0, 3.0])
+
+    # __rtruediv__: 20 / x
+    x = Tensor(np.array([2.0, 4.0, 5.0]), requires_grad=True)
+    y = 20 / x
+    y.sum().backward()
+    assert np.allclose(y.data, [10.0, 5.0, 4.0])
+    assert np.allclose(x.grad, -20.0 / (x.data ** 2))
+
+    # sum(): 2D sum(), no axis
+    x = Tensor(np.array([[1.0, 2.0], [3.0, 4.0]]), requires_grad=True)
+    y = x.sum()
+    y.backward()
+    assert np.isclose(y.data, 10.0)
+    assert np.allclose(x.grad, np.ones((2, 2)))
+
+    print("✅ Reflected operator and sum() gradients work correctly")
+
+
 if __name__ == "__main__":
     print("\n" + "="*70)
     print("GRADIENT FLOW TEST SUITE")
@@ -159,6 +208,7 @@ if __name__ == "__main__":
     test_gelu_gradient_flow()
     test_layernorm_operations()
     test_reshape_gradient_flow()
+    test_reflected_operator_gradients()
 
     print("\n" + "="*70)
     print("✅ ALL GRADIENT FLOW TESTS PASSED")

--- a/tinytorch/tests/06_autograd/test_autograd_gradient_flow.py
+++ b/tinytorch/tests/06_autograd/test_autograd_gradient_flow.py
@@ -197,6 +197,39 @@ def test_reflected_operator_gradients():
     print("✅ Reflected operator and sum() gradients work correctly")
 
 
+def test_forward_scalar_branch_gradients():
+    """
+    Gradient-level regression for __add__/__sub__/__truediv__'s scalar
+    (non-Tensor other) branch. tracked_add/tracked_sub/tracked_div
+    previously reassigned `other = Tensor(other)` before calling
+    _original_add/_original_sub/_original_div, so those originals'
+    own scalar branch (`else: return Tensor(self.data + other)`) never
+    ran, only their Tensor branch did, since `other` always arrived
+    pre-converted. tracked_mul already avoided this by keeping a
+    separate Tensor-typed copy for gradient bookkeeping while passing
+    the original `other` through unchanged, add/sub/div now match that.
+    """
+    x = Tensor(np.array([1.0, 2.0, 3.0]), requires_grad=True)
+    y = x + 5
+    y.sum().backward()
+    assert np.allclose(y.data, [6.0, 7.0, 8.0])
+    assert np.allclose(x.grad, [1.0, 1.0, 1.0])
+
+    x = Tensor(np.array([5.0, 10.0]), requires_grad=True)
+    y = x - 2
+    y.sum().backward()
+    assert np.allclose(y.data, [3.0, 8.0])
+    assert np.allclose(x.grad, [1.0, 1.0])
+
+    x = Tensor(np.array([4.0, 6.0, 8.0]), requires_grad=True)
+    y = x / 2
+    y.sum().backward()
+    assert np.allclose(y.data, [2.0, 3.0, 4.0])
+    assert np.allclose(x.grad, [0.5, 0.5, 0.5])
+
+    print("✅ Forward scalar-branch gradients work correctly")
+
+
 if __name__ == "__main__":
     print("\n" + "="*70)
     print("GRADIENT FLOW TEST SUITE")
@@ -209,6 +242,7 @@ if __name__ == "__main__":
     test_layernorm_operations()
     test_reshape_gradient_flow()
     test_reflected_operator_gradients()
+    test_forward_scalar_branch_gradients()
 
     print("\n" + "="*70)
     print("✅ ALL GRADIENT FLOW TESTS PASSED")


### PR DESCRIPTION
## Summary

Part of an ongoing testing effort tracked in #2046, found via mutation testing (`cosmic-ray`) against `tests/01_tensor`.

`enable_autograd()` monkeypatches several `Tensor` arithmetic methods in ways that made Module 01's own implementation unreachable in the fully-built reference package, split across two related but distinct causes:

**1. Reflected operators and `sum()`** (`__radd__`, `__rsub__`, `__rmul__`, `__rtruediv__`, `.sum()`): these were reimplemented directly inside the monkeypatch instead of delegating back to the Module 01 originals, unlike every sibling method (`__add__`, `__sub__`, `__mul__`, `matmul`, `transpose`, `reshape`, `__getitem__`, `__init__`), which already call their captured `_original_*` reference.

**2. The forward operators' scalar branch** (`__add__`, `__sub__`, `__truediv__`): `tracked_add`/`tracked_sub`/`tracked_div` reassigned `other = Tensor(other)` *before* calling `_original_add`/`_original_sub`/`_original_div`, so those originals' own scalar (non-Tensor) branch never ran, only their Tensor-typed branch did. `tracked_mul` already avoided this (keeps a separate Tensor-typed copy for gradient bookkeeping while passing the original `other` through unchanged), which is why `__mul__` had zero mutation survivors while the other three had 11-23 each.

Since `tinytorch/__init__.py` unconditionally calls `enable_autograd()` on package import, both issues meant real chunks of Module 01's `Tensor` class were dead code in any normal test run, no test in this repo, however thorough, could have observed a bug introduced into them. Confirmed directly both times: hand-mutating the affected code and re-running the full test suite left it green before the fix, and failing after.

## Test plan
- [x] `pytest tests/01_tensor tests/02_activations tests/03_layers tests/04_losses tests/06_autograd tests/07_optimizers tests/08_training tests/09_convolutions tests/10_tokenization tests/11_embeddings tests/12_attention tests/13_transformers -q` passes locally (438 passed, 26 skipped)
- [x] Manually verified values and gradients for all affected paths against hand-computed expected values
- [x] New `test_reflected_operator_gradients` and `test_forward_scalar_branch_gradients` lock in both value and gradient for each
- [x] Confirmed via hand-mutation, twice, that the fixes actually restore testability