### PR TITLE
test(tinytorch): add systematic boundary-value coverage

### DIFF
--- a/tinytorch/tests/05_dataloader/test_dataloader_boundary_values.py
+++ b/tinytorch/tests/05_dataloader/test_dataloader_boundary_values.py
@@ -1,0 +1,93 @@
+"""
+Boundary-value tests for DataLoader batching.
+
+Systematic sweep of batch-size/dataset-size edge cases: a dataset size
+not evenly divisible by batch_size (the last batch is partial), a single
+sample, and a batch_size equal to the whole dataset. None of these were
+previously exercised, only "typical" evenly-divisible cases were.
+"""
+
+import numpy as np
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from tinytorch.core.tensor import Tensor
+from tinytorch.core.dataloader import TensorDataset, DataLoader
+
+
+class TestDataLoaderBoundaryValues:
+    def test_partial_last_batch_has_correct_size_and_content(self):
+        """5 samples, batch_size=2 -> batches of [2, 2, 1], not silently
+        dropped or padded."""
+        features = Tensor(np.arange(5).reshape(5, 1).astype(np.float32))
+        labels = Tensor(np.arange(5).astype(np.float32))
+        dataset = TensorDataset(features, labels)
+        loader = DataLoader(dataset, batch_size=2, shuffle=False)
+
+        batches = list(loader)
+
+        assert len(batches) == 3
+        assert batches[0][0].shape == (2, 1)
+        assert batches[1][0].shape == (2, 1)
+        assert batches[2][0].shape == (1, 1)
+
+        # Nothing lost or duplicated: concatenating batches recovers the
+        # full dataset in order.
+        all_labels = np.concatenate([b[1].data for b in batches])
+        np.testing.assert_array_equal(all_labels, np.arange(5))
+
+    def test_len_matches_actual_number_of_batches_yielded_for_partial_batch(self):
+        features = Tensor(np.arange(7).reshape(7, 1).astype(np.float32))
+        dataset = TensorDataset(features)
+        loader = DataLoader(dataset, batch_size=3, shuffle=False)
+
+        assert len(loader) == 3
+        assert len(list(loader)) == len(loader)
+
+    def test_batch_size_one_yields_one_sample_per_batch(self):
+        features = Tensor(np.arange(4).reshape(4, 1).astype(np.float32))
+        dataset = TensorDataset(features)
+        loader = DataLoader(dataset, batch_size=1, shuffle=False)
+
+        batches = list(loader)
+
+        assert len(batches) == 4
+        for i, batch in enumerate(batches):
+            assert batch[0].shape == (1, 1)
+            assert batch[0].data[0, 0] == i
+
+    def test_batch_size_equal_to_dataset_size_yields_single_batch(self):
+        features = Tensor(np.arange(6).reshape(6, 1).astype(np.float32))
+        dataset = TensorDataset(features)
+        loader = DataLoader(dataset, batch_size=6, shuffle=False)
+
+        batches = list(loader)
+
+        assert len(batches) == 1
+        assert batches[0][0].shape == (6, 1)
+
+    def test_batch_size_larger_than_dataset_yields_one_partial_batch(self):
+        """batch_size exceeding the dataset size must not crash or hang,
+        it should just yield everything as one (smaller than requested)
+        batch."""
+        features = Tensor(np.arange(3).reshape(3, 1).astype(np.float32))
+        dataset = TensorDataset(features)
+        loader = DataLoader(dataset, batch_size=100, shuffle=False)
+
+        batches = list(loader)
+
+        assert len(batches) == 1
+        assert batches[0][0].shape == (3, 1)
+
+    def test_single_sample_dataset(self):
+        features = Tensor(np.array([[42.0]]))
+        dataset = TensorDataset(features)
+        loader = DataLoader(dataset, batch_size=4, shuffle=False)
+
+        batches = list(loader)
+
+        assert len(batches) == 1
+        assert batches[0][0].shape == (1, 1)
+        assert batches[0][0].data[0, 0] == 42.0

