### PR TITLE
fix(tinytorch): _offer_post_login_sync crashed on wrong-type progress.json

### DIFF
--- a/tinytorch/tests/cli/test_login_malformed_progress.py
+++ b/tinytorch/tests/cli/test_login_malformed_progress.py
@@ -1,0 +1,55 @@
+"""
+Malformed .tito/progress.json test for
+LoginCommand._offer_post_login_sync().
+
+Same bug class already found and fixed in tito/commands/milestone.py,
+tito/commands/module/workflow.py, tito/core/submission.py, and
+tito/core/auth.py: json.loads() succeeds on syntactically valid JSON of
+the wrong shape, and .get() on the wrong type raises AttributeError,
+which wasn't one of the exceptions this call site caught.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from tito.commands.login import LoginCommand
+from tito.core.config import CLIConfig
+
+
+def _make_command(tmp_path):
+    config = CLIConfig(
+        project_root=tmp_path,
+        assignments_dir=tmp_path,
+        tinytorch_dir=tmp_path,
+        bin_dir=tmp_path,
+        modules_dir=tmp_path,
+    )
+    return LoginCommand(config)
+
+
+def _write(path: Path, content: str):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+class TestOfferPostLoginSyncMalformedProgress:
+    def test_list_type_progress_json_does_not_crash(self, tmp_path):
+        _write(tmp_path / ".tito" / "progress.json", json.dumps(["01_tensor"]))
+        cmd = _make_command(tmp_path)
+
+        # Must not raise.
+        cmd._offer_post_login_sync()
+
+    def test_string_type_progress_json_does_not_crash(self, tmp_path):
+        _write(tmp_path / ".tito" / "progress.json", json.dumps("corrupted"))
+        cmd = _make_command(tmp_path)
+
+        cmd._offer_post_login_sync()
+
+    def test_missing_progress_json_does_not_crash(self, tmp_path):
+        cmd = _make_command(tmp_path)
+
+        cmd._offer_post_login_sync()

--- a/tinytorch/tito/commands/login.py
+++ b/tinytorch/tito/commands/login.py
@@ -109,9 +109,13 @@ class LoginCommand(BaseCommand):
 
         progress_file = self.config.project_root / ".tito" / "progress.json"
         try:
-            data = json.loads(progress_file.read_text()) if progress_file.exists() else {}
-            completed = data.get("completed_modules", [])
-        except (json.JSONDecodeError, OSError):
+            data = json.loads(progress_file.read_text(encoding="utf-8")) if progress_file.exists() else {}
+            # Valid JSON but not the expected object shape (a bad merge,
+            # partial write) must not be treated as the real data: .get()
+            # on the wrong type raises AttributeError, which isn't one of
+            # the exceptions caught below.
+            completed = data.get("completed_modules", []) if isinstance(data, dict) else []
+        except (json.JSONDecodeError, OSError, UnicodeDecodeError):
             completed = []
 
         if not completed:


### PR DESCRIPTION
Part of #2046.

Same bug class already found and fixed in `tito/commands/milestone.py`, `tito/commands/module/workflow.py`, `tito/core/submission.py`, and `tito/core/auth.py`: `json.loads()` succeeds on syntactically valid JSON of the wrong shape (a bad merge, partial write), and `.get()` on the wrong type raises `AttributeError`, which wasn't one of the exceptions this call site caught (only `JSONDecodeError` and `OSError`). Also added explicit `encoding='utf-8'` to the read, matching every other fix in this series.

Confirmed the crash directly before fixing: a wrong-type `progress.json` crashed `tito login`'s post-login sync offer.

Verified via hand-mutation: reverting the isinstance check reproduces the crash.

Found during a systematic audit of `tito/` for this bug pattern (this is the sixth location it's been found in, all fixed in this initiative: #2049, #2070, #2072, #2073, and this one).
