### PR TITLE
fix(tinytorch): get_progress_data() crashed on wrong-type progress.json, silently swallowed malformed milestones.json

### DIFF
--- a/tinytorch/tests/cli/test_workflow_malformed_progress.py
+++ b/tinytorch/tests/cli/test_workflow_malformed_progress.py
@@ -1,0 +1,154 @@
+"""
+Malformed .tito/progress.json and .tito/milestones.json tests for
+ModuleWorkflowCommand (the `tito module start/resume/complete` workflow).
+
+Same bug class already found and fixed twice in tito/commands/milestone.py:
+json.load() succeeds on syntactically valid JSON of the wrong shape (a
+bare list instead of the expected object), and code that assumes a dict
+crashes with a raw AttributeError/TypeError deep inside whichever
+command happened to run next.
+
+get_progress_data() is the single source of progress data for 14+ call
+sites across the module workflow (is_module_started, mark_module_started,
+update_progress, ...), so an unvalidated wrong-type progress.json broke
+essentially the entire `tito module` command surface, not just one
+command.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from tito.commands.module.workflow import ModuleWorkflowCommand
+from tito.core.config import CLIConfig
+
+
+def _make_command(tmp_path):
+    config = CLIConfig(
+        project_root=tmp_path,
+        assignments_dir=tmp_path,
+        tinytorch_dir=tmp_path,
+        bin_dir=tmp_path,
+        modules_dir=tmp_path,
+    )
+    return ModuleWorkflowCommand(config)
+
+
+def _write(path: Path, content: str):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+class TestGetProgressDataWrongType:
+    """progress.json is syntactically valid JSON, but not an object."""
+
+    def test_list_type_progress_json_does_not_crash(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write(tmp_path / ".tito" / "progress.json", json.dumps(["01_tensor", "02_activations"]))
+        cmd = _make_command(tmp_path)
+
+        result = cmd.get_progress_data()
+
+        assert isinstance(result, dict)
+        assert result["completed_modules"] == []
+
+    def test_string_type_progress_json_does_not_crash(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write(tmp_path / ".tito" / "progress.json", json.dumps("not an object"))
+        cmd = _make_command(tmp_path)
+
+        result = cmd.get_progress_data()
+
+        assert isinstance(result, dict)
+
+    def test_is_module_started_with_wrong_type_progress_json(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write(tmp_path / ".tito" / "progress.json", json.dumps(["01_tensor"]))
+        cmd = _make_command(tmp_path)
+
+        result = cmd.is_module_started("01")
+
+        assert result is False
+
+    def test_mark_module_started_with_wrong_type_progress_json_does_not_crash(self, tmp_path, monkeypatch):
+        """mark_module_started mutates and re-saves progress; a wrong-type
+        file must not crash even on the write path."""
+        monkeypatch.chdir(tmp_path)
+        _write(tmp_path / ".tito" / "progress.json", json.dumps(42))
+        cmd = _make_command(tmp_path)
+
+        cmd.mark_module_started("01")
+
+        saved = json.loads((tmp_path / ".tito" / "progress.json").read_text(encoding="utf-8"))
+        assert saved["started_modules"] == ["01"]
+
+    def test_valid_dict_progress_json_still_works(self, tmp_path, monkeypatch):
+        """Regression guard: the type check must not break the normal case."""
+        monkeypatch.chdir(tmp_path)
+        _write(
+            tmp_path / ".tito" / "progress.json",
+            json.dumps({"completed_modules": ["01_tensor", "02_activations"]}),
+        )
+        cmd = _make_command(tmp_path)
+
+        result = cmd.get_progress_data()
+
+        assert result["completed_modules"] == ["01_tensor", "02_activations"]
+
+
+class TestCheckMilestoneUnlocksWrongType:
+    """milestones.json is syntactically valid JSON, but not an object."""
+
+    def test_list_type_milestones_json_does_not_crash(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        _write(tmp_path / ".tito" / "progress.json", json.dumps({"completed_modules": ["01_tensor"]}))
+        _write(tmp_path / ".tito" / "milestones.json", json.dumps([1, 2, 3]))
+        cmd = _make_command(tmp_path)
+
+        # Must not raise.
+        cmd._check_milestone_unlocks("01_tensor")
+
+    def test_list_type_milestones_json_still_completes_the_unlock_check(self, tmp_path, monkeypatch, capsys):
+        """The outer function-level exception handler already prevents a
+        crash from ever reaching the caller (it's designed not to fail
+        the workflow), so a 'does not raise' test alone can't tell a real
+        fix from silently swallowing the error and giving up early. This
+        confirms the function actually completes its normal logic
+        (treats the malformed file as empty and rewrites it as a valid
+        object) rather than bailing into the broad except."""
+        monkeypatch.chdir(tmp_path)
+        # 03_layers requires modules [1, 2, 3]; completing 03_layers should
+        # unlock milestone 01 (requires_modules [1, 2, 3]).
+        _write(
+            tmp_path / ".tito" / "progress.json",
+            json.dumps({"completed_modules": ["01_tensor", "02_activations", "03_layers"]}),
+        )
+        _write(tmp_path / ".tito" / "milestones.json", json.dumps([1, 2, 3]))
+        cmd = _make_command(tmp_path)
+
+        cmd._check_milestone_unlocks("03_layers")
+
+        capsys.readouterr()  # drain output, not asserted on here
+        milestones_path = tmp_path / ".tito" / "milestones.json"
+        saved = json.loads(milestones_path.read_text(encoding="utf-8"))
+        assert isinstance(saved, dict)
+        assert "01" in saved.get("unlocked_milestones", []), (
+            "Malformed milestones.json should be treated as empty and "
+            "still let a genuinely-unlocked milestone be recorded, not "
+            "silently give up"
+        )
+
+    def test_valid_dict_milestones_json_still_works(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write(tmp_path / ".tito" / "progress.json", json.dumps({"completed_modules": ["01_tensor", "02_activations", "03_layers"]}))
+        _write(
+            tmp_path / ".tito" / "milestones.json",
+            json.dumps({"unlocked_milestones": [], "completed_milestones": []}),
+        )
+        cmd = _make_command(tmp_path)
+
+        # Must not raise, and should actually process the valid data.
+        cmd._check_milestone_unlocks("03_layers")

--- a/tinytorch/tito/commands/module/workflow.py
+++ b/tinytorch/tito/commands/module/workflow.py
@@ -1349,8 +1349,15 @@ class ModuleWorkflowCommand(BaseCommand):
         try:
             import json
             if progress_file.exists():
-                with open(progress_file, 'r') as f:
-                    return json.load(f)
+                with open(progress_file, 'r', encoding='utf-8') as f:
+                    data = json.load(f)
+                # Valid JSON but not the expected object shape (e.g. a bare
+                # list from a bad merge or partial write) must not be
+                # returned as-is: every caller assumes a dict and calling
+                # .get()/membership/assignment on the wrong type crashes
+                # deep inside whichever command happened to run next.
+                if isinstance(data, dict):
+                    return data
         except Exception:
             pass
 
@@ -1373,7 +1380,7 @@ class ModuleWorkflowCommand(BaseCommand):
             from datetime import datetime
             progress['last_updated'] = datetime.now().isoformat()
 
-            with open(progress_file, 'w') as f:
+            with open(progress_file, 'w', encoding='utf-8') as f:
                 json.dump(progress, f, indent=2)
         except Exception as e:
             self.console.print(f"[yellow]⚠️  Could not save progress: {e}[/yellow]")
@@ -1705,7 +1712,7 @@ class ModuleWorkflowCommand(BaseCommand):
         completed_milestones = []
         if milestones_file.exists():
             try:
-                with open(milestones_file, 'r') as f:
+                with open(milestones_file, 'r', encoding='utf-8') as f:
                     data = json.load(f)
                     completed_milestones = data.get("completed_milestones", [])
             except Exception:
@@ -1827,8 +1834,9 @@ class ModuleWorkflowCommand(BaseCommand):
             milestones_file.parent.mkdir(parents=True, exist_ok=True)
             if milestones_file.exists():
                 try:
-                    with open(milestones_file, 'r') as f:
-                        milestone_progress = json.load(f)
+                    with open(milestones_file, 'r', encoding='utf-8') as f:
+                        loaded = json.load(f)
+                    milestone_progress = loaded if isinstance(loaded, dict) else {}
                 except Exception:
                     milestone_progress = {}
             else:
@@ -1857,7 +1865,7 @@ class ModuleWorkflowCommand(BaseCommand):
             milestone_progress["total_unlocked"] = len(unlocked)
             milestone_progress.setdefault("achievements", [])
 
-            with open(milestones_file, 'w') as f:
+            with open(milestones_file, 'w', encoding='utf-8') as f:
                 json.dump(milestone_progress, f, indent=2)
 
             for milestone_id, milestone in newly_unlocked:


### PR DESCRIPTION
Part of #2046.

Same bug class already found and fixed twice in `tito/commands/milestone.py`: `json.load()` succeeds on syntactically valid JSON of the wrong shape (a bare list or string instead of the expected object), and code that assumes a dict crashes.

`get_progress_data()` is the single source of progress data for 14+ call sites across the module workflow (`is_module_started`, `mark_module_started`, `update_progress`, `get_last_worked_module`, ...), so an unvalidated wrong-type `progress.json` broke essentially the entire `tito module` command surface, not one isolated command. Confirmed the crash directly before fixing: `is_module_started()` raised a raw `AttributeError`.

`_check_milestone_unlocks()` had the same gap for `milestones.json`, though its own outer exception handler already prevented a crash from reaching the caller (by design, so milestone-check failures don't fail the whole workflow). That made it a silent-failure bug rather than a crash: a malformed `milestones.json` meant the function gave up early instead of treating it as empty and correctly recording newly-unlocked milestones. Fixed the same way, and added explicit UTF-8 encoding to both read and write sites in this file for consistency with the already-fixed `milestone.py`.

Verified via hand-mutation: reverting either isinstance check reproduces its respective failure mode (a hard crash for `progress.json`, a silently incomplete `milestones.json` for the other).

Found during a systematic audit of `tito/` for this bug pattern.
