### PR TITLE
fix(tinytorch): tito setup crashed completely on corrupted profile.json

### DIFF
--- a/tinytorch/tests/cli/test_setup_profile_malformed.py
+++ b/tinytorch/tests/cli/test_setup_profile_malformed.py
@@ -1,0 +1,87 @@
+"""
+Malformed/corrupted ~/.tinytorch/profile.json tests for
+SetupCommand.create_user_profile().
+
+create_user_profile() previously read profile.json with zero exception
+handling at all, not even a narrow catch: a corrupted file (bad merge,
+interrupted write, manual edit gone wrong) crashed `tito setup`
+completely, with no way to recover short of manually deleting the file.
+The write side wasn't atomic either, so an interrupted write could be
+the very thing that corrupts the file in the first place.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from tito.commands.setup import SetupCommand
+from tito.core.config import CLIConfig
+
+
+def _make_command(tmp_path):
+    config = CLIConfig(
+        project_root=tmp_path,
+        assignments_dir=tmp_path,
+        tinytorch_dir=tmp_path,
+        bin_dir=tmp_path,
+        modules_dir=tmp_path,
+    )
+    return SetupCommand(config)
+
+
+class TestCreateUserProfileMalformedFile:
+    def test_corrupted_json_does_not_crash(self, tmp_path):
+        home = tmp_path / "home"
+        (home / ".tinytorch").mkdir(parents=True)
+        (home / ".tinytorch" / "profile.json").write_text("not valid json {{{", encoding="utf-8")
+
+        cmd = _make_command(tmp_path)
+        with patch("pathlib.Path.home", return_value=home), \
+             patch("tito.commands.setup.Prompt.ask", side_effect=["Test User", "test@example.com", "Test Org"]):
+            profile = cmd.create_user_profile()
+
+        assert profile["name"] == "Test User"
+
+    def test_wrong_type_profile_json_does_not_crash(self, tmp_path):
+        """Valid JSON, but not an object (e.g. a bare list)."""
+        home = tmp_path / "home"
+        (home / ".tinytorch").mkdir(parents=True)
+        (home / ".tinytorch" / "profile.json").write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+
+        cmd = _make_command(tmp_path)
+        with patch("pathlib.Path.home", return_value=home), \
+             patch("tito.commands.setup.Prompt.ask", side_effect=["Test User", "test@example.com", "Test Org"]):
+            profile = cmd.create_user_profile()
+
+        assert profile["name"] == "Test User"
+
+    def test_valid_profile_json_still_reused(self, tmp_path):
+        """Regression guard: a valid existing profile must still be
+        returned as-is, not overwritten."""
+        home = tmp_path / "home"
+        (home / ".tinytorch").mkdir(parents=True)
+        (home / ".tinytorch" / "profile.json").write_text(
+            json.dumps({"name": "Existing User", "email": "e@example.com"}), encoding="utf-8"
+        )
+
+        cmd = _make_command(tmp_path)
+        with patch("pathlib.Path.home", return_value=home):
+            profile = cmd.create_user_profile()
+
+        assert profile["name"] == "Existing User"
+
+    def test_new_profile_write_leaves_no_temp_file_behind(self, tmp_path):
+        home = tmp_path / "home"
+        (home / ".tinytorch").mkdir(parents=True)
+
+        cmd = _make_command(tmp_path)
+        with patch("pathlib.Path.home", return_value=home), \
+             patch("tito.commands.setup.Prompt.ask", side_effect=["Test User", "test@example.com", "Test Org"]):
+            cmd.create_user_profile()
+
+        profile_path = home / ".tinytorch" / "profile.json"
+        assert profile_path.exists()
+        assert not (home / ".tinytorch" / "profile.json.tmp").exists()

--- a/tinytorch/tito/commands/setup.py
+++ b/tinytorch/tito/commands/setup.py
@@ -365,16 +365,26 @@ class SetupCommand(BaseCommand):
 
         if profile_path.exists():
             import json
-            with open(profile_path, 'r') as f:
-                existing_profile = json.load(f)
+            existing_profile = None
+            try:
+                with open(profile_path, 'r', encoding='utf-8') as f:
+                    loaded = json.load(f)
+                if isinstance(loaded, dict):
+                    existing_profile = loaded
+            except (json.JSONDecodeError, IOError, UnicodeDecodeError):
+                pass
 
-            if not force:
+            if existing_profile is None:
+                # Corrupted or wrong-shape profile (interrupted write, bad
+                # merge, manual edit gone wrong): fall through and create
+                # a fresh one rather than crashing setup entirely.
+                self.console.print("[yellow]⚠️  Existing profile is unreadable, creating a new one[/yellow]")
+            elif not force:
                 # Silently use existing profile
                 self.console.print(f"[green]✅ Using existing profile[/green] [dim]({existing_profile.get('name', 'Unknown')})[/dim]")
                 return existing_profile
-
-            # Force mode - ask before overwriting
-            if not Confirm.ask("[yellow]Update your existing profile?[/yellow]"):
+            elif not Confirm.ask("[yellow]Update your existing profile?[/yellow]"):
+                # Force mode - ask before overwriting
                 self.console.print("[green]✅ Keeping existing profile[/green]")
                 return existing_profile
 
@@ -398,10 +408,22 @@ class SetupCommand(BaseCommand):
             "last_active": datetime.datetime.now().isoformat()
         }
 
-        # Save profile
+        # Save profile. Write to a temp file first and atomically replace
+        # the target so an interrupted write can't leave a corrupted
+        # profile.json in place (the exact failure mode the read-side fix
+        # above has to defend against).
         import json
-        with open(profile_path, 'w') as f:
-            json.dump(profile, f, indent=2)
+        tmp_path = f"{profile_path}.tmp"
+        try:
+            with open(tmp_path, 'w', encoding='utf-8') as f:
+                json.dump(profile, f, indent=2)
+            os.replace(tmp_path, profile_path)
+        except BaseException:
+            try:
+                os.remove(tmp_path)
+            except OSError:
+                pass
+            raise
 
         _print_file_update(self.console, profile_path)
         self.console.print(f"✅ Profile created for {profile['name']}")


### PR DESCRIPTION
Part of #2046.

`create_user_profile()` read `~/.tinytorch/profile.json` with zero exception handling at all, not even a narrow catch: a corrupted file (interrupted write, bad merge, manual edit gone wrong) crashed `tito setup` completely, with no way to recover short of manually deleting the file. Confirmed the crash directly before fixing (`JSONDecodeError`, uncaught).

The write side wasn't atomic either, the exact fault-injection pattern already fixed for `Trainer.save_checkpoint`: a crash mid-write to `profile.json` would corrupt it, which is the very thing the read side then couldn't recover from.

Fixed both: the read now catches `JSONDecodeError`/`IOError`/`UnicodeDecodeError` and validates the loaded value is actually a dict, falling back to creating a fresh profile rather than crashing setup entirely. The write now goes through a temp file and `os.replace()`, atomic on both POSIX and Windows, with cleanup on failure.

Verified via hand-mutation: reverting to the unguarded read reproduces both a `JSONDecodeError` crash (malformed JSON) and a `TypeError` crash (valid JSON, wrong shape).

Found during a systematic audit of `tito/` for this bug pattern.
