### PR TITLE
fix(link-check): count broken links from the errors section only

### DIFF
--- a/.github/workflows/infra-link-check.yml
+++ b/.github/workflows/infra-link-check.yml
@@ -163,40 +163,64 @@ jobs:
           fi
 
           # ---- Parse the lychee markdown report for an exact count ----
-          # The action writes a report to ./lychee/out.md by default. Broken
-          # links are listed under "## Errors per input", one per line, as
-          #   * [404] <https://example.com/foo> | Not Found
-          # Two properties of that report drive the parsing below.
+          # The action writes a report to ./lychee/out.md by default. It is a
+          # series of top-level sections, one per outcome:
           #
-          # 1. Scope the scan to the errors section. The report also carries a
-          #    "## Redirects per input" section whose entries have the exact
-          #    same "* [<status>] <url>" shape, so scanning the whole file
-          #    counts every followed redirect as a broken link. Those entries
-          #    are usually [200], and they can even be a status this workflow
-          #    passed --accept for, which means a whole-file scan reports
-          #    links as broken that lychee was explicitly told are fine.
+          #   ## Errors per input      <- a failure
+          #   ## Timeouts per input    <- a failure
+          #   ## Redirects per input   <- NOT a failure, the link resolved
+          #   ## Ignored per input     <- NOT a failure, excluded on purpose
+          #   ## Suggestions per input <- NOT a failure
           #
-          # 2. The bracketed status is not always numeric. A request that
-          #    never produced an HTTP response is reported as [ERROR] or
-          #    [TIMEOUT]: TLS failures, DNS failures, timeouts, and missing
-          #    local files all land there. Matching only digits drops exactly
-          #    the failures that are hardest to diagnose from a URL alone, and
-          #    a site whose failures are all of that kind parses to 0 and then
-          #    gets reported as "?" by the guard below.
+          # and each entry inside them looks like
+          #   * [404] <https://example.com/foo> (at 12:3) | Not Found
+          # where the "(at line:col)" span is present whenever lychee knows the
+          # source position. Four properties of that shape drive the parsing.
           #
-          # Lychee wraps each URL as a markdown autolink (<https://...>), so
-          # strip the delimiters to emit a bare URL that renders as a link.
+          # 1. Collect from Errors AND Timeouts, and only those. They are
+          #    siblings, not nested, so bounding the scan at the first "## "
+          #    after Errors silently drops every timeout, which is the same
+          #    under-count this step exists to fix.
+          #
+          # 2. Do not scan the whole file. Redirect entries have the identical
+          #    "* [<status>] <url>" shape, so a whole-file scan counts every
+          #    followed redirect as broken. Those are usually [200], and can
+          #    even be a status this workflow passed --accept for, which means
+          #    reporting links as broken that lychee was told are fine.
+          #
+          # 3. The bracketed status is not always numeric. A request that never
+          #    produced an HTTP response is reported as [ERROR] or [TIMEOUT]:
+          #    TLS failures, DNS failures, timeouts, and missing local files all
+          #    land there. Matching only digits drops exactly the failures that
+          #    are hardest to diagnose from a URL alone, and a site whose
+          #    failures are all of that kind parses to 0 and then gets reported
+          #    as "?" by the guard below.
+          #
+          # 4. The URL is not always last on the line. Strip the "(at line:col)"
+          #    span before the markdown autolink delimiters (<https://...>), or
+          #    the emitted URL keeps a trailing "> (at 12:3)" and every entry in
+          #    the triage list is corrupt.
           REPORT="./lychee/out.md"
           BROKEN_COUNT=0
           BROKEN_SAMPLE=""
           if [ -f "$REPORT" ]; then
             BROKEN_URLS=$(awk '
-              /^##[[:space:]]+Errors per input[[:space:]]*$/ { in_errors = 1; next }
-              /^##[[:space:]]/                               { in_errors = 0 }
-              in_errors && /^[[:space:]]*\*[[:space:]]+\[[^]]+\][[:space:]]+/ {
+              # Collect from every section that means "this link failed".
+              # lychee writes each as its own top-level section, so Timeouts is
+              # a SIBLING of Errors, not nested inside it. Stopping at the first
+              # "## " after Errors therefore dropped every timeout, which is the
+              # same silent under-count this step exists to fix. Redirects,
+              # Ignored and Suggestions are siblings too, and are not failures.
+              /^##[[:space:]]+(Errors|Timeouts)[[:space:]]+per input[[:space:]]*$/ { collect = 1; next }
+              /^##[[:space:]]/                                                     { collect = 0 }
+              collect && /^[[:space:]]*\*[[:space:]]+\[[^]]+\][[:space:]]+/ {
                   url = $0
                   sub(/^[[:space:]]*\*[[:space:]]+\[[^]]+\][[:space:]]+/, "", url)
                   sub(/[[:space:]]*\|.*$/, "", url)
