### PR TITLE
fix(tinytorch): test_deep_network_gradient_chain flaky under full test suite

### DIFF
--- a/tinytorch/tests/integration/test_training_flow.py
+++ b/tinytorch/tests/integration/test_training_flow.py
@@ -188,11 +188,27 @@ class TestGradientChainNotBroken:
 
     def test_deep_network_gradient_chain(self):
         """Gradients must flow through 5 layers"""
-        # Use fixed seed for reproducibility - prevents flaky test due to
-        # random initialization that might kill all ReLUs
+        # Fixed seed for reproducibility. Note this only seeds x/target
+        # below: Linear's default weight init draws from a *different*,
+        # module-level shared rng in tinytorch.core.layers that isn't
+        # reset per test, so its state (and therefore these layers'
+        # initial weights) depends on how many other tests ran before
+        # this one and how many Linear layers *they* created. That
+        # previously made this test genuinely flaky under a large test
+        # suite: an unlucky draw could zero out every ReLU in a layer,
+        # killing the gradient chain by design, not by bug. Overriding
+        # each layer's weights explicitly below makes the test fully
+        # deterministic regardless of suite composition or run order.
         rng = np.random.default_rng(7)
 
         layers = [Linear(4, 4) for _ in range(5)]
+        for layer in layers:
+            # Small, well-conditioned, non-zero weights: guarantees every
+            # ReLU sees a mix of positive and negative pre-activations,
+            # so no layer can go fully dead regardless of the input.
+            layer.weight.data = (rng.standard_normal((4, 4)) * 0.5 + 0.1).astype(np.float32)
+            if layer.bias is not None:
+                layer.bias.data = np.full(4, 0.1, dtype=np.float32)
 
         # Enable gradient tracking on all layer parameters
         for layer in layers:


### PR DESCRIPTION
Part of #2046.

Found while doing a full combined integration check across this testing initiative's PRs: `test_deep_network_gradient_chain` failed once in a full-suite run despite passing every time in isolation.

Root cause: the test's own comment claimed a fixed seed prevented flakiness from random initialization killing all ReLUs, but the seed only covered the test's local x/target tensors. `Linear`'s default weight init draws from a separate, module-level shared `rng` in `tinytorch.core.layers` that is never reset per test, so this test's actual layer weights depended on how many other tests ran before it and how many `Linear` layers *they* created, order- and suite-composition-dependent, not a fixed seed at all.

Confirmed via simulation (burning a variable number of draws from the shared `rng` before constructing the test's layers, 500 trials): the original code failed in **148/500 cases** (a layer's ReLU going fully dead, zeroing its gradient). It happened to surface in this session's integration run simply because more test files now exist elsewhere in the suite, shifting the shared rng's state enough to trigger it, nothing about their content is related.

Fixed by explicitly overriding each layer's weight and bias data after construction with values from the test's own seeded generator, small and non-zero enough that no layer can go fully dead regardless of input. Verified via the same simulation: 0/200 failures after the fix.
