### PR TITLE
fix(tinytorch): Trainer.save_checkpoint not atomic, crash mid-write corrupts checkpoint

### DIFF
--- a/tinytorch/src/08_training/08_training.py
+++ b/tinytorch/src/08_training/08_training.py
@@ -1292,8 +1292,24 @@ def trainer_save_checkpoint(self, path: str):
     }
 
     Path(path).parent.mkdir(parents=True, exist_ok=True)
-    with open(path, 'wb') as f:
-        pickle.dump(checkpoint, f)
+    # Write to a temp file first, then atomically replace the target.
+    # Writing directly to `path` would leave a partially-written (corrupt)
+    # checkpoint in place if the process is killed, the disk fills up, or
+    # pickling fails partway through, silently destroying whatever good
+    # checkpoint was there before. os.replace() is atomic on both POSIX
+    # and Windows: `path` is always either the old complete checkpoint or
+    # the new one, never a partial write.
+    tmp_path = f"{path}.tmp"
+    try:
+        with open(tmp_path, 'wb') as f:
+            pickle.dump(checkpoint, f)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.remove(tmp_path)
+        except OSError:
+            pass
+        raise
     ### END SOLUTION
 
 Trainer.save_checkpoint = trainer_save_checkpoint

--- a/tinytorch/tests/08_training/test_training_coverage.py
+++ b/tinytorch/tests/08_training/test_training_coverage.py
@@ -260,6 +260,79 @@ class TestCheckpointing:
             assert os.path.exists(path)
 
 
+class TestSaveCheckpointIsAtomic:
+    """save_checkpoint must never leave a corrupted or partially-written
+    file at the target path, the classic "process killed mid-write" or
+    "disk full during save" failure mode. It writes to a temp file and
+    atomically replaces the target, so the target is always either the
+    old complete checkpoint or the new one, never a partial write."""
+
+    def test_failure_during_write_leaves_previous_checkpoint_intact(self, monkeypatch):
+        """Simulates a crash/disk-full event partway through pickling by
+        making pickle.dump raise. The previous good checkpoint at the
+        target path must be completely unaffected."""
+        import tinytorch.core.training as training_module
+
+        trainer, _ = simple_trainer()
+        trainer.epoch = 1
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "ckpt.pkl")
+            trainer.save_checkpoint(path)
+            with open(path, "rb") as f:
+                original_bytes = f.read()
+
+            trainer.epoch = 999  # state that must NOT end up on disk
+
+            def failing_dump(obj, f):
+                f.write(b"partial garbage")
+                raise OSError("simulated disk full")
+
+            monkeypatch.setattr(training_module.pickle, "dump", failing_dump)
+
+            with pytest.raises(OSError):
+                trainer.save_checkpoint(path)
+
+            with open(path, "rb") as f:
+                after_bytes = f.read()
+            assert after_bytes == original_bytes, (
+                "A failed save must not corrupt the previous checkpoint"
+            )
+
+    def test_failure_during_write_does_not_leave_temp_file_behind(self, monkeypatch):
+        import tinytorch.core.training as training_module
+
+        trainer, _ = simple_trainer()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "ckpt.pkl")
+
+            def failing_dump(obj, f):
+                raise OSError("simulated disk full")
+
+            monkeypatch.setattr(training_module.pickle, "dump", failing_dump)
+
+            with pytest.raises(OSError):
+                trainer.save_checkpoint(path)
+
+            assert not os.path.exists(path)
+            assert not os.path.exists(path + ".tmp")
+
+    def test_successful_save_still_produces_a_loadable_checkpoint(self):
+        """Regression guard: the atomic-write change must not break the
+        normal, successful save path."""
+        trainer, model = simple_trainer()
+        trainer.epoch = 5
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "ckpt.pkl")
+            trainer.save_checkpoint(path)
+
+            assert os.path.exists(path)
+            assert not os.path.exists(path + ".tmp")
+
+            trainer.epoch = 0
+            trainer.load_checkpoint(path)
+            assert trainer.epoch == 5
+
+
 # ─────────────────────────────────────────────
 # Trainer.evaluate
 # ─────────────────────────────────────────────


### PR DESCRIPTION
Part of #2046.

`save_checkpoint` wrote directly to the target path: `open(path, 'wb')` then `pickle.dump(checkpoint, f)`. If the process is killed, the disk fills up, or pickling fails partway through (all realistic during a long training run), the target file is left partially written, silently destroying whatever good checkpoint was there before. Unlike a read-time corruption (already handled gracefully by `Trainer.load_checkpoint`'s error handling), this is unrecoverable: the previous valid checkpoint is gone, along with however many hours of training it represented.

Fixed with the standard write-temp-then-atomic-replace pattern: `pickle.dump` to a `.tmp` file, then `os.replace()` into the real path. `os.replace()` is atomic on both POSIX and Windows, so the target is always either the old complete checkpoint or the new one, never a partial write. The temp file is cleaned up on any failure.

Verified via hand-mutation: reverting to the direct-write pattern reproduces both failure modes these tests catch, a corrupted target file and a leftover `.tmp` file.

Found during the anomaly/fault-injection testing pass from the testing plan.
