### PR TITLE
fix(tinytorch): SubmissionHandler._read_json_safe returned wrong-type JSON as-is

### DIFF
--- a/tinytorch/tests/cli/test_submission_malformed_json.py
+++ b/tinytorch/tests/cli/test_submission_malformed_json.py
@@ -1,0 +1,83 @@
+"""
+Malformed progress.json/milestones.json tests for
+SubmissionHandler._read_json_safe() / assemble_payload().
+
+Same bug class already found and fixed in tito/commands/milestone.py and
+tito/commands/module/workflow.py: json.load() succeeds on syntactically
+valid JSON of the wrong shape, and code that assumes a dict crashes.
+_read_json_safe()'s own docstring and type signature promise a dict but
+never validated it, so assemble_payload() crashed with a raw
+AttributeError on a wrong-type progress.json.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from tito.core.submission import SubmissionHandler
+from tito.core.config import CLIConfig
+from tito.core.console import get_console
+
+
+def _make_handler(tmp_path):
+    config = CLIConfig(
+        project_root=tmp_path,
+        assignments_dir=tmp_path,
+        tinytorch_dir=tmp_path,
+        bin_dir=tmp_path,
+        modules_dir=tmp_path,
+    )
+    return SubmissionHandler(config, get_console())
+
+
+def _write(path: Path, content: str):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+class TestReadJsonSafeWrongType:
+    def test_list_type_returns_empty_dict(self, tmp_path):
+        _write(tmp_path / "data.json", json.dumps([1, 2, 3]))
+        handler = _make_handler(tmp_path)
+
+        result = handler._read_json_safe(tmp_path / "data.json")
+
+        assert result == {}
+
+    def test_string_type_returns_empty_dict(self, tmp_path):
+        _write(tmp_path / "data.json", json.dumps("not an object"))
+        handler = _make_handler(tmp_path)
+
+        result = handler._read_json_safe(tmp_path / "data.json")
+
+        assert result == {}
+
+    def test_valid_dict_still_returned(self, tmp_path):
+        _write(tmp_path / "data.json", json.dumps({"key": "value"}))
+        handler = _make_handler(tmp_path)
+
+        result = handler._read_json_safe(tmp_path / "data.json")
+
+        assert result == {"key": "value"}
+
+
+class TestAssemblePayloadWrongTypeFiles:
+    def test_wrong_type_progress_json_does_not_crash(self, tmp_path):
+        _write(tmp_path / ".tito" / "progress.json", json.dumps(["01_tensor"]))
+        _write(tmp_path / ".tito" / "milestones.json", json.dumps({"completed_milestones": []}))
+        handler = _make_handler(tmp_path)
+
+        payload = handler.assemble_payload()
+
+        assert payload["module_progress"]["completed_count"] == 0
+
+    def test_wrong_type_milestones_json_does_not_crash(self, tmp_path):
+        _write(tmp_path / ".tito" / "progress.json", json.dumps({"completed_modules": ["01_tensor"]}))
+        _write(tmp_path / ".tito" / "milestones.json", json.dumps("corrupted"))
+        handler = _make_handler(tmp_path)
+
+        payload = handler.assemble_payload()
+
+        assert payload["module_progress"]["completed_count"] == 1

--- a/tinytorch/tito/core/submission.py
+++ b/tinytorch/tito/core/submission.py
@@ -92,8 +92,17 @@ class SubmissionHandler:
             return {}
         try:
             with open(path, "r", encoding="utf-8") as f:
-                return json.load(f)
-        except (json.JSONDecodeError, IOError) as e:
+                data = json.load(f)
+            # Valid JSON but not the expected object shape (e.g. a bare
+            # list from a bad merge or partial write) must not be
+            # returned as-is: the declared return type is Dict[str, Any]
+            # and every caller relies on that, calling .get() on the
+            # wrong type crashes deep inside assemble_payload().
+            if isinstance(data, dict):
+                return data
+            self.console.print(f"[yellow]Warning: {path} does not contain a JSON object, ignoring[/yellow]")
+            return {}
+        except (json.JSONDecodeError, IOError, UnicodeDecodeError) as e:
             self.console.print(f"[yellow]Warning: Could not read {path}: {e}[/yellow]")
             return {}
 


### PR DESCRIPTION
Part of #2046.

Same bug class already found and fixed in `tito/commands/milestone.py` and `tito/commands/module/workflow.py`: `json.load()` succeeds on syntactically valid JSON of the wrong shape, and code that assumes a dict crashes. `_read_json_safe()`'s own docstring and type signature promise a `Dict[str, Any]` but never validated it, so a wrong-type `progress.json` or `milestones.json` (a bad merge, partial write) made `assemble_payload()` crash with a raw `AttributeError`, blocking `tito community sync`/submission entirely. Also added `UnicodeDecodeError` to the caught exceptions, since `encoding='utf-8'` was already explicit here but a genuinely non-UTF-8 file would still have escaped uncaught.

Confirmed the crash directly before fixing.

Verified via hand-mutation: reverting the isinstance check reproduces the crash for both `progress.json` and `milestones.json`.

Found during a systematic audit of `tito/` for this bug pattern (this is the fourth location it's been found in).
