### PR TITLE
test(tinytorch): add softmax backward coverage for non-uniform gradients

### DIFF
--- a/tinytorch/tests/06_autograd/test_gradient_correctness.py
+++ b/tinytorch/tests/06_autograd/test_gradient_correctness.py
@@ -38,7 +38,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 # so that enable_autograd() can patch their forward methods correctly.
 from tinytorch.core.tensor import Tensor
 from tinytorch.core.layers import Linear
-from tinytorch.core.activations import ReLU, Sigmoid, Tanh, GELU
+from tinytorch.core.activations import ReLU, Sigmoid, Tanh, GELU, Softmax
 from tinytorch.core.losses import MSELoss, CrossEntropyLoss, BinaryCrossEntropyLoss
 from tinytorch.core.autograd import enable_autograd
 
@@ -236,6 +236,21 @@ class TestActivationGradients:
         # GELU's derivative changes rapidly; use smaller eps for accuracy
         check_grad(fn, np.array([0.0, 1.0, -1.0, 0.5, -0.5]),
                    rtol=1e-2, atol=1e-3, eps=1e-4)
+
+    def test_softmax_backward_nonuniform_grad(self):
+        """Softmax's gradient depends on grad_output via a sum-and-subtract term;
+        summing the output directly makes that term always cancel to zero
+        (softmax rows always sum to 1), which hides bugs in the subtraction.
+        Weighting the output first keeps grad_output non-uniform."""
+        softmax = Softmax()
+        weights_data = np.array([2.0, -1.0, 3.0])
+
+        def fn(x):
+            y = softmax(x)
+            w = Tensor(weights_data.copy())
+            return (y * w).sum()
+
+        check_grad(fn, np.array([1.0, 2.0, 0.5]))
 
     def test_relu_zero_boundary(self):
         """ReLU grad at x=0 should be 0."""


### PR DESCRIPTION
Part of #2046.

Mutation testing (cosmic-ray) against `tinytorch/core/autograd.py` found that `SoftmaxBackward.apply()`'s gradient formula could be mutated (subtraction to addition, multiplication, division) without any test noticing.

Root cause: every existing softmax gradient test called `.sum()` on the softmax output directly before `backward()`. That forces `grad_output` to be uniform (all ones), and since softmax rows always sum to 1, the gradient's `sum(grad_output * softmax)` term is then always exactly 1, making `grad_output - sum_term` always 0 regardless of whether the operator is `-`, `+`, `*`, or `/`.

Fix: weight the softmax output by a non-uniform tensor before summing, so `grad_output` at the softmax node is non-trivial and the formula is actually exercised. Verified via hand-mutation: the new test fails against the mutated formula and passes against the correct one.