--- a/tinytorch/tests/09_convolutions/test_conv2d_boundary_values.py
+++ b/tinytorch/tests/09_convolutions/test_conv2d_boundary_values.py
@@ -1,0 +1,67 @@
+"""
+Boundary-value tests for Conv2d/pooling with kernel_size == input spatial size.
+
+This is the "global" convolution/pooling boundary: the kernel exactly
+covers the whole input, so the output collapses to a single spatial
+position (1x1). Off-by-one errors in the output-size formula
+((in + 2*padding - kernel) // stride + 1) are most visible right at this
+edge, and no existing test exercised it.
+"""
+
+import numpy as np
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from tinytorch.core.tensor import Tensor
+from tinytorch.core.spatial import Conv2d, MaxPool2d, AvgPool2d
+from tinytorch.core.autograd import enable_autograd
+
+enable_autograd()
+
+
+class TestKernelEqualsInputSize:
+    def test_conv2d_kernel_equals_input_produces_1x1_output(self):
+        conv = Conv2d(in_channels=3, out_channels=4, kernel_size=5)
+        x = Tensor(np.random.randn(2, 3, 5, 5).astype(np.float32), requires_grad=True)
+
+        out = conv(x)
+
+        assert out.shape == (2, 4, 1, 1)
+        assert np.all(np.isfinite(out.data))
+
+        out.sum().backward()
+        assert np.all(np.isfinite(x.grad))
+        assert x.grad.shape == x.shape
+
+    def test_maxpool2d_kernel_equals_input_produces_1x1_output(self):
+        pool = MaxPool2d(kernel_size=4)
+        x = Tensor(np.arange(2 * 3 * 4 * 4).reshape(2, 3, 4, 4).astype(np.float32))
+
+        out = pool(x)
+
+        assert out.shape == (2, 3, 1, 1)
+        # The single output per channel must be that channel's global max.
+        expected = x.data.max(axis=(2, 3), keepdims=True)
+        np.testing.assert_allclose(out.data, expected)
+
+    def test_avgpool2d_kernel_equals_input_produces_1x1_output(self):
+        pool = AvgPool2d(kernel_size=4)
+        x = Tensor(np.arange(2 * 3 * 4 * 4).reshape(2, 3, 4, 4).astype(np.float32))
+
+        out = pool(x)
+
+        assert out.shape == (2, 3, 1, 1)
+        expected = x.data.mean(axis=(2, 3), keepdims=True)
+        np.testing.assert_allclose(out.data, expected)
+
+    def test_conv2d_1x1_input_1x1_kernel(self):
+        """The most degenerate case: a single pixel input."""
+        conv = Conv2d(in_channels=2, out_channels=3, kernel_size=1)
+        x = Tensor(np.random.randn(1, 2, 1, 1).astype(np.float32), requires_grad=True)
+
+        out = conv(x)
+
+        assert out.shape == (1, 3, 1, 1)
+        assert np.all(np.isfinite(out.data))

--- a/tinytorch/tests/12_attention/test_attention_boundary_values.py
+++ b/tinytorch/tests/12_attention/test_attention_boundary_values.py
@@ -1,0 +1,60 @@
+"""
+Boundary-value tests for attention with a single-token sequence.
+
+seq_len=1 is a real, common case: the first token of autoregressive
+generation. The causal mask degenerates to a 1x1 all-ones matrix (the
+one token can only attend to itself), an edge case no existing test
+exercised.
+"""
+
+import numpy as np
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from tinytorch.core.tensor import Tensor
+from tinytorch.core.attention import MultiHeadAttention, scaled_dot_product_attention
+from tinytorch.core.autograd import enable_autograd
+
+enable_autograd()
+
+
+class TestAttentionSingleToken:
+    def test_scaled_dot_product_attention_seq_len_one(self):
+        Q = Tensor(np.random.randn(1, 1, 4).astype(np.float32), requires_grad=True)
+        K = Tensor(np.random.randn(1, 1, 4).astype(np.float32), requires_grad=True)
+        V = Tensor(np.random.randn(1, 1, 4).astype(np.float32), requires_grad=True)
+
+        output, weights = scaled_dot_product_attention(Q, K, V)
+
+        assert output.shape == (1, 1, 4)
+        assert weights.shape == (1, 1, 1)
+        # A single token attending only to itself must get weight 1.0.
+        np.testing.assert_allclose(weights.data, np.ones((1, 1, 1)), atol=1e-5)
+        np.testing.assert_allclose(output.data, V.data, atol=1e-5)
+
+    def test_multihead_attention_seq_len_one_with_causal_mask(self):
+        mha = MultiHeadAttention(embed_dim=8, num_heads=2)
+        x = Tensor(np.random.randn(1, 1, 8).astype(np.float32), requires_grad=True)
+        mask = Tensor(np.tril(np.ones((1, 1, 1))))
+
+        out = mha(x, mask)
+
+        assert out.shape == (1, 1, 8)
+        assert np.all(np.isfinite(out.data))
+
+        out.sum().backward()
+        assert np.all(np.isfinite(x.grad))
+
+    def test_multihead_attention_seq_len_one_batch_greater_than_one(self):
+        """Multiple independent single-token sequences in the same batch
+        (e.g. the first generation step for several prompts at once)."""
+        mha = MultiHeadAttention(embed_dim=8, num_heads=2)
+        x = Tensor(np.random.randn(4, 1, 8).astype(np.float32), requires_grad=True)
+        mask = Tensor(np.tril(np.ones((1, 1, 1))))
+
+        out = mha(x, mask)
+
+        assert out.shape == (4, 1, 8)
+        assert np.all(np.isfinite(out.data))


### PR DESCRIPTION
Part of #2046.

Adds the boundary-value sweep from the testing plan:

- **DataLoader**: a partial last batch (dataset size not evenly divisible by batch_size), `batch_size=1`, `batch_size` equal to or larger than the dataset size.
- **Attention**: single-token sequences (`seq_len=1`, the first step of autoregressive generation), where the causal mask degenerates to a 1x1 all-ones matrix.
- **Conv2d/MaxPool2d/AvgPool2d**: `kernel_size` equal to the input's spatial size (the "global" convolution/pooling boundary), including the fully degenerate 1x1 input case.

None of these were previously exercised, only evenly-divisible batch sizes and kernel sizes smaller than the input were tested.

Verified via hand-mutation: a floor-division bug in `DataLoader.__len__`, an unscaled attention output, and an off-by-one in Conv2d's output-size formula are all caught by the corresponding new tests.