+                  # lychee appends the source position as "(at line:col)" whenever
+                  # the link carries a span, so the URL is not always last on the
+                  # line and a bare trailing ">" strip leaves "url> (at 1:1)".
+                  sub(/[[:space:]]*\(at[[:space:]][^)]*\)[[:space:]]*$/, "", url)
                   sub(/[[:space:]]+$/, "", url)
                   sub(/^</, "", url)
                   sub(/>$/, "", url)

--- a/.github/workflows/infra-link-check.yml
+++ b/.github/workflows/infra-link-check.yml
@@ -163,24 +163,50 @@ jobs:
           fi
 
           # ---- Parse the lychee markdown report for an exact count ----
-          # The action writes a report to ./lychee/out.md by default. The
-          # "Errors per input" section lists each broken URL on its own line
-          # like:  * [ERROR] https://example.com/foo (404 Not Found)
-          # We count those for an honest broken_count, and grab the first
-          # 10 URLs as a triage sample for the issue body.
+          # The action writes a report to ./lychee/out.md by default. Broken
+          # links are listed under "## Errors per input", one per line, as
+          #   * [404] <https://example.com/foo> | Not Found
+          # Two properties of that report drive the parsing below.
+          #
+          # 1. Scope the scan to the errors section. The report also carries a
+          #    "## Redirects per input" section whose entries have the exact
+          #    same "* [<status>] <url>" shape, so scanning the whole file
+          #    counts every followed redirect as a broken link. Those entries
+          #    are usually [200], and they can even be a status this workflow
+          #    passed --accept for, which means a whole-file scan reports
+          #    links as broken that lychee was explicitly told are fine.
+          #
+          # 2. The bracketed status is not always numeric. A request that
+          #    never produced an HTTP response is reported as [ERROR] or
+          #    [TIMEOUT]: TLS failures, DNS failures, timeouts, and missing
+          #    local files all land there. Matching only digits drops exactly
+          #    the failures that are hardest to diagnose from a URL alone, and
+          #    a site whose failures are all of that kind parses to 0 and then
+          #    gets reported as "?" by the guard below.
+          #
+          # Lychee wraps each URL as a markdown autolink (<https://...>), so
+          # strip the delimiters to emit a bare URL that renders as a link.
           REPORT="./lychee/out.md"
           BROKEN_COUNT=0
           BROKEN_SAMPLE=""
           if [ -f "$REPORT" ]; then
-            # Lines starting with "* [" are per-link error entries in
-            # lychee's markdown output. Be tolerant of leading whitespace.
-            BROKEN_COUNT=$(grep -cE '^[[:space:]]*\*[[:space:]]+\[[[:digit:]]+\]' "$REPORT" || true)
-            # Pull the URL (second whitespace-separated field after the
-            # status code bracket) for the first 10 entries.
-            BROKEN_SAMPLE=$(grep -hE '^[[:space:]]*\*[[:space:]]+\[[[:digit:]]+\]' "$REPORT" \
-              | head -n 10 \
-              | sed -E 's/^[[:space:]]*\*[[:space:]]+\[[[:digit:]]+\][[:space:]]+([^[:space:]]+).*/\1/' \
-              || true)
+            BROKEN_URLS=$(awk '
+              /^##[[:space:]]+Errors per input[[:space:]]*$/ { in_errors = 1; next }
+              /^##[[:space:]]/                               { in_errors = 0 }
+              in_errors && /^[[:space:]]*\*[[:space:]]+\[[^]]+\][[:space:]]+/ {
+                  url = $0
+                  sub(/^[[:space:]]*\*[[:space:]]+\[[^]]+\][[:space:]]+/, "", url)
+                  sub(/[[:space:]]*\|.*$/, "", url)
+                  sub(/[[:space:]]+$/, "", url)
+                  sub(/^</, "", url)
+                  sub(/>$/, "", url)
+                  if (url != "") print url
+              }
+            ' "$REPORT" || true)
+            if [ -n "$BROKEN_URLS" ]; then
+              BROKEN_COUNT=$(printf '%s\n' "$BROKEN_URLS" | grep -c . || true)
+              BROKEN_SAMPLE=$(printf '%s\n' "$BROKEN_URLS" | head -n 10)
+            fi
           fi
 
           # If lychee said failure but we couldn't parse a count (e.g. report


