### PR TITLE
fix(tinytorch): milestone JSON reading crashed on non-cp1252 unicode and null/wrong-type completed_modules

### DIFF
--- a/tinytorch/pyproject.toml
+++ b/tinytorch/pyproject.toml
@@ -48,6 +48,14 @@ dev = [
 visualization = [
     "matplotlib>=3.10.9",  # For plotting in Modules 17, 19, 20
 ]
+fuzz = [
+    # Test-only dependency for property-based fuzz tests, never imported by
+    # the tinytorch package itself. Generates randomized inputs (shapes,
+    # dtypes, edge-case values) to find cases no one thought to write a
+    # test for. Optional: fuzz tests skip themselves cleanly via
+    # pytest.importorskip if this isn't installed.
+    "hypothesis>=6.100",
+]
 docs = [
     "jupyter-book>=2.1.5,<3.0.0",
     "sphinxcontrib-mermaid>=2.0.2",

--- a/tinytorch/tests/milestones/test_malformed_state_files.py
+++ b/tinytorch/tests/milestones/test_malformed_state_files.py
@@ -83,6 +83,50 @@ class TestProgressJsonWrongType:
 
         assert result == {1, 2}
 
+    def test_null_completed_modules_value_does_not_crash(self, tmp_path, monkeypatch):
+        """'completed_modules' present but explicitly null (a bad merge or
+        partial write) is a different corruption mode than the key being
+        absent entirely: dict.get(key, []) only substitutes the default
+        when the key is missing, not when its value is None."""
+        monkeypatch.chdir(tmp_path)
+        _write(Path(".tito/progress.json"), json.dumps({"completed_modules": None}))
+
+        result = _load_completed_module_numbers()
+
+        assert result == set()
+
+    def test_non_list_completed_modules_value_does_not_crash(self, tmp_path, monkeypatch):
+        """'completed_modules' present but holding a non-list value (bool,
+        number, string) rather than being absent or null."""
+        monkeypatch.chdir(tmp_path)
+        for bad_value in (True, 42, "01_tensor"):
+            _write(Path(".tito/progress.json"), json.dumps({"completed_modules": bad_value}))
+
+            result = _load_completed_module_numbers()
+
+            assert result == set()
+
+    def test_progress_json_with_non_cp1252_unicode_does_not_crash(self, tmp_path, monkeypatch):
+        """A progress.json containing a Unicode character outside cp1252's
+        range (the platform's default text encoding on Windows, not
+        UTF-8) must be read correctly rather than raising a raw
+        UnicodeDecodeError. Reproduces via a real string value, not
+        malformed bytes, since the file itself is valid, well-formed
+        UTF-8 JSON; the bug was reading it without an explicit encoding."""
+        monkeypatch.chdir(tmp_path)
+        # An emoji is valid UTF-8 and valid JSON content, but not
+        # representable in cp1252. ensure_ascii=False is required here:
+        # the default True would escape it to a \uXXXX sequence, an
+        # all-ASCII file that wouldn't reproduce the encoding bug at all.
+        content = json.dumps({"completed_modules": ["01_tensor"], "note": "\U0001f600"}, ensure_ascii=False)
+        progress_path = tmp_path / ".tito" / "progress.json"
+        progress_path.parent.mkdir(parents=True, exist_ok=True)
+        progress_path.write_bytes(content.encode("utf-8"))
+
+        result = _load_completed_module_numbers()
+
+        assert result == {1}
+
 
 class TestMilestonesJsonWrongType:
     """milestones.json is syntactically valid JSON, but not an object."""

--- a/tinytorch/tests/milestones/test_malformed_state_files.py
+++ b/tinytorch/tests/milestones/test_malformed_state_files.py
@@ -1,0 +1,163 @@
+"""
+Malformed .tito state file tests.
+
+TinyTorch's progress/milestone tracking already had a defensive pattern
+in tito/commands/milestone.py: catch (json.JSONDecodeError, IOError) around
+every state-file read and fall back to sensible empty defaults rather than
+crashing. That pattern correctly handles a file that is not valid JSON at
+all (truncated, empty, binary garbage).
+
+It did not handle a file that IS valid JSON but the wrong shape (a bare
+list or string instead of the expected object), a real corruption mode:
+a bad merge conflict resolution, a manual edit gone wrong, or an
+interrupted write from something else can all produce syntactically valid
+JSON of the wrong type. json.load() succeeds, .get() on a list or string
+then raises a raw AttributeError with no useful message.
+
+These tests reproduce that class of corruption directly (crafting the
+state file's content in a temp .tito directory) rather than going through
+a full tito CLI invocation, so they stay fast and independent of any real
+project checkout.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from tito.commands.milestone import _load_completed_module_numbers, MilestoneSystem
+
+
+def _write(path: Path, content: str):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+class TestProgressJsonWrongType:
+    """progress.json is syntactically valid JSON, but not an object."""
+
+    def test_list_type_progress_json_does_not_crash(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write(Path(".tito/progress.json"), json.dumps(["01_tensor", "02_activations"]))
+
+        result = _load_completed_module_numbers()
+
+        assert result == set()
+
+    def test_string_type_progress_json_does_not_crash(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write(Path(".tito/progress.json"), json.dumps("not an object"))
+
+        result = _load_completed_module_numbers()
+
+        assert result == set()
+
+    def test_int_type_progress_json_does_not_crash(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write(Path(".tito/progress.json"), json.dumps(42))
+
+        result = _load_completed_module_numbers()
+
+        assert result == set()
+
+    def test_is_module_completed_with_wrong_type_progress_json(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write(Path(".tito/progress.json"), json.dumps(["01_tensor"]))
+        ms = MilestoneSystem(config=None)
+
+        result = ms._is_module_completed("01_tensor")
+
+        assert result is False
+
+    def test_valid_dict_progress_json_still_works(self, tmp_path, monkeypatch):
+        """Regression guard: the type check must not break the normal case."""
+        monkeypatch.chdir(tmp_path)
+        _write(
+            Path(".tito/progress.json"),
+            json.dumps({"completed_modules": ["01_tensor", "02_activations"]}),
+        )
+
+        result = _load_completed_module_numbers()
+
+        assert result == {1, 2}
+
+
+class TestMilestonesJsonWrongType:
+    """milestones.json is syntactically valid JSON, but not an object."""
+
+    def test_list_type_milestones_json_falls_back_to_default(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write(Path(".tito/milestones.json"), json.dumps([1, 2, 3]))
+        ms = MilestoneSystem(config=None)
+
+        result = ms._get_milestone_progress_data()
+
+        assert isinstance(result, dict)
+        assert result["unlocked_milestones"] == []
+        assert result["completed_milestones"] == []
+
+    def test_string_type_milestones_json_falls_back_to_default(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write(Path(".tito/milestones.json"), json.dumps("corrupted"))
+        ms = MilestoneSystem(config=None)
+
+        result = ms._get_milestone_progress_data()
+
+        assert isinstance(result, dict)
+        assert result["total_unlocked"] == 0
+
+    def test_valid_dict_milestones_json_still_works(self, tmp_path, monkeypatch):
+        """Regression guard: the type check must not break the normal case."""
+        monkeypatch.chdir(tmp_path)
+        stored = {
+            "completed_milestones": ["01"],
+            "completion_dates": {"01": "2026-01-01T00:00:00"},
+            "unlocked_milestones": ["01"],
+            "unlock_dates": {"01": "2026-01-01T00:00:00"},
+            "total_unlocked": 1,
+            "achievements": [],
+        }
+        _write(Path(".tito/milestones.json"), json.dumps(stored))
+        ms = MilestoneSystem(config=None)
+
+        result = ms._get_milestone_progress_data()
+
+        assert result == stored
+
+
+class TestTrulyMalformedJsonStillFallsBackCleanly:
+    """
+    Sanity check that the pre-existing (json.JSONDecodeError, IOError)
+    handling for genuinely invalid JSON, truncated, empty, binary garbage,
+    still works after adding the isinstance(dict) check alongside it.
+    """
+
+    def test_truncated_progress_json(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write(Path(".tito/progress.json"), '{"completed_modules": ["01_tensor"')
+
+        result = _load_completed_module_numbers()
+
+        assert result == set()
+
+    def test_empty_progress_json(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write(Path(".tito/progress.json"), "")
+
+        result = _load_completed_module_numbers()
+
+        assert result == set()
+
+    def test_binary_garbage_milestones_json(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        path = tmp_path / ".tito" / "milestones.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"\x00\x01\x02not json at all\xff\xfe")
+        ms = MilestoneSystem(config=None)
+
+        result = ms._get_milestone_progress_data()
+
+        assert isinstance(result, dict)
+        assert result["unlocked_milestones"] == []

--- a/tinytorch/tests/milestones/test_milestone_json_fuzz.py
+++ b/tinytorch/tests/milestones/test_milestone_json_fuzz.py
@@ -1,0 +1,88 @@
+"""
+Property-based fuzz tests for milestone/progress JSON parsing.
+
+Extends test_malformed_state_files.py's hand-picked corruption cases
+(wrong top-level type, missing keys) with randomized JSON structures:
+arbitrarily nested objects/arrays/scalars, and a "completed_modules"
+key holding arbitrary garbage instead of a list of strings. The
+function under test must never raise, only ever return a set (possibly
+empty).
+
+Requires the optional `fuzz` dependency group; skips cleanly if
+hypothesis isn't installed.
+"""
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+import pytest
+
+hypothesis = pytest.importorskip("hypothesis", reason="fuzz tests need the optional 'fuzz' dependency group")
+from hypothesis import given, settings, strategies as st
+
+from tito.commands.milestone import _load_completed_module_numbers
+
+
+def _load_with_progress_content(content: str) -> set:
+    """Write content to a fresh temp dir's .tito/progress.json, chdir
+    there, and call the function under test. Uses tempfile directly
+    (not pytest's tmp_path fixture) since hypothesis's @given doesn't
+    mix cleanly with function-scoped pytest fixtures."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tito_dir = Path(tmp_dir) / ".tito"
+        tito_dir.mkdir(parents=True, exist_ok=True)
+        (tito_dir / "progress.json").write_text(content, encoding="utf-8")
+
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(tmp_dir)
+            return _load_completed_module_numbers()
+        finally:
+            os.chdir(original_cwd)
+
+
+# Any JSON-serializable value, recursively: scalars, lists, and dicts with
+# string keys, nested up to a few levels deep.
+json_value = st.recursive(
+    st.none() | st.booleans() | st.integers() | st.floats(allow_nan=False, allow_infinity=False) | st.text(max_size=20),
+    lambda children: st.lists(children, max_size=5) | st.dictionaries(st.text(max_size=10), children, max_size=5),
+    max_leaves=20,
+)
+
+
+@given(json_value)
+@settings(max_examples=200)
+def test_load_completed_modules_never_crashes_on_arbitrary_json(value):
+    """Any syntactically valid JSON document, regardless of shape, must
+    produce a set (possibly empty), never an exception."""
+    result = _load_with_progress_content(json.dumps(value))
+
+    assert isinstance(result, set)
+
+
+@given(st.dictionaries(st.text(max_size=10), json_value, max_size=5), json_value)
+@settings(max_examples=200)
+def test_load_completed_modules_never_crashes_on_arbitrary_dict_shape(extra_fields, completed_modules_value):
+    """A well-formed top-level object but with 'completed_modules' set to
+    an arbitrary value (not a list of strings) must not crash."""
+    progress = dict(extra_fields)
+    progress["completed_modules"] = completed_modules_value
+
+    result = _load_with_progress_content(json.dumps(progress))
+
+    assert isinstance(result, set)
+
+
+@given(st.text(max_size=500))
+@settings(max_examples=200)
+def test_load_completed_modules_never_crashes_on_arbitrary_text(garbage_text):
+    """Arbitrary (likely not even valid JSON) text content, truncated
+    writes, binary-ish garbage, must fall back cleanly."""
+    result = _load_with_progress_content(garbage_text)
+
+    assert isinstance(result, set)

--- a/tinytorch/tito/commands/milestone.py
+++ b/tinytorch/tito/commands/milestone.py
@@ -228,6 +228,18 @@ def _module_progress_to_int(module_value):
         return None
 
 
+def _get_completed_modules_list(progress_data: dict) -> list:
+    """Safely extract the 'completed_modules' list from progress data.
+
+    dict.get(key, []) only falls back to the default when the key is
+    absent, not when its value is present but the wrong type (null,
+    a bool, a string, ...), a real corruption mode from a bad merge or
+    partial write. Always returns a list, iterating it is always safe.
+    """
+    value = progress_data.get("completed_modules")
+    return value if isinstance(value, list) else []
+
+
 def _load_completed_module_numbers() -> set:
     """Read completed module numbers from the canonical .tito progress file."""
     progress_file = Path(".tito") / "progress.json"
@@ -236,9 +248,9 @@ def _load_completed_module_numbers() -> set:
         return completed
 
     try:
-        with open(progress_file, 'r') as f:
+        with open(progress_file, 'r', encoding='utf-8') as f:
             progress_data = json.load(f)
-    except (json.JSONDecodeError, IOError):
+    except (json.JSONDecodeError, IOError, UnicodeDecodeError):
         return completed
 
     if not isinstance(progress_data, dict):
@@ -246,7 +258,7 @@ def _load_completed_module_numbers() -> set:
         # treat it the same as a decode failure rather than crashing below.
         return completed
 
-    for module_value in progress_data.get("completed_modules", []):
+    for module_value in _get_completed_modules_list(progress_data):
         module_num = _module_progress_to_int(module_value)
         if module_num is not None:
             completed.add(module_num)
@@ -510,17 +522,17 @@ class MilestoneSystem:
         progress_file = Path(".tito") / "progress.json"
         if progress_file.exists():
             try:
-                with open(progress_file, 'r') as f:
+                with open(progress_file, 'r', encoding='utf-8') as f:
                     progress_data = json.load(f)
                     if not isinstance(progress_data, dict):
                         return False
                     module_num = _module_progress_to_int(module_name)
                     completed_nums = {
                         _module_progress_to_int(mod)
-                        for mod in progress_data.get("completed_modules", [])
+                        for mod in _get_completed_modules_list(progress_data)
                     }
                     return module_num in completed_nums
-            except (json.JSONDecodeError, IOError):
+            except (json.JSONDecodeError, IOError, UnicodeDecodeError):
                 pass
         return False
 
@@ -533,11 +545,11 @@ class MilestoneSystem:
 
         if progress_file.exists():
             try:
-                with open(progress_file, 'r') as f:
+                with open(progress_file, 'r', encoding='utf-8') as f:
                     data = json.load(f)
                 if isinstance(data, dict):
                     return data
-            except (json.JSONDecodeError, IOError):
+            except (json.JSONDecodeError, IOError, UnicodeDecodeError):
                 pass
 
         return {
@@ -557,7 +569,7 @@ class MilestoneSystem:
         progress_dir.mkdir(exist_ok=True)
 
         try:
-            with open(progress_file, 'w') as f:
+            with open(progress_file, 'w', encoding='utf-8') as f:
                 json.dump(milestone_data, f, indent=2)
         except IOError:
             pass
@@ -1451,15 +1463,15 @@ class MilestoneCommand(BaseCommand):
                 completed_modules = []
                 if progress_file.exists():
                     try:
-                        with open(progress_file, 'r') as f:
+                        with open(progress_file, 'r', encoding='utf-8') as f:
                             progress_data = json.load(f)
                             if isinstance(progress_data, dict):
-                                for mod in progress_data.get("completed_modules", []):
+                                for mod in _get_completed_modules_list(progress_data):
                                     try:
                                         completed_modules.append(int(mod.split("_")[0]))
                                     except (ValueError, IndexError):
                                         pass
-                    except (json.JSONDecodeError, IOError):
+                    except (json.JSONDecodeError, IOError, UnicodeDecodeError):
                         pass
 
                 # Check if unlocked
@@ -1574,11 +1586,11 @@ class MilestoneCommand(BaseCommand):
 
         if progress_file.exists():
             try:
-                with open(progress_file, 'r') as f:
+                with open(progress_file, 'r', encoding='utf-8') as f:
                     data = json.load(f)
                 if isinstance(data, dict):
                     return data
-            except (json.JSONDecodeError, IOError):
+            except (json.JSONDecodeError, IOError, UnicodeDecodeError):
                 pass
 
         return {
@@ -1598,7 +1610,7 @@ class MilestoneCommand(BaseCommand):
         progress_dir.mkdir(exist_ok=True)
 
         try:
-            with open(progress_file, 'w') as f:
+            with open(progress_file, 'w', encoding='utf-8') as f:
                 json.dump(milestone_data, f, indent=2)
         except IOError:
             pass

--- a/tinytorch/tito/commands/milestone.py
+++ b/tinytorch/tito/commands/milestone.py
@@ -241,6 +241,11 @@ def _load_completed_module_numbers() -> set:
     except (json.JSONDecodeError, IOError):
         return completed
 
+    if not isinstance(progress_data, dict):
+        # Valid JSON but not the expected object shape (e.g. a bare list),
+        # treat it the same as a decode failure rather than crashing below.
+        return completed
+
     for module_value in progress_data.get("completed_modules", []):
         module_num = _module_progress_to_int(module_value)
         if module_num is not None:
@@ -507,6 +512,8 @@ class MilestoneSystem:
             try:
                 with open(progress_file, 'r') as f:
                     progress_data = json.load(f)
+                    if not isinstance(progress_data, dict):
+                        return False
                     module_num = _module_progress_to_int(module_name)
                     completed_nums = {
                         _module_progress_to_int(mod)
@@ -527,7 +534,9 @@ class MilestoneSystem:
         if progress_file.exists():
             try:
                 with open(progress_file, 'r') as f:
-                    return json.load(f)
+                    data = json.load(f)
+                if isinstance(data, dict):
+                    return data
             except (json.JSONDecodeError, IOError):
                 pass
 
@@ -1444,11 +1453,12 @@ class MilestoneCommand(BaseCommand):
                     try:
                         with open(progress_file, 'r') as f:
                             progress_data = json.load(f)
-                            for mod in progress_data.get("completed_modules", []):
-                                try:
-                                    completed_modules.append(int(mod.split("_")[0]))
-                                except (ValueError, IndexError):
-                                    pass
+                            if isinstance(progress_data, dict):
+                                for mod in progress_data.get("completed_modules", []):
+                                    try:
+                                        completed_modules.append(int(mod.split("_")[0]))
+                                    except (ValueError, IndexError):
+                                        pass
                     except (json.JSONDecodeError, IOError):
                         pass
 
@@ -1565,7 +1575,9 @@ class MilestoneCommand(BaseCommand):
         if progress_file.exists():
             try:
                 with open(progress_file, 'r') as f:
-                    return json.load(f)
+                    data = json.load(f)
+                if isinstance(data, dict):
+                    return data
             except (json.JSONDecodeError, IOError):
                 pass
 


### PR DESCRIPTION
Note: this branch is built on top of #2049 (unmerged), since it fuzzes the exact function that PR fixed. Until #2049 merges, this diff will show both PRs' changes combined; the changes specific to this PR are the encoding fix, the completed_modules type-safety helper, and the new fuzz/regression tests described below.

Part of #2046.

Property-based fuzz testing (hypothesis, extending the malformed-JSON regression tests from #2049) found two more real bugs in `_load_completed_module_numbers()` and its two call sites reading `progress.json`:

1. `open(progress_file, 'r')` had no explicit encoding, so on Windows it defaults to the system locale (cp1252), not UTF-8. Any `progress.json` containing a Unicode character outside cp1252's range raised a raw `UnicodeDecodeError`, uncaught since the except clause only handled `(json.JSONDecodeError, IOError)`. Fixed by opening with `encoding='utf-8'` explicitly (all read and write sites) and adding `UnicodeDecodeError` to the caught exceptions as defense in depth.

2. `progress_data.get("completed_modules", [])` only substitutes the default when the key is absent, not when its value is present but the wrong type: `{"completed_modules": null}` or `{"completed_modules": true}` (a real corruption mode from a bad merge or partial write) returned `None`/`True` respectively, and iterating that raised a raw `TypeError`. Added a `_get_completed_modules_list()` helper that validates the value is actually a list before using it, applied at all three call sites.

Both verified via hand-mutation (reverting each fix independently reproduces its crash) and locked in with hand-picked regression tests in `test_malformed_state_files.py`, plus a new property-based fuzz test file covering the full space of malformed `progress.json` shapes.
