### PR TITLE
Fix dead-code loss forward() implementations shadowed by monkeypatch

### DIFF
--- a/tinytorch/src/06_autograd/06_autograd.py
+++ b/tinytorch/src/06_autograd/06_autograd.py
@@ -2904,15 +2904,8 @@ def enable_autograd(quiet=False):
 
         def tracked_bce_forward(self, predictions, targets):
             """Binary cross-entropy with gradient tracking."""
-            # Compute BCE loss
-            eps = EPSILON
-            clamped_preds = np.clip(predictions.data, eps, 1 - eps)
-            log_preds = np.log(clamped_preds)
-            log_one_minus_preds = np.log(1 - clamped_preds)
-            bce_per_sample = -(targets.data * log_preds + (1 - targets.data) * log_one_minus_preds)
-            bce_loss = np.mean(bce_per_sample)
-
-            result = Tensor(bce_loss)
+            # Call original forward to get result using the module's own implementation
+            result = _original_bce_forward(self, predictions, targets)
 
             if _GRAD_TRACKING_ENABLED and predictions.requires_grad:
                 result.requires_grad = True
@@ -2922,12 +2915,8 @@ def enable_autograd(quiet=False):
 
         def tracked_mse_forward(self, predictions, targets):
             """MSE loss with gradient tracking."""
-            # Compute MSE loss
-            diff = predictions.data - targets.data
-            squared_diff = diff ** 2
-            mse = np.mean(squared_diff)
-
-            result = Tensor(mse)
+            # Call original forward to get result using the module's own implementation
+            result = _original_mse_forward(self, predictions, targets)
 
             if _GRAD_TRACKING_ENABLED and predictions.requires_grad:
                 result.requires_grad = True
@@ -2937,20 +2926,8 @@ def enable_autograd(quiet=False):
 
         def tracked_ce_forward(self, logits, targets):
             """Cross-entropy loss with gradient tracking."""
-            from tinytorch.core.losses import log_softmax
-
-            # Compute log-softmax for numerical stability
-            log_probs = log_softmax(logits, dim=-1)
-
-            # Select log-probabilities for correct classes
-            batch_size = logits.shape[0]
-            target_indices = targets.data.astype(int)
-            selected_log_probs = log_probs.data[np.arange(batch_size), target_indices]
-
-            # Return negative mean
-            ce_loss = -np.mean(selected_log_probs)
-
-            result = Tensor(ce_loss)
+            # Call original forward to get result using the module's own implementation
+            result = _original_ce_forward(self, logits, targets)
 
             if _GRAD_TRACKING_ENABLED and logits.requires_grad:
                 result.requires_grad = True


### PR DESCRIPTION
## What

`MSELoss.forward`, `CrossEntropyLoss.forward`, and `BinaryCrossEntropyLoss.forward` are monkeypatched by `enable_autograd()` on package import (which always runs, since `tinytorch/__init__.py` calls it unconditionally). The three replacements (`tracked_mse_forward`, `tracked_ce_forward`, `tracked_bce_forward`) each reimplemented the loss math inline from scratch, rather than calling the original module's `forward`, even though `_original_mse_forward` / `_original_ce_forward` / `_original_bce_forward` were already captured right above them and never used.

This made the three loss `forward()` implementations in `04_losses.py` permanently dead code once autograd loaded (always, in practice). Any future fix or numerical-stability change made there would silently never ship.

## Why this matters

This is the same architecture bug class as #2051 (`__radd__`/`__rsub__`/`__rmul__`) and the same failure mode that made `Sigmoid.forward` diverge from its tracked replacement in a real, previously-shipped bug. It was found while triaging mutation-testing survivors for `04_losses`: several survivors in the loss `forward()` bodies were unkillable because the mutated code was unreachable, not because it was well-tested.

Verified by hand-mutation: flipping `diff = predictions.data - targets.data` to `+` in `04_losses.py` had **zero effect on any test** before this fix (confirmed via `inspect.getsource(MSELoss.forward)` showing the live code was actually `tracked_mse_forward`'s independent reimplementation). After this fix, the same mutation is correctly caught by `tests/04_losses/test_losses_core.py::TestMSELoss::test_mse_computation`.

Confirmed the three original implementations were not currently numerically divergent from their tracked replacements (unlike Sigmoid's case), so this is a dead-code/fragility fix rather than a behavior-changing bugfix. `CrossEntropyLoss`/`BinaryCrossEntropyLoss` cross-checked the same way.

## Fix

Made all three delegate to the already-captured originals, matching the pattern already used correctly by `tracked_softmax_forward` and `tracked_gelu_forward` in the same function.

## Testing

- `tests/04_losses`, `tests/06_autograd`: all passing
- Full local suite (excluding `tests/cli`/`tests/e2e`/`tests/environment`/`tests/milestones/test_milestones_run.py`, which fail identically on a clean checkout due to pre-existing Windows-only issues): 762 passed, 35 skipped, 0 new failures (one integration test flaked in the full run due to pre-existing test-order state pollution unrelated to this change; confirmed by rerunning `tests/integration` alone: 178 passed, 0 failed)
- Hand-mutation verification on the MSE diff-sign computation: correctly unreachable before this fix, correctly caught after