### PR DESCRIPTION
## Summary

The nightly link-rot summary counts broken links by scanning the whole lychee report for lines shaped `* [<status>] <url>`. That matches the wrong set in both directions, so the counts in #1810 are wrong on five of the nine sites. This scopes the scan to the report's "Errors per input" section and accepts non-numeric statuses.

## Area

- [ ] Book (textbook content, figures, exercises)
- [ ] TinyTorch (modules, tests, milestones)
- [ ] StaffML (interview questions, challenges)
- [ ] Kits (hardware labs)
- [x] Infrastructure (CI/CD, scripts, config)

## Changes

Measured against last night's sweep, [run 31995703306](https://github.com/harvard-edge/cs249r_book/actions/runs/31995703306):

| Site | lychee errors + timeouts | tracker reported | after |
|---|---:|---:|---:|
| Book | 2 | `?` | 2 |
| Labs | 0 | 0 | 0 |
| Kits | 0 | 1 | 0 |
| MLSys·im | 0 | `?` | 0 |
| Slides | 2 | `?` | 2 |
| Instructors | 35 | 36 | 35 |
| TinyTorch | 1 | 27 | 1 |
| Unified Site | 1 | 3 | 1 |
| StaffML | 0 | 0 | 0 |

Two separate causes, same line of code.

**Over-counting.** The report also carries a `## Redirects per input` section whose entries have the identical `* [<status>] <url>` shape, so every followed redirect was counted as broken. TinyTorch is the clearest case: lychee found 1 error, the tracker said 27, and 26 of those were redirect entries like

```
* [200] <https://www.nature.com/articles/323533a0> | Redirect: Followed 3 redirects resolving to the final status of: OK.
```

Four of them were `[403]`, which is a status this workflow already passes `--accept 200,403` for. Links lychee was explicitly told to accept were still being reported broken.

**Under-counting.** The status is not always numeric. A request that never produced an HTTP response is reported as `[ERROR]` or `[TIMEOUT]`, covering TLS failures, DNS failures, timeouts and missing local files. `[[:digit:]]+` cannot match those, so they were dropped from both the count and the triage sample. When every failure on a site was that kind, the count parsed to 0 and the "broken but unknown" guard rewrote it to `?`. That is why Book, MLSys·im and Slides show `?` in #1810 with no URL list, and it means the two failures that are hardest to diagnose from a URL alone were the ones being hidden:

```
* [ERROR]   <https://web.eng.fiu.edu/.../563900a043.pdf> | SSL certificate not trusted
* [ERROR]   <file:///.../slides/tinyml/chapter-3-applications-of-tinyml> | Cannot find file
* [TIMEOUT] <https://larissasuzuki.com/> | Timeout
```

The fix replaces the two whole-file greps with one awk pass scoped to the errors section, matching any bracketed status. It also strips lychee's markdown autolink delimiters, so the tracker lists `https://example.com` rather than `<https://example.com>` as it does today.

The step's contract is unchanged: same three outputs, same `?` fallback when the report is missing, same behaviour under `fail_on_broken`.

## Testing

- [ ] Rendered the book locally (`quarto render`)
- [ ] Ran tests (`pytest tests/`)
- [ ] Ran `tito module test NN` for affected module(s)
- [x] Manual verification (describe below)

Pulled the archived lychee report out of the job logs for all nine sweeps in run 31995703306 and replayed both the old and new parser over them. The new count equals lychee's own `Errors` + `Timeouts` tally on all nine; the old one matched on four. Timeouts are counted because lychee tallies them separately in the summary table but lists them in the same "Errors per input" section, and a timeout is a link worth triaging.

Nothing outside this repo is needed to reproduce it: the reports are in the logs of that run.

## Related Issues

Related to #1810 (the counts and the missing URL lists in that tracker come from this step).
