### PR TITLE
test(tinytorch): add reshape -1 inference coverage for multiple known dimensions

### DIFF
--- a/tinytorch/tests/01_tensor/test_tensor_core.py
+++ b/tinytorch/tests/01_tensor/test_tensor_core.py
@@ -568,6 +568,30 @@ class TestTensorPyTorchCompat:
         assert np.array_equal(stacked.data[0], t1.data)
         assert np.array_equal(stacked.data[1], t2.data)
 
+    def test_reshape_infers_minus_one_across_multiple_known_dims(self):
+        """
+        reshape's -1 inference multiplies every OTHER dimension together
+        to get known_size (unknown_dim = self.size // known_size). Every
+        existing reshape(-1, ...) test only ever has a single other
+        dimension (e.g. reshape(8, -1)), so that multiplication loop
+        never actually needed to combine more than one term. This uses
+        two known dimensions to confirm the product, not just the
+        single-dimension case, is computed correctly.
+        """
+        t = Tensor(np.arange(24))  # 24 elements
+        reshaped = t.reshape(2, 3, -1)  # known_size = 2*3 = 6, infer 24//6 = 4
+
+        assert reshaped.shape == (2, 3, 4)
+        assert np.array_equal(reshaped.data.flatten(), np.arange(24))
+
+    def test_reshape_minus_one_first_position(self):
+        """The -1 can appear in any position, not just the last."""
+        t = Tensor(np.arange(24))
+        reshaped = t.reshape(-1, 3, 4)  # known_size = 3*4 = 12, infer 24//12 = 2
+
+        assert reshaped.shape == (2, 3, 4)
+        assert np.array_equal(reshaped.data.flatten(), np.arange(24))
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Part of an ongoing testing effort tracked in #2046. Found via mutation testing (`cosmic-ray`) against `tests/01_tensor`: the `known_size` accumulation loop inside `reshape`'s `-1` inference (`known_size *= dim` for every dimension except the unknown one) was never exercised with more than one known dimension. Every existing `reshape(-1, ...)` test uses exactly one other dimension (e.g. `reshape(8, -1)`), so the loop's accumulation across multiple terms was never actually needed.

Adds two cases: `-1` in the last position with two known dimensions (`reshape(2, 3, -1)`), and `-1` in the first position (`reshape(-1, 3, 4)`), both verifying the inferred dimension and the resulting data.

Most of this mutation run's other ~180 remaining survivors turned out to already be covered elsewhere in the broader test suite (`tests/regression/`, `tests/06_autograd/`), just outside `tests/01_tensor`'s own narrow scope for this particular run, or were mutations of error-message text nobody asserts the exact wording of. This is the one gap confirmed genuinely uncovered anywhere.

## Test plan
- [x] `pytest tests/01_tensor -q` passes locally (47 passed)
- [x] Confirmed via hand-mutation of the accumulation loop's condition (`!=` to `==`) that the new tests catch it