### PR TITLE
Fix Windows cp1252 encoding crashes across all tito file I/O (tests + source)

### DIFF
--- a/tinytorch/tests/cli/test_cli_execution.py
+++ b/tinytorch/tests/cli/test_cli_execution.py
@@ -32,7 +32,7 @@ class TestCommandExecution:
             [sys.executable, '-m', 'tito.main'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         # Should exit successfully
@@ -48,7 +48,7 @@ class TestCommandExecution:
             [sys.executable, '-m', 'tito.main', '-h'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         assert result.returncode == 0
@@ -62,7 +62,7 @@ class TestCommandExecution:
             [sys.executable, '-m', 'tito.main', '--version'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         assert result.returncode == 0
@@ -78,7 +78,7 @@ class TestCommandExecution:
             [sys.executable, '-m', 'tito.main', command, '-h'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         # Help should always succeed
@@ -106,7 +106,7 @@ class TestCommandExecution:
             [sys.executable, '-m', 'tito.main', command, subcommand, '-h'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         # Subcommand help should work
@@ -130,7 +130,7 @@ class TestCommandGrouping:
             [sys.executable, '-m', 'tito.main'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         # Key student commands should be visible
@@ -147,7 +147,7 @@ class TestCommandGrouping:
             [sys.executable, '-m', 'tito.main', '-h'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         # Developer commands should be in help
@@ -172,7 +172,7 @@ class TestErrorMessages:
             [sys.executable, '-m', 'tito.main', 'nonexistent'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         # Should fail
@@ -189,7 +189,7 @@ class TestErrorMessages:
             [sys.executable, '-m', 'tito.main', 'module'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         # Should show help or error

--- a/tinytorch/tests/cli/test_cli_help_consistency.py
+++ b/tinytorch/tests/cli/test_cli_help_consistency.py
@@ -32,7 +32,7 @@ class TestHelpConsistency:
             [sys.executable, '-m', 'tito.main'] + list(args) + ['-h'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
         return result.stdout + result.stderr
 
@@ -53,7 +53,7 @@ class TestHelpConsistency:
             [sys.executable, '-m', 'tito.main'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         # Get help output
@@ -61,7 +61,7 @@ class TestHelpConsistency:
             [sys.executable, '-m', 'tito.main', '-h'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         bare_output = bare_result.stdout
@@ -133,7 +133,7 @@ class TestWelcomeScreen:
             [sys.executable, '-m', 'tito.main'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         output = result.stdout
@@ -146,7 +146,7 @@ class TestWelcomeScreen:
             [sys.executable, '-m', 'tito.main'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         output = result.stdout
@@ -159,7 +159,7 @@ class TestWelcomeScreen:
             [sys.executable, '-m', 'tito.main'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         output = result.stdout
@@ -184,7 +184,7 @@ class TestCommandDocumentation:
             [sys.executable, '-m', 'tito.main'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         # Get help
@@ -192,7 +192,7 @@ class TestCommandDocumentation:
             [sys.executable, '-m', 'tito.main', '-h'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         combined = welcome_result.stdout + help_result.stdout
@@ -214,14 +214,14 @@ class TestCommandDocumentation:
             [sys.executable, '-m', 'tito.main'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         help_result = subprocess.run(
             [sys.executable, '-m', 'tito.main', '-h'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         combined = welcome_result.stdout + help_result.stdout
@@ -234,7 +234,7 @@ class TestCommandDocumentation:
             [sys.executable, '-m', 'tito.main', 'milestone', '-h'],
             cwd=self.project_root,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         assert 'progress' in milestone_help.stdout.lower() or \

--- a/tinytorch/tests/cli/test_live_submission.py
+++ b/tinytorch/tests/cli/test_live_submission.py
@@ -31,7 +31,7 @@ from tito.core import auth
 def load_local_env():
     env_path = Path(__file__).parent.parent.parent / "local.env"
     if env_path.exists():
-        for line in env_path.read_text().splitlines():
+        for line in env_path.read_text(encoding='utf-8').splitlines():
             line = line.strip()
             if not line or line.startswith('#') or '=' not in line:
                 continue
@@ -49,7 +49,7 @@ def get_supabase_keys():
     if not config_js.exists():
         return None, None
     
-    content = config_js.read_text()
+    content = config_js.read_text(encoding='utf-8')
     import re
     url_match = re.search(r'SUPABASE_PROJECT_URL\s*=\s*["\']([^"\']+)["\']', content)
     key_match = re.search(r'SUPABASE_ANON_KEY\s*=\s*["\']([^"\']+)["\']', content)

--- a/tinytorch/tests/cli/test_release_regressions.py
+++ b/tinytorch/tests/cli/test_release_regressions.py
@@ -162,7 +162,7 @@ def test_milestone_list_uses_actual_history_start_year():
         [sys.executable, "-m", "tito.main", "milestone", "list", "--simple"],
         cwd=TINYTORCH_ROOT,
         capture_output=True,
-        text=True,
+        text=True, encoding='utf-8', errors='replace',
         env=env,
     )
 

--- a/tinytorch/tests/e2e/test_user_journey.py
+++ b/tinytorch/tests/e2e/test_user_journey.py
@@ -39,7 +39,7 @@ def run_tito(args: list, cwd: Optional[Path] = None, timeout: int = 60) -> Tuple
         cmd,
         cwd=cwd or PROJECT_ROOT,
         capture_output=True,
-        text=True,
+        text=True, encoding='utf-8', errors='replace',
         timeout=timeout,
         env=env
     )
@@ -52,7 +52,7 @@ def run_python_script(script_path: Path, timeout: int = 120) -> Tuple[int, str, 
         [sys.executable, str(script_path)],
         cwd=PROJECT_ROOT,
         capture_output=True,
-        text=True,
+        text=True, encoding='utf-8', errors='replace',
         timeout=timeout
     )
     return result.returncode, result.stdout, result.stderr
@@ -145,14 +145,14 @@ class TestQuickVerification:
             [sys.executable, "-c", "import tinytorch; print('OK')"],
             cwd=PROJECT_ROOT,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         ).returncode, "", ""
 
         result = subprocess.run(
             [sys.executable, "-c", "import tinytorch; print('OK')"],
             cwd=PROJECT_ROOT,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
         assert result.returncode == 0, f"Cannot import tinytorch: {result.stderr}"
         assert "OK" in result.stdout
@@ -234,7 +234,7 @@ class TestModuleFlow:
 
         # Check progress file still exists and has data
         assert progress_file.exists()
-        data = json.loads(progress_file.read_text())
+        data = json.loads(progress_file.read_text(encoding='utf-8'))
         assert "started_modules" in data
 
     @pytest.mark.module_flow
@@ -333,7 +333,7 @@ class TestFullJourney:
             [sys.executable, "-c", "from tinytorch import Tensor; print('OK')"],
             cwd=PROJECT_ROOT,
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
         # This tests that the package structure is correct
         # If Tensor is not exported, that's a test failure
@@ -357,7 +357,7 @@ print('OK')
 """],
             cwd=PROJECT_ROOT,
             capture_output=True,
-            text=True,
+            text=True, encoding='utf-8', errors='replace',
             timeout=10
         )
         assert result.returncode == 0, (

--- a/tinytorch/tests/environment/test_all_requirements.py
+++ b/tinytorch/tests/environment/test_all_requirements.py
@@ -36,7 +36,7 @@ def parse_requirements_file(filepath: Path) -> List[Tuple[str, Optional[str], Op
     if not filepath.exists():
         return packages
 
-    with open(filepath, 'r') as f:
+    with open(filepath, 'r', encoding='utf-8') as f:
         for line in f:
             line = line.strip()
 
@@ -164,7 +164,7 @@ def check_package_functionality(package_name: str, import_name: str) -> Tuple[bo
             result = subprocess.run(
                 [sys.executable, "-m", "pytest", "--version"],
                 capture_output=True,
-                text=True
+                text=True, encoding='utf-8', errors='replace'
             )
             return result.returncode == 0, "Command available"
 
@@ -172,7 +172,7 @@ def check_package_functionality(package_name: str, import_name: str) -> Tuple[bo
             result = subprocess.run(
                 ["jupyter", "lab", "--version"],
                 capture_output=True,
-                text=True
+                text=True, encoding='utf-8', errors='replace'
             )
             return result.returncode == 0, "Command available"
 
@@ -282,7 +282,7 @@ class TestRequirementsFileValidity:
         """Requirements file must be readable."""
         assert req_file.exists(), f"Requirements file not found: {req_file}"
 
-        content = req_file.read_text()
+        content = req_file.read_text(encoding='utf-8')
         assert len(content) > 0, f"Requirements file is empty: {req_file}"
 
         print(f"✅ Requirements file readable: {req_file}")
@@ -293,7 +293,7 @@ class TestRequirementsFileValidity:
         packages = parse_requirements_file(req_file)
 
         # Should have at least one package (unless it's all comments)
-        lines = req_file.read_text().splitlines()
+        lines = req_file.read_text(encoding='utf-8').splitlines()
         non_comment_lines = [l for l in lines if l.strip() and not l.strip().startswith('#')]
 
         if non_comment_lines:

--- a/tinytorch/tests/environment/test_setup_validation.py
+++ b/tinytorch/tests/environment/test_setup_validation.py
@@ -49,7 +49,7 @@ class TestPythonEnvironment:
         result = subprocess.run(
             [sys.executable, "-m", "pip", "--version"],
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
         assert result.returncode == 0, "pip not available"
         print(f"✅ pip available: {result.stdout.strip()}")
@@ -118,7 +118,7 @@ class TestCoreDependencies:
         result = subprocess.run(
             [sys.executable, "-m", "pytest", "--version"],
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
         assert result.returncode == 0, "pytest not available"
         print(f"✅ pytest available: {result.stdout.strip()}")
@@ -171,7 +171,7 @@ class TestJupyterEnvironment:
         result = subprocess.run(
             ["jupyter", "--version"],
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
         assert result.returncode == 0, "jupyter command not found"
         print(f"✅ jupyter command available:\n{result.stdout.strip()}")
@@ -181,7 +181,7 @@ class TestJupyterEnvironment:
         result = subprocess.run(
             ["jupyter", "lab", "--version"],
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
         assert result.returncode == 0, "jupyter lab command not found"
         print(f"✅ jupyter lab command available: {result.stdout.strip()}")
@@ -191,7 +191,7 @@ class TestJupyterEnvironment:
         result = subprocess.run(
             ["jupyter", "kernelspec", "list"],
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
         assert result.returncode == 0, "Cannot list Jupyter kernels"
         assert "python3" in result.stdout, "Python3 kernel not found"
@@ -328,7 +328,7 @@ class TestSystemResources:
                 result = subprocess.run(
                     ["sysctl", "-n", "machdep.cpu.brand_string"],
                     capture_output=True,
-                    text=True
+                    text=True, encoding='utf-8', errors='replace'
                 )
                 if "Apple" in result.stdout:
                     print("⚠️  Running x86_64 Python on Apple Silicon (Rosetta)")
@@ -345,7 +345,7 @@ class TestGitConfiguration:
         result = subprocess.run(
             ["git", "--version"],
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
         assert result.returncode == 0, "git command not found"
         print(f"✅ Git available: {result.stdout.strip()}")
@@ -355,12 +355,12 @@ class TestGitConfiguration:
         name_result = subprocess.run(
             ["git", "config", "user.name"],
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
         email_result = subprocess.run(
             ["git", "config", "user.email"],
             capture_output=True,
-            text=True
+            text=True, encoding='utf-8', errors='replace'
         )
 
         if name_result.returncode != 0 or email_result.returncode != 0:
@@ -391,7 +391,7 @@ class TestStudentProtection:
         if module_dirs:
             test_file = list(module_dirs[0].glob("*.py"))
             if test_file:
-                content = test_file[0].read_text()
+                content = test_file[0].read_text(encoding='utf-8')
                 assert len(content) > 0, "Cannot read source files"
                 print(f"✅ Source files readable: {test_file[0]}")
 

--- a/tinytorch/tests/integration/test_gradients.py
+++ b/tinytorch/tests/integration/test_gradients.py
@@ -505,7 +505,7 @@ def test_gradient_clipping():
 if __name__ == "__main__":
     # When run directly, use pytest
     import subprocess
-    result = subprocess.run(["pytest", __file__, "-v"], capture_output=True, text=True)
+    result = subprocess.run(["pytest", __file__, "-v"], capture_output=True, text=True, encoding='utf-8', errors='replace')
     print(result.stdout)
     if result.stderr:
         print(result.stderr)

--- a/tinytorch/tests/integration/test_module_05_dense.py
+++ b/tinytorch/tests/integration/test_module_05_dense.py
@@ -169,7 +169,7 @@ if __name__ == "__main__":
     result = subprocess.run(
         [sys.executable, '-m', 'pytest', __file__, '-v', '--tb=short'],
         capture_output=True,
-        text=True
+        text=True, encoding='utf-8', errors='replace'
     )
 
     print(result.stdout)

--- a/tinytorch/tests/integration/test_shapes.py
+++ b/tinytorch/tests/integration/test_shapes.py
@@ -445,7 +445,7 @@ def test_cifar10_cnn_dimensions():
 if __name__ == "__main__":
     # When run directly, use pytest
     import subprocess
-    result = subprocess.run(["pytest", __file__, "-v"], capture_output=True, text=True)
+    result = subprocess.run(["pytest", __file__, "-v"], capture_output=True, text=True, encoding='utf-8', errors='replace')
     print(result.stdout)
     if result.stderr:
         print(result.stderr)

--- a/tinytorch/tests/milestones/milestone_tracker.py
+++ b/tinytorch/tests/milestones/milestone_tracker.py
@@ -66,9 +66,9 @@ class MilestoneTracker:
     def _load_progress(self) -> Dict:
         if self.progress_file.exists():
             try:
-                with open(self.progress_file, "r") as f:
+                with open(self.progress_file, "r", encoding="utf-8") as f:
                     progress = json.load(f)
-            except (json.JSONDecodeError, OSError):
+            except (json.JSONDecodeError, OSError, UnicodeDecodeError):
                 progress = {}
         else:
             progress = {}
@@ -81,16 +81,16 @@ class MilestoneTracker:
         return progress
 
     def _save_progress(self) -> None:
-        with open(self.progress_file, "w") as f:
+        with open(self.progress_file, "w", encoding="utf-8") as f:
             json.dump(self.progress, f, indent=2)
 
     def _load_completed_modules(self) -> List[str]:
         if not self.module_progress_file.exists():
             return []
         try:
-            with open(self.module_progress_file, "r") as f:
+            with open(self.module_progress_file, "r", encoding="utf-8") as f:
                 progress = json.load(f)
-        except (json.JSONDecodeError, OSError):
+        except (json.JSONDecodeError, OSError, UnicodeDecodeError):
             return []
 
         completed = []
@@ -104,12 +104,12 @@ class MilestoneTracker:
         progress = {}
         if self.module_progress_file.exists():
             try:
-                with open(self.module_progress_file, "r") as f:
+                with open(self.module_progress_file, "r", encoding="utf-8") as f:
                     progress = json.load(f)
-            except (json.JSONDecodeError, OSError):
+            except (json.JSONDecodeError, OSError, UnicodeDecodeError):
                 progress = {}
         progress["completed_modules"] = sorted(set(completed_modules))
-        with open(self.module_progress_file, "w") as f:
+        with open(self.module_progress_file, "w", encoding="utf-8") as f:
             json.dump(progress, f, indent=2)
 
     def mark_module_complete(self, module_name: str) -> List[str]:

--- a/tinytorch/tests/milestones/test_milestones_run.py
+++ b/tinytorch/tests/milestones/test_milestones_run.py
@@ -59,7 +59,7 @@ def run_milestone(milestone_id: str, part: int = None, timeout: int = 300) -> tu
         cmd,
         cwd=TINYTORCH_ROOT,
         capture_output=True,
-        text=True,
+        text=True, encoding='utf-8', errors='replace',
         timeout=timeout,
         env=env,
         input="n\nn\nn\n"  # Answer 'n' to any prompts

--- a/tinytorch/tito/__init__.py
+++ b/tinytorch/tito/__init__.py
@@ -12,7 +12,7 @@ def _get_version() -> str:
     try:
         pyproject_path = _Path(__file__).parent.parent / "pyproject.toml"
         if pyproject_path.exists():
-            content = pyproject_path.read_text()
+            content = pyproject_path.read_text(encoding='utf-8')
             for line in content.splitlines():
                 if line.strip().startswith("version"):
                     return line.split("=")[1].strip().strip('"').strip("'")

--- a/tinytorch/tito/commands/benchmark.py
+++ b/tinytorch/tito/commands/benchmark.py
@@ -240,7 +240,7 @@ class BenchmarkCommand(BaseCommand):
         timestamp_str = datetime.now().strftime("%Y%m%d_%H%M%S")
         results_file = benchmark_dir / f"baseline_{timestamp_str}.json"
 
-        with open(results_file, 'w') as f:
+        with open(results_file, 'w', encoding='utf-8') as f:
             json.dump(results, f, indent=2)
 
         console.print(f"\n[green]✅ Results saved to: {results_file}[/green]")
@@ -346,7 +346,7 @@ class BenchmarkCommand(BaseCommand):
         timestamp_str = datetime.now().strftime("%Y%m%d_%H%M%S")
         results_file = benchmark_dir / f"capstone_{timestamp_str}.json"
 
-        with open(results_file, 'w') as f:
+        with open(results_file, 'w', encoding='utf-8') as f:
             json.dump(results, f, indent=2)
 
         # Display results
@@ -393,7 +393,7 @@ class BenchmarkCommand(BaseCommand):
         timestamp_str = datetime.now().strftime("%Y%m%d_%H%M%S")
         results_file = benchmark_dir / f"capstone_simplified_{timestamp_str}.json"
 
-        with open(results_file, 'w') as f:
+        with open(results_file, 'w', encoding='utf-8') as f:
             json.dump(results, f, indent=2)
 
         console.print(f"\n[green]✅ Results saved to: {results_file}[/green]")
@@ -571,7 +571,7 @@ class BenchmarkCommand(BaseCommand):
                 timestamp_str = datetime.now().strftime("%Y%m%d_%H%M%S")
                 submission_file = submission_dir / f"{benchmark_type}_submission_{timestamp_str}.json"
 
-                with open(submission_file, 'w') as f:
+                with open(submission_file, 'w', encoding='utf-8') as f:
                     json.dump(submission, f, indent=2)
 
                 console.print(f"\n[green]✅ Submission prepared: {submission_file}[/green]")
@@ -593,7 +593,7 @@ class BenchmarkCommand(BaseCommand):
         profile_file = Path.home() / ".tinytorch" / "profile.json"
         if profile_file.exists():
             try:
-                with open(profile_file, 'r') as f:
+                with open(profile_file, 'r', encoding='utf-8') as f:
                     return json.load(f)
             except Exception:
                 return None
@@ -617,7 +617,7 @@ class BenchmarkCommand(BaseCommand):
 
         if config_file.exists():
             try:
-                with open(config_file, 'r') as f:
+                with open(config_file, 'r', encoding='utf-8') as f:
                     user_config = json.load(f)
                     # Merge with defaults
                     default_config.update(user_config)
@@ -627,7 +627,7 @@ class BenchmarkCommand(BaseCommand):
 
         # Create default config if it doesn't exist
         config_file.parent.mkdir(parents=True, exist_ok=True)
-        with open(config_file, 'w') as f:
+        with open(config_file, 'w', encoding='utf-8') as f:
             json.dump(default_config, f, indent=2)
 
         return default_config

--- a/tinytorch/tito/commands/dev/preflight.py
+++ b/tinytorch/tito/commands/dev/preflight.py
@@ -229,7 +229,7 @@ class PreflightCommand(BaseCommand):
     def _save_log(self) -> None:
         """Save the log file."""
         try:
-            self.log_file.write_text("\n".join(self.log_lines))
+            self.log_file.write_text("\n".join(self.log_lines), encoding='utf-8')
         except Exception:
             pass  # Don't fail if we can't write log
 

--- a/tinytorch/tito/commands/login.py
+++ b/tinytorch/tito/commands/login.py
@@ -109,9 +109,9 @@ class LoginCommand(BaseCommand):
 
         progress_file = self.config.project_root / ".tito" / "progress.json"
         try:
-            data = json.loads(progress_file.read_text()) if progress_file.exists() else {}
+            data = json.loads(progress_file.read_text(encoding='utf-8')) if progress_file.exists() else {}
             completed = data.get("completed_modules", [])
-        except (json.JSONDecodeError, OSError):
+        except (json.JSONDecodeError, OSError, UnicodeDecodeError):
             completed = []
 
         if not completed:

--- a/tinytorch/tito/commands/milestone.py
+++ b/tinytorch/tito/commands/milestone.py
@@ -236,7 +236,7 @@ def _load_completed_module_numbers() -> set:
         return completed
 
     try:
-        with open(progress_file, 'r') as f:
+        with open(progress_file, 'r', encoding='utf-8') as f:
             progress_data = json.load(f)
     except (json.JSONDecodeError, IOError):
         return completed
@@ -300,7 +300,7 @@ class MilestoneSystem:
         # Try to load main milestones.yml first
         if config_path.exists():
             try:
-                with open(config_path, 'r') as f:
+                with open(config_path, 'r', encoding='utf-8') as f:
                     config = yaml.safe_load(f)
 
                 # Convert to expected format
@@ -321,7 +321,7 @@ class MilestoneSystem:
         for era_path in era_paths:
             if era_path.exists():
                 try:
-                    with open(era_path, 'r') as f:
+                    with open(era_path, 'r', encoding='utf-8') as f:
                         era_config = yaml.safe_load(f)
 
                     if 'milestone' in era_config:
@@ -505,7 +505,7 @@ class MilestoneSystem:
         progress_file = Path(".tito") / "progress.json"
         if progress_file.exists():
             try:
-                with open(progress_file, 'r') as f:
+                with open(progress_file, 'r', encoding='utf-8') as f:
                     progress_data = json.load(f)
                     module_num = _module_progress_to_int(module_name)
                     completed_nums = {
@@ -526,7 +526,7 @@ class MilestoneSystem:
 
         if progress_file.exists():
             try:
-                with open(progress_file, 'r') as f:
+                with open(progress_file, 'r', encoding='utf-8') as f:
                     return json.load(f)
             except (json.JSONDecodeError, IOError):
                 pass
@@ -548,7 +548,7 @@ class MilestoneSystem:
         progress_dir.mkdir(exist_ok=True)
 
         try:
-            with open(progress_file, 'w') as f:
+            with open(progress_file, 'w', encoding='utf-8') as f:
                 json.dump(milestone_data, f, indent=2)
         except IOError:
             pass
@@ -1442,7 +1442,7 @@ class MilestoneCommand(BaseCommand):
                 completed_modules = []
                 if progress_file.exists():
                     try:
-                        with open(progress_file, 'r') as f:
+                        with open(progress_file, 'r', encoding='utf-8') as f:
                             progress_data = json.load(f)
                             for mod in progress_data.get("completed_modules", []):
                                 try:
@@ -1564,7 +1564,7 @@ class MilestoneCommand(BaseCommand):
 
         if progress_file.exists():
             try:
-                with open(progress_file, 'r') as f:
+                with open(progress_file, 'r', encoding='utf-8') as f:
                     return json.load(f)
             except (json.JSONDecodeError, IOError):
                 pass
@@ -1586,7 +1586,7 @@ class MilestoneCommand(BaseCommand):
         progress_dir.mkdir(exist_ok=True)
 
         try:
-            with open(progress_file, 'w') as f:
+            with open(progress_file, 'w', encoding='utf-8') as f:
                 json.dump(milestone_data, f, indent=2)
         except IOError:
             pass

--- a/tinytorch/tito/commands/module/reset.py
+++ b/tinytorch/tito/commands/module/reset.py
@@ -224,7 +224,7 @@ class ModuleResetCommand(BaseCommand):
 
         if progress_file.exists():
             try:
-                with open(progress_file, "r") as f:
+                with open(progress_file, "r", encoding='utf-8') as f:
                     progress = json.load(f)
 
                 # Remove from completed and started modules
@@ -238,7 +238,7 @@ class ModuleResetCommand(BaseCommand):
 
                 progress["last_updated"] = datetime.now().isoformat()
 
-                with open(progress_file, "w") as f:
+                with open(progress_file, "w", encoding='utf-8') as f:
                     json.dump(progress, f, indent=2)
             except Exception as e:
                 console.print(f"[dim]Could not update progress: {e}[/dim]")
@@ -256,7 +256,7 @@ class ModuleResetCommand(BaseCommand):
             "completed_modules": [],
             "last_worked": None,
             "last_updated": datetime.now().isoformat()
-        }, indent=2))
+        }, indent=2), encoding='utf-8')
 
         # Reset milestones
         milestones_file = tito_dir / "milestones.json"
@@ -264,7 +264,7 @@ class ModuleResetCommand(BaseCommand):
             "version": "1.0",
             "completed_milestones": [],
             "completion_dates": {}
-        }, indent=2))
+        }, indent=2), encoding='utf-8')
 
     def run(self, args: Namespace) -> int:
         """Execute the reset command."""

--- a/tinytorch/tito/commands/module/workflow.py
+++ b/tinytorch/tito/commands/module/workflow.py
@@ -1349,7 +1349,7 @@ class ModuleWorkflowCommand(BaseCommand):
         try:
             import json
             if progress_file.exists():
-                with open(progress_file, 'r') as f:
+                with open(progress_file, 'r', encoding='utf-8') as f:
                     return json.load(f)
         except Exception:
             pass
@@ -1373,7 +1373,7 @@ class ModuleWorkflowCommand(BaseCommand):
             from datetime import datetime
             progress['last_updated'] = datetime.now().isoformat()
 
-            with open(progress_file, 'w') as f:
+            with open(progress_file, 'w', encoding='utf-8') as f:
                 json.dump(progress, f, indent=2)
         except Exception as e:
             self.console.print(f"[yellow]⚠️  Could not save progress: {e}[/yellow]")
@@ -1705,7 +1705,7 @@ class ModuleWorkflowCommand(BaseCommand):
         completed_milestones = []
         if milestones_file.exists():
             try:
-                with open(milestones_file, 'r') as f:
+                with open(milestones_file, 'r', encoding='utf-8') as f:
                     data = json.load(f)
                     completed_milestones = data.get("completed_milestones", [])
             except Exception:
@@ -1827,7 +1827,7 @@ class ModuleWorkflowCommand(BaseCommand):
             milestones_file.parent.mkdir(parents=True, exist_ok=True)
             if milestones_file.exists():
                 try:
-                    with open(milestones_file, 'r') as f:
+                    with open(milestones_file, 'r', encoding='utf-8') as f:
                         milestone_progress = json.load(f)
                 except Exception:
                     milestone_progress = {}
@@ -1857,7 +1857,7 @@ class ModuleWorkflowCommand(BaseCommand):
             milestone_progress["total_unlocked"] = len(unlocked)
             milestone_progress.setdefault("achievements", [])
 
-            with open(milestones_file, 'w') as f:
+            with open(milestones_file, 'w', encoding='utf-8') as f:
                 json.dump(milestone_progress, f, indent=2)
 
             for milestone_id, milestone in newly_unlocked:

--- a/tinytorch/tito/commands/package/reset.py
+++ b/tinytorch/tito/commands/package/reset.py
@@ -235,7 +235,7 @@ class ResetCommand(BaseCommand):
             "version": "1.0",
             "completed_modules": [],
             "completion_dates": {}
-        }, indent=2))
+        }, indent=2), encoding='utf-8')
 
         # Reset milestones.json
         milestones_file = tito_dir / "milestones.json"
@@ -243,13 +243,13 @@ class ResetCommand(BaseCommand):
             "version": "1.0",
             "completed_milestones": [],
             "completion_dates": {}
-        }, indent=2))
+        }, indent=2), encoding='utf-8')
 
         # Reset config.json
         config_file = tito_dir / "config.json"
         config_file.write_text(json.dumps({
             "logo_theme": "standard"
-        }, indent=2))
+        }, indent=2), encoding='utf-8')
 
         console.print(Panel(
             "[green]✅ All progress reset![/green]\n\n"
@@ -300,7 +300,7 @@ class ResetCommand(BaseCommand):
             "version": "1.0",
             "completed_modules": [],
             "completion_dates": {}
-        }, indent=2))
+        }, indent=2), encoding='utf-8')
 
         console.print(Panel(
             "[green]✅ Module progress reset![/green]\n\n"
@@ -351,7 +351,7 @@ class ResetCommand(BaseCommand):
             "version": "1.0",
             "completed_milestones": [],
             "completion_dates": {}
-        }, indent=2))
+        }, indent=2), encoding='utf-8')
 
         console.print(Panel(
             "[green]✅ Milestone achievements reset![/green]\n\n"
@@ -395,7 +395,7 @@ class ResetCommand(BaseCommand):
         config_file = tito_dir / "config.json"
         config_file.write_text(json.dumps({
             "logo_theme": "standard"
-        }, indent=2))
+        }, indent=2), encoding='utf-8')
 
         console.print(Panel(
             "[green]✅ Configuration reset to defaults![/green]",

--- a/tinytorch/tito/commands/setup.py
+++ b/tinytorch/tito/commands/setup.py
@@ -365,7 +365,7 @@ class SetupCommand(BaseCommand):
 
         if profile_path.exists():
             import json
-            with open(profile_path, 'r') as f:
+            with open(profile_path, 'r', encoding='utf-8') as f:
                 existing_profile = json.load(f)
 
             if not force:
@@ -400,7 +400,7 @@ class SetupCommand(BaseCommand):
 
         # Save profile
         import json
-        with open(profile_path, 'w') as f:
+        with open(profile_path, 'w', encoding='utf-8') as f:
             json.dump(profile, f, indent=2)
 
         _print_file_update(self.console, profile_path)

--- a/tinytorch/tito/commands/system/health.py
+++ b/tinytorch/tito/commands/system/health.py
@@ -308,7 +308,7 @@ class HealthCommand(BaseCommand):
                     kernel_dir = kernels[kernel_name].get("resource_dir", "")
                     kernel_json = Path(kernel_dir) / "kernel.json"
                     if kernel_json.exists():
-                        spec = json.loads(kernel_json.read_text())
+                        spec = json.loads(kernel_json.read_text(encoding='utf-8'))
                         argv = spec.get("argv", [])
                         if argv:
                             return argv[0]  # First element is the Python path

--- a/tinytorch/tito/core/auth.py
+++ b/tinytorch/tito/core/auth.py
@@ -248,7 +248,7 @@ class LocalAuthServer(http.server.HTTPServer):
 def _is_wsl() -> bool:
     """Check if running in WSL environment."""
     try:
-        with open('/proc/version', 'r') as f:
+        with open('/proc/version', 'r', encoding='utf-8') as f:
             return 'microsoft' in f.read().lower()
     except:
         return False

--- a/tinytorch/tito/core/browser.py
+++ b/tinytorch/tito/core/browser.py
@@ -13,7 +13,7 @@ from rich.panel import Panel
 def is_wsl() -> bool:
     """Check if running in WSL (Windows Subsystem for Linux) environment."""
     try:
-        with open('/proc/version', 'r') as f:
+        with open('/proc/version', 'r', encoding='utf-8') as f:
             return 'microsoft' in f.read().lower()
     except:
         return False

--- a/tinytorch/tito/core/status_analyzer.py
+++ b/tinytorch/tito/core/status_analyzer.py
@@ -263,13 +263,13 @@ class TinyTorchStatusAnalyzer:
             # Test if module can be imported
             try:
                 # Create a temporary file to test import
-                with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as temp_file:
+                with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False, encoding='utf-8') as temp_file:
                     # Write a minimal test to check if the module can be imported
                     test_code = f"""
 import sys
 sys.path.insert(0, '{module_path}')
 try:
-    exec(open('{dev_file}').read())
+    exec(open('{dev_file}', encoding='utf-8').read())
     print("SUCCESS: Module imports and runs")
 except Exception as e:
     print(f"ERROR: {{e}}")

--- a/tinytorch/tito/core/virtual_env_manager.py
+++ b/tinytorch/tito/core/virtual_env_manager.py
@@ -22,7 +22,8 @@ def get_venv_path() -> Path:
 
     if Path(CONFIG_FILE).exists():
         try:
-            cfg = json.load(open(CONFIG_FILE))
+            with open(CONFIG_FILE, encoding='utf-8') as f:
+                cfg = json.load(f)
             return Path(cfg.get("venv_path", DEFAULT_VENV)).expanduser().resolve()
         except Exception:
             pass

--- a/tinytorch/tito/main.py
+++ b/tinytorch/tito/main.py
@@ -63,7 +63,7 @@ def _get_version() -> str:
         tito_dir = Path(__file__).parent
         pyproject_path = tito_dir.parent / "pyproject.toml"
         if pyproject_path.exists():
-            content = pyproject_path.read_text()
+            content = pyproject_path.read_text(encoding='utf-8')
             for line in content.splitlines():
                 if line.strip().startswith("version"):
                     # Parse: version = "0.1.4"


### PR DESCRIPTION
## What

Supersedes #2088 (closing it in favor of this PR, which is a superset). Fixes the Windows cp1252-default-encoding problem everywhere it appears in `tito/`, not just in tests: every `subprocess.run(..., text=True)` call, and every plain `open()` / `read_text()` / `write_text()` call, that was missing an explicit `encoding=`.

## Root cause

On Windows, `subprocess.run(..., text=True)` without an explicit `encoding=` decodes the child process's stdout/stderr using `locale.getpreferredencoding()`, which is cp1252. `open()`/`read_text()`/`write_text()` without `encoding=` behave the same way. `tito`'s own CLI output (via `rich`) and various progress/config JSON files can contain characters outside cp1252, so reads/writes/subprocess captures crash with an unhandled `UnicodeDecodeError` or `UnicodeEncodeError`. On Linux/Mac this is a no-op fix, since the default encoding there is already UTF-8.

## Scope

**Tests** (`tests/cli`, `tests/environment`, `tests/e2e`, `tests/integration`, `tests/milestones`): all 42 `subprocess.run(..., text=True)` call sites, plus a handful of `read_text()`/`open()` calls in the same files. Also extended `tests/milestones/milestone_tracker.py`'s `except` clauses to catch `UnicodeDecodeError`.

**`tito/` source** (the CLI itself, not just its tests): `subprocess.run`/`Popen` calls here were already correctly encoded. The gap was in plain file I/O:
- `benchmark.py`: results/config/profile file reads and writes
- `milestone.py`: progress and config file reads/writes (9 sites)
- `commands/module/reset.py`, `commands/package/reset.py`: progress/milestone reset writes
- `commands/module/workflow.py`: progress and milestones file reads/writes
- `commands/setup.py`: user profile read/write
- `commands/dev/preflight.py`: preflight log file write
- `commands/system/health.py`: Jupyter kernelspec JSON read
- `main.py`, `__init__.py`: `pyproject.toml` version parsing
- `commands/login.py`: post-sync progress check (also extended its `except` to catch `UnicodeDecodeError`)
- `core/virtual_env_manager.py`: venv config lookup
- `core/status_analyzer.py`: the dynamically generated import-check script, both the temp file write and the `exec(open(...).read())` call that runs inside the spawned subprocess
- `core/auth.py`, `core/browser.py`: `/proc/version` reads (Linux/WSL-only, fixed for consistency)

## What's intentionally NOT in scope

A handful of already-open PRs from earlier this session (#2073 auth.py, #2074 login.py, #2070 workflow.py, etc.) fix a *different*, related bug: `json.load()` succeeding on syntactically-valid-but-wrong-type JSON and crashing downstream with `AttributeError`. This PR only adds `encoding='utf-8'` and (where an existing broad `except` was already present) extends it to catch `UnicodeDecodeError`; it does not add `isinstance` validation or otherwise change control flow. There will be a small amount of surface overlap with those PRs on `login.py` (both touch the same read line for different reasons) that the maintainer can trivially resolve on merge.

## Testing

- `tests/cli`: 92 passed, 1 skipped (was 13 failed, 79 passed)
- `tests/environment`: 58 passed, 1 failed. That one remaining failure (`test_pip_available`) is unrelated: this dev venv has no `pip` module installed, nothing to do with encoding.
- Full suite excluding `tests/cli`/`tests/e2e`/`tests/environment`/`tests/milestones/test_milestones_run.py` (which still have a separate, unrelated `WinError 193` subprocess-executable-resolution issue not addressed here): 762 passed, 35 skipped, 0 new failures. The only failure seen was the same pre-existing order-dependent flake (`test_deep_network_gradient_chain`) already known from earlier in this testing effort, confirmed unrelated by rerunning `tests/integration` alone (all passing).
- All modified files verified with `py_compile`.
