### PR TITLE
fix(tinytorch): tito module start/resume spawns duplicate Jupyter servers

### DIFF
--- a/tinytorch/tests/cli/test_jupyter_duplicate_detection.py
+++ b/tinytorch/tests/cli/test_jupyter_duplicate_detection.py
@@ -1,0 +1,117 @@
+"""
+Tests for _find_running_jupyter_lab_pids(), the duplicate-process guard
+for `tito module start`/`resume`.
+
+Repeated `tito module resume` calls previously spawned a brand new
+Jupyter Lab server process every time, with nothing tracking or
+cleaning up the previous one, an unbounded resource leak. These tests
+mock psutil directly rather than spawning real Jupyter processes, which
+would be slow and environment-fragile in CI.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from tito.commands.module.workflow import _find_running_jupyter_lab_pids
+
+
+def _make_proc(pid, cmdline):
+    proc = MagicMock()
+    proc.info = {"pid": pid, "cmdline": cmdline}
+    return proc
+
+
+class TestFindRunningJupyterLabPids:
+    def test_returns_none_when_psutil_not_installed(self):
+        with patch.dict(sys.modules, {"psutil": None}):
+            result = _find_running_jupyter_lab_pids()
+
+        assert result is None
+
+    def test_returns_empty_list_when_no_jupyter_running(self):
+        fake_procs = [
+            _make_proc(100, ["python", "some_script.py"]),
+            _make_proc(101, ["node", "server.js"]),
+        ]
+        fake_psutil = MagicMock()
+        fake_psutil.process_iter.return_value = fake_procs
+        fake_psutil.NoSuchProcess = Exception
+        fake_psutil.AccessDenied = Exception
+
+        with patch.dict(sys.modules, {"psutil": fake_psutil}):
+            result = _find_running_jupyter_lab_pids()
+
+        assert result == []
+
+    def test_finds_running_jupyter_lab_process(self):
+        fake_procs = [
+            _make_proc(200, ["python", "-m", "jupyter", "lab", "--notebook-dir=."]),
+        ]
+        fake_psutil = MagicMock()
+        fake_psutil.process_iter.return_value = fake_procs
+        fake_psutil.NoSuchProcess = Exception
+        fake_psutil.AccessDenied = Exception
+
+        with patch.dict(sys.modules, {"psutil": fake_psutil}):
+            result = _find_running_jupyter_lab_pids()
+
+        assert result == [200]
+
+    def test_ignores_processes_matching_jupyter_but_not_lab(self):
+        """'jupyter kernelspec' or 'jupyter notebook' aren't the target
+        server process this guard is meant to deduplicate against."""
+        fake_procs = [
+            _make_proc(300, ["jupyter", "kernelspec", "list"]),
+        ]
+        fake_psutil = MagicMock()
+        fake_psutil.process_iter.return_value = fake_procs
+        fake_psutil.NoSuchProcess = Exception
+        fake_psutil.AccessDenied = Exception
+
+        with patch.dict(sys.modules, {"psutil": fake_psutil}):
+            result = _find_running_jupyter_lab_pids()
+
+        assert result == []
+
+    def test_skips_processes_that_raise_during_inspection(self):
+        """A process that exits between process_iter() listing it and
+        reading its cmdline (psutil.NoSuchProcess) must not crash the
+        whole scan, just be skipped."""
+        vanished_proc = MagicMock()
+        vanished_proc.info = {"pid": 400}
+
+        class FakeNoSuchProcess(Exception):
+            pass
+
+        def raise_on_get(key, default=None):
+            raise FakeNoSuchProcess()
+
+        vanished_proc.info = MagicMock()
+        vanished_proc.info.get.side_effect = raise_on_get
+
+        fake_psutil = MagicMock()
+        fake_psutil.process_iter.return_value = [vanished_proc]
+        fake_psutil.NoSuchProcess = FakeNoSuchProcess
+        fake_psutil.AccessDenied = Exception
+
+        with patch.dict(sys.modules, {"psutil": fake_psutil}):
+            result = _find_running_jupyter_lab_pids()
+
+        assert result == []
+
+    def test_returns_none_on_unexpected_scan_failure(self):
+        """Any other unexpected failure scanning processes (e.g. a
+        platform-specific psutil error) must degrade to 'unknown' rather
+        than crash the module start/resume flow."""
+        fake_psutil = MagicMock()
+        fake_psutil.process_iter.side_effect = RuntimeError("platform error")
+        fake_psutil.NoSuchProcess = Exception
+        fake_psutil.AccessDenied = Exception
+
+        with patch.dict(sys.modules, {"psutil": fake_psutil}):
+            result = _find_running_jupyter_lab_pids()
+
+        assert result is None

--- a/tinytorch/tito/commands/module/workflow.py
+++ b/tinytorch/tito/commands/module/workflow.py
@@ -36,6 +36,36 @@ from ...core.modules import (
     get_all_module_metadata,
 )
 
+def _find_running_jupyter_lab_pids() -> Optional[list]:
+    """Return PIDs of currently running 'jupyter lab' / 'jupyter-lab'
+    processes, or None if this can't be determined (psutil not
+    installed, or a permission error scanning processes).
+
+    None is deliberately distinct from an empty list: it means "unknown"
+    so callers can choose to proceed rather than block a legitimate
+    launch just because the check itself failed.
+    """
+    try:
+        import psutil
+    except ImportError:
+        return None
+
+    pids = []
+    try:
+        for proc in psutil.process_iter(["pid", "cmdline"]):
+            try:
+                cmdline = proc.info.get("cmdline") or []
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+            joined = " ".join(cmdline).lower()
+            if "jupyter" in joined and "lab" in joined:
+                pids.append(proc.info["pid"])
+    except Exception:
+        return None
+
+    return pids
+
+
 class ModuleWorkflowCommand(BaseCommand):
     """Enhanced module command with natural workflow."""
 
@@ -534,6 +564,21 @@ class ModuleWorkflowCommand(BaseCommand):
                     notebook_path = notebooks[0]
                 else:
                     notebook_path = None
+
+            # Avoid piling up untracked Jupyter server processes: repeated
+            # `tito module resume` calls (e.g. after forgetting a session
+            # was already open) previously spawned a brand new server
+            # every time, with no way to clean them up short of finding
+            # and killing them manually.
+            running_pids = _find_running_jupyter_lab_pids()
+            if running_pids:
+                self.console.print(
+                    f"[yellow]⚠️  Jupyter Lab already appears to be running "
+                    f"(pid {running_pids[0]}).[/yellow]"
+                )
+                self.console.print("[dim]Reusing it instead of starting a duplicate server.[/dim]")
+                self.console.print("[dim]Open http://localhost:8888 in your browser if it's not already open.[/dim]")
+                return 0
 
             self.console.print(f"\n[cyan]🚀 Opening Jupyter Lab for module {module_name}...[/cyan]")
 


### PR DESCRIPTION
Part of #2046.

`_open_jupyter()` (used by both `tito module start` and `tito module resume`) had no check for an already-running Jupyter Lab server before spawning a new one via `subprocess.Popen`. Calling resume more than once, e.g. after forgetting a previous session was still open, silently piled up untracked Jupyter server processes with no way to clean them up short of finding and killing them manually. This is the resource-leak class of bug flagged in the testing plan.

Added `_find_running_jupyter_lab_pids()`, a psutil-based scan for processes whose command line contains both "jupyter" and "lab". If one is already running, `_open_jupyter()` now reuses it (prints a message and returns) instead of spawning a duplicate.

Matches the existing codebase convention of treating psutil as optional (try/except ImportError, already used in `tito/commands/system/info.py`): if psutil isn't installed or the scan fails for any reason, the check returns `None` and launch proceeds as before rather than blocking a legitimate start.

Tested by mocking psutil directly (spawning real Jupyter processes in CI would be slow and environment-fragile) plus one live check against the real psutil integration path against actual running system processes.
