### PR TITLE
Fix Windows cp1252 crashes in subprocess-based tests

### DIFF
--- a/tinytorch/tests/cli/test_cli_execution.py
+++ b/tinytorch/tests/cli/test_cli_execution.py
@@ -32,7 +32,7 @@ class TestCommandExecution:
             [sys.executable, '-m', 'tito.main'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         # Should exit successfully
@@ -48,7 +48,7 @@ class TestCommandExecution:
             [sys.executable, '-m', 'tito.main', '-h'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         assert result.returncode == 0
@@ -62,7 +62,7 @@ class TestCommandExecution:
             [sys.executable, '-m', 'tito.main', '--version'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         assert result.returncode == 0
@@ -78,7 +78,7 @@ class TestCommandExecution:
             [sys.executable, '-m', 'tito.main', command, '-h'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         # Help should always succeed
@@ -106,7 +106,7 @@ class TestCommandExecution:
             [sys.executable, '-m', 'tito.main', command, subcommand, '-h'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         # Subcommand help should work
@@ -130,7 +130,7 @@ class TestCommandGrouping:
             [sys.executable, '-m', 'tito.main'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         # Key student commands should be visible
@@ -147,7 +147,7 @@ class TestCommandGrouping:
             [sys.executable, '-m', 'tito.main', '-h'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         # Developer commands should be in help
@@ -172,7 +172,7 @@ class TestErrorMessages:
             [sys.executable, '-m', 'tito.main', 'nonexistent'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         # Should fail
@@ -189,7 +189,7 @@ class TestErrorMessages:
             [sys.executable, '-m', 'tito.main', 'module'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         # Should show help or error

--- a/tinytorch/tests/cli/test_cli_help_consistency.py
+++ b/tinytorch/tests/cli/test_cli_help_consistency.py
@@ -32,7 +32,7 @@ class TestHelpConsistency:
             [sys.executable, '-m', 'tito.main'] + list(args) + ['-h'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
         return result.stdout + result.stderr
 
@@ -53,7 +53,7 @@ class TestHelpConsistency:
             [sys.executable, '-m', 'tito.main'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         # Get help output
@@ -61,7 +61,7 @@ class TestHelpConsistency:
             [sys.executable, '-m', 'tito.main', '-h'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         bare_output = bare_result.stdout
@@ -133,7 +133,7 @@ class TestWelcomeScreen:
             [sys.executable, '-m', 'tito.main'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         output = result.stdout
@@ -146,7 +146,7 @@ class TestWelcomeScreen:
             [sys.executable, '-m', 'tito.main'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         output = result.stdout
@@ -159,7 +159,7 @@ class TestWelcomeScreen:
             [sys.executable, '-m', 'tito.main'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         output = result.stdout
@@ -184,7 +184,7 @@ class TestCommandDocumentation:
             [sys.executable, '-m', 'tito.main'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         # Get help
@@ -192,7 +192,7 @@ class TestCommandDocumentation:
             [sys.executable, '-m', 'tito.main', '-h'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         combined = welcome_result.stdout + help_result.stdout
@@ -214,14 +214,14 @@ class TestCommandDocumentation:
             [sys.executable, '-m', 'tito.main'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         help_result = subprocess.run(
             [sys.executable, '-m', 'tito.main', '-h'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         combined = welcome_result.stdout + help_result.stdout
@@ -234,7 +234,7 @@ class TestCommandDocumentation:
             [sys.executable, '-m', 'tito.main', 'milestone', '-h'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         assert 'progress' in milestone_help.stdout.lower() or \

--- a/tinytorch/tests/cli/test_live_submission.py
+++ b/tinytorch/tests/cli/test_live_submission.py
@@ -31,7 +31,7 @@ from tito.core import auth
 def load_local_env():
     env_path = Path(__file__).parent.parent.parent / "local.env"
     if env_path.exists():
-        for line in env_path.read_text().splitlines():
+        for line in env_path.read_text(encoding='utf-8').splitlines():
             line = line.strip()
             if not line or line.startswith('#') or '=' not in line:
                 continue
@@ -49,7 +49,7 @@ def get_supabase_keys():
     if not config_js.exists():
         return None, None
     
-    content = config_js.read_text()
+    content = config_js.read_text(encoding='utf-8')
     import re
     url_match = re.search(r'SUPABASE_PROJECT_URL\s*=\s*["\']([^"\']+)["\']', content)
     key_match = re.search(r'SUPABASE_ANON_KEY\s*=\s*["\']([^"\']+)["\']', content)

--- a/tinytorch/tests/cli/test_release_regressions.py
+++ b/tinytorch/tests/cli/test_release_regressions.py
@@ -162,7 +162,7 @@ def test_milestone_list_uses_actual_history_start_year():
         [sys.executable, "-m", "tito.main", "milestone", "list", "--simple"],
         cwd=TINYTORCH_ROOT,
         capture_output=True,
-        text=True,
+        text=True, encoding='utf-8', errors='replace',
         env=env,
     )
 

--- a/tinytorch/tests/e2e/test_user_journey.py
+++ b/tinytorch/tests/e2e/test_user_journey.py
@@ -39,7 +39,7 @@ def run_tito(args: list, cwd: Optional[Path] = None, timeout: int = 60) -> Tuple
         cmd,
         cwd=cwd or PROJECT_ROOT,
         capture_output=True,
-        text=True,
+        text=True, encoding='utf-8', errors='replace',
         timeout=timeout,
         env=env
     )
@@ -52,7 +52,7 @@ def run_python_script(script_path: Path, timeout: int = 120) -> Tuple[int, str, 
         [sys.executable, str(script_path)],
         cwd=PROJECT_ROOT,
         capture_output=True,
-        text=True,
+        text=True, encoding='utf-8', errors='replace',
         timeout=timeout
     )
     return result.returncode, result.stdout, result.stderr
@@ -145,14 +145,14 @@ class TestQuickVerification:
             [sys.executable, "-c", "import tinytorch; print('OK')"],
             cwd=PROJECT_ROOT,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         ).returncode, "", ""
 
         result = subprocess.run(
             [sys.executable, "-c", "import tinytorch; print('OK')"],
             cwd=PROJECT_ROOT,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
         assert result.returncode == 0, f"Cannot import tinytorch: {result.stderr}"
         assert "OK" in result.stdout
@@ -234,7 +234,7 @@ class TestModuleFlow:
 
         # Check progress file still exists and has data
         assert progress_file.exists()
-        data = json.loads(progress_file.read_text())
+        data = json.loads(progress_file.read_text(encoding='utf-8'))
         assert "started_modules" in data
 
     @pytest.mark.module_flow
@@ -333,7 +333,7 @@ class TestFullJourney:
             [sys.executable, "-c", "from tinytorch import Tensor; print('OK')"],
             cwd=PROJECT_ROOT,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
         # This tests that the package structure is correct
         # If Tensor is not exported, that's a test failure
@@ -357,7 +357,7 @@ print('OK')
 """],
             cwd=PROJECT_ROOT,
             capture_output=True,
-            text=True,
+            text=True, encoding='utf-8', errors='replace',
             timeout=10
         )
         assert result.returncode == 0, (

--- a/tinytorch/tests/environment/test_all_requirements.py
+++ b/tinytorch/tests/environment/test_all_requirements.py
@@ -36,7 +36,7 @@ def parse_requirements_file(filepath: Path) -> List[Tuple[str, Optional[str], Op
     if not filepath.exists():
         return packages
 
-    with open(filepath, 'r') as f:
+    with open(filepath, 'r', encoding='utf-8') as f:
         for line in f:
             line = line.strip()
 
@@ -164,7 +164,7 @@ def check_package_functionality(package_name: str, import_name: str) -> Tuple[bo
             result = subprocess.run(
                 [sys.executable, "-m", "pytest", "--version"],
                 capture_output=True,
-                text=True
+                text=True, encoding='utf-8', errors='replace'
             )
             return result.returncode == 0, "Command available"
 
@@ -172,7 +172,7 @@ def check_package_functionality(package_name: str, import_name: str) -> Tuple[bo
             result = subprocess.run(
                 ["jupyter", "lab", "--version"],
                 capture_output=True,
-                text=True
+                text=True, encoding='utf-8', errors='replace'
             )
             return result.returncode == 0, "Command available"
 
@@ -282,7 +282,7 @@ class TestRequirementsFileValidity:
         """Requirements file must be readable."""
         assert req_file.exists(), f"Requirements file not found: {req_file}"
 
-        content = req_file.read_text()
+        content = req_file.read_text(encoding='utf-8')
         assert len(content) > 0, f"Requirements file is empty: {req_file}"
 
         print(f"✅ Requirements file readable: {req_file}")
@@ -293,7 +293,7 @@ class TestRequirementsFileValidity:
         packages = parse_requirements_file(req_file)
 
         # Should have at least one package (unless it's all comments)
-        lines = req_file.read_text().splitlines()
+        lines = req_file.read_text(encoding='utf-8').splitlines()
         non_comment_lines = [l for l in lines if l.strip() and not l.strip().startswith('#')]
 
         if non_comment_lines:

--- a/tinytorch/tests/environment/test_setup_validation.py
+++ b/tinytorch/tests/environment/test_setup_validation.py
@@ -49,7 +49,7 @@ class TestPythonEnvironment:
         result = subprocess.run(
             [sys.executable, "-m", "pip", "--version"],
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
         assert result.returncode == 0, "pip not available"
         print(f"✅ pip available: {result.stdout.strip()}")
@@ -118,7 +118,7 @@ class TestCoreDependencies:
         result = subprocess.run(
             [sys.executable, "-m", "pytest", "--version"],
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
         assert result.returncode == 0, "pytest not available"
         print(f"✅ pytest available: {result.stdout.strip()}")
@@ -171,7 +171,7 @@ class TestJupyterEnvironment:
         result = subprocess.run(
             ["jupyter", "--version"],
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
         assert result.returncode == 0, "jupyter command not found"
         print(f"✅ jupyter command available:\n{result.stdout.strip()}")
@@ -181,7 +181,7 @@ class TestJupyterEnvironment:
         result = subprocess.run(
             ["jupyter", "lab", "--version"],
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
         assert result.returncode == 0, "jupyter lab command not found"
         print(f"✅ jupyter lab command available: {result.stdout.strip()}")
@@ -191,7 +191,7 @@ class TestJupyterEnvironment:
         result = subprocess.run(
             ["jupyter", "kernelspec", "list"],
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
         assert result.returncode == 0, "Cannot list Jupyter kernels"
         assert "python3" in result.stdout, "Python3 kernel not found"
@@ -328,7 +328,7 @@ class TestSystemResources:
                 result = subprocess.run(
                     ["sysctl", "-n", "machdep.cpu.brand_string"],
                     capture_output=True,
-                    text=True
+                    text=True, encoding='utf-8', errors='replace'
                 )
                 if "Apple" in result.stdout:
                     print("⚠️  Running x86_64 Python on Apple Silicon (Rosetta)")
@@ -345,7 +345,7 @@ class TestGitConfiguration:
         result = subprocess.run(
             ["git", "--version"],
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
         assert result.returncode == 0, "git command not found"
         print(f"✅ Git available: {result.stdout.strip()}")
@@ -355,12 +355,12 @@ class TestGitConfiguration:
         name_result = subprocess.run(
             ["git", "config", "user.name"],
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
         email_result = subprocess.run(
             ["git", "config", "user.email"],
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         if name_result.returncode != 0 or email_result.returncode != 0:
@@ -391,7 +391,7 @@ class TestStudentProtection:
         if module_dirs:
             test_file = list(module_dirs[0].glob("*.py"))
             if test_file:
-                content = test_file[0].read_text()
+                content = test_file[0].read_text(encoding='utf-8')
                 assert len(content) > 0, "Cannot read source files"
                 print(f"✅ Source files readable: {test_file[0]}")
 

--- a/tinytorch/tests/integration/test_gradients.py
+++ b/tinytorch/tests/integration/test_gradients.py
@@ -505,7 +505,7 @@ def test_gradient_clipping():
 if __name__ == "__main__":
     # When run directly, use pytest
     import subprocess
-    result = subprocess.run(["pytest", __file__, "-v"], capture_output=True, text=True)
+    result = subprocess.run(["pytest", __file__, "-v"], capture_output=True, text=True, encoding='utf-8', errors='replace')
     print(result.stdout)
     if result.stderr:
         print(result.stderr)

--- a/tinytorch/tests/integration/test_module_05_dense.py
+++ b/tinytorch/tests/integration/test_module_05_dense.py
@@ -169,7 +169,7 @@ if __name__ == "__main__":
     result = subprocess.run(
         [sys.executable, '-m', 'pytest', __file__, '-v', '--tb=short'],
         capture_output=True,
-        text=True
+        text=True, encoding='utf-8', errors='replace'
     )
 
     print(result.stdout)

--- a/tinytorch/tests/integration/test_shapes.py
+++ b/tinytorch/tests/integration/test_shapes.py
@@ -445,7 +445,7 @@ def test_cifar10_cnn_dimensions():
 if __name__ == "__main__":
     # When run directly, use pytest
     import subprocess
-    result = subprocess.run(["pytest", __file__, "-v"], capture_output=True, text=True)
+    result = subprocess.run(["pytest", __file__, "-v"], capture_output=True, text=True, encoding='utf-8', errors='replace')
     print(result.stdout)
     if result.stderr:
         print(result.stderr)

--- a/tinytorch/tests/milestones/milestone_tracker.py
+++ b/tinytorch/tests/milestones/milestone_tracker.py
@@ -66,9 +66,9 @@ class MilestoneTracker:
     def _load_progress(self) -> Dict:
         if self.progress_file.exists():
             try:
-                with open(self.progress_file, "r") as f:
+                with open(self.progress_file, "r", encoding="utf-8") as f:
                     progress = json.load(f)
-            except (json.JSONDecodeError, OSError):
+            except (json.JSONDecodeError, OSError, UnicodeDecodeError):
                 progress = {}
         else:
             progress = {}
@@ -81,16 +81,16 @@ class MilestoneTracker:
         return progress
 
     def _save_progress(self) -> None:
-        with open(self.progress_file, "w") as f:
+        with open(self.progress_file, "w", encoding="utf-8") as f:
             json.dump(self.progress, f, indent=2)
 
     def _load_completed_modules(self) -> List[str]:
         if not self.module_progress_file.exists():
             return []
         try:
-            with open(self.module_progress_file, "r") as f:
+            with open(self.module_progress_file, "r", encoding="utf-8") as f:
                 progress = json.load(f)
-        except (json.JSONDecodeError, OSError):
+        except (json.JSONDecodeError, OSError, UnicodeDecodeError):
             return []
 
         completed = []
@@ -104,12 +104,12 @@ class MilestoneTracker:
         progress = {}
         if self.module_progress_file.exists():
             try:
-                with open(self.module_progress_file, "r") as f:
+                with open(self.module_progress_file, "r", encoding="utf-8") as f:
                     progress = json.load(f)
-            except (json.JSONDecodeError, OSError):
+            except (json.JSONDecodeError, OSError, UnicodeDecodeError):
                 progress = {}
         progress["completed_modules"] = sorted(set(completed_modules))
-        with open(self.module_progress_file, "w") as f:
+        with open(self.module_progress_file, "w", encoding="utf-8") as f:
             json.dump(progress, f, indent=2)
 
     def mark_module_complete(self, module_name: str) -> List[str]:

--- a/tinytorch/tests/milestones/test_milestones_run.py
+++ b/tinytorch/tests/milestones/test_milestones_run.py
@@ -59,7 +59,7 @@ def run_milestone(milestone_id: str, part: int = None, timeout: int = 300) -> tu
         cmd,
         cwd=TINYTORCH_ROOT,
         capture_output=True,
-        text=True,
+        text=True, encoding='utf-8', errors='replace',
         timeout=timeout,
         env=env,
         input="n\nn\nn\n"  # Answer 'n' to any prompts


### PR DESCRIPTION
## What

`subprocess.run(..., text=True)` without an explicit `encoding=` decodes the child process's stdout/stderr using `locale.getpreferredencoding()`, which is cp1252 on Windows. `tito`'s own CLI output (via `rich`) contains characters that aren't valid cp1252, so the internal stdout reader thread crashed with an unhandled `UnicodeDecodeError`:

```
File "...\Lib\subprocess.py", line 1614, in _readerthread
  buffer.append(fh.read())
File "...\Lib\encodings\cp1252.py", line 23, in decode
  return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 607: character maps to <undefined>
```

leaving `result.stdout` as `None`, which then crashed one line later in whatever test tried to search it (`TypeError: argument of type 'NoneType' is not a container or iterable`). Several `Path.read_text()` / `open()` calls in the same test files had the identical default-encoding gap.

## Why this matters

This was previously worked around by excluding `tests/cli`, `tests/e2e`, `tests/environment`, and `tests/milestones/test_milestones_run.py` from "full suite" runs on Windows, treating the failures as environmental noise. They aren't: they're entirely caused by a missing `encoding=` argument, not by anything wrong with the commands or files under test, and are fixable with no behavior change on Linux/Mac (where the default encoding is already UTF-8, so this is a no-op there).

## Fix

Added `encoding='utf-8', errors='replace'` to all 42 `subprocess.run(..., text=True)` call sites across `tests/cli`, `tests/environment`, `tests/e2e`, `tests/integration`, and `tests/milestones`, and `encoding='utf-8'` to the handful of `read_text()`/`open()` calls in the same files. Also extended `tests/milestones/milestone_tracker.py`'s `except` clauses to catch `UnicodeDecodeError`, matching the same fix pattern already applied across `tito/` earlier this session (#2049, #2070-2075).

## Testing

- `tests/cli`: 92 passed, 1 skipped (was 13 failed, 79 passed, 1 skipped)
- `tests/environment`: 58 passed, 1 failed (was multiple cp1252-related failures). The one remaining failure (`test_pip_available`) is unrelated: this dev venv genuinely has no `pip` module installed (created via `uv`), not an encoding issue, so left as-is.
