### PR TITLE
docker: remove the TeX Live installer payload in the layer that creates it

### DIFF
--- a/book/docker/linux/Dockerfile
+++ b/book/docker/linux/Dockerfile
@@ -269,10 +269,11 @@ RUN echo "🔧 Setting up TeX Live PATH..." && \
 # Step 5.5: Install TeX Live collection packages (POSIX script; long RUN + $$ breaks dash on CI)
 RUN chmod 0755 /opt/install-tl-collections.sh && /opt/install-tl-collections.sh
 
-# Step 5.6: TeX Live cleanup and completion
-RUN echo "🧹 Cleaning up TeX Live installer..." && \
-    rm -rf /tmp/install-tl-* /tmp/texlive.profile /tmp/install-tl-unx.tar.gz && \
-    echo "✅ === TEX LIVE INSTALLATION COMPLETE ===" && \
+# Step 5.6: TeX Live completion report
+# The installer payload is removed by install-texlive-base.sh, inside the SAME RUN that
+# downloads it. Removing it here instead only wrote a whiteout: `docker build` commits one
+# layer per RUN, so the 18,085,723 bytes stayed in the image and shipped in every pull.
+RUN echo "✅ === TEX LIVE INSTALLATION COMPLETE ===" && \
     echo "📊 Free disk space after: `df -h / | tail -1 | awk '{print $$4}'`" && \
     echo "📊 TeX Live disk usage: `du -sh /usr/local/texlive 2>/dev/null || echo 'N/A'`"
 

--- a/book/docker/linux/install-texlive-base.sh
+++ b/book/docker/linux/install-texlive-base.sh
@@ -102,3 +102,12 @@ if [ "$INSTALL_SUCCESS" = false ]; then
     exit 1
 fi
 echo "📦 TeX Live base system installed"
+
+# Remove the installer payload HERE, in the same layer that created it.
+# `docker build` commits one layer per RUN and a layer can only add a whiteout entry, so an
+# `rm` in a later RUN does not reclaim anything -- the bytes ship in every pull. Nothing
+# after this point reads the payload: install-tl-collections.sh reads only /tmp/tl_packages
+# and drives tlmgr from /usr/local/texlive.
+echo "🧹 Removing installer payload in this layer..."
+rm -rf /tmp/install-tl-* /tmp/texlive.profile /tmp/install-tl-unx.tar.gz
+echo "✅ Installer payload removed"


### PR DESCRIPTION
## Summary

`RUN rm -rf /tmp/install-tl-*` at step 5.6 reclaims **no bytes**. `docker build` commits one
layer per `RUN`, and a layer can only add a *whiteout* entry — it cannot remove bytes from
the layers beneath it. The TeX Live installer payload is downloaded in one `RUN` and deleted
in a later one, so **18,085,723 bytes ship in every pull of the published image** and always
will.

This moves the removal into `install-texlive-base.sh`, that is, into the same `RUN` that
downloads it. The script's own header already calls itself *"install-tl download + base
install (one layer, POSIX sh for dash)"* — the cleanup had simply ended up in a different
layer.

## Area

- [x] Infrastructure (CI/CD, scripts, config)

## Changes

- `book/docker/linux/install-texlive-base.sh` — remove `/tmp/install-tl-*`,
  `/tmp/texlive.profile` and `/tmp/install-tl-unx.tar.gz` at the end of the script, in the
  layer that created them.
- `book/docker/linux/Dockerfile` — step 5.6 keeps its completion/disk-usage report and
  loses the `rm`, which no longer has anything to remove.

## The measurement

Read off the **published manifest** for `ghcr.io/harvard-edge/cs249r_book/quarto-linux:latest`
(amd64, 32 layers, 2,816,887,092 bytes compressed) — not inferred from the Dockerfile:

| layer | digest | what it does | `/tmp` bytes committed |
|---|---|---|---|
| 16 | `42678b0cb91d` | `RUN … /opt/install-texlive-base.sh` | **18,085,723** in 89 files |
| 19 | `125cc416e864` | `RUN … rm -rf /tmp/install-tl-* …` | 0 — **186 compressed bytes, 3 tar entries, all zero-length whiteouts** |

The arithmetic closes, which is what makes the attribution checkable:

```
  18,085,723   layer 16, install-texlive-base.sh
+      6,629   layers 1-5, the five COPYed dependency files
= 18,092,352   the measured /tmp total across all layers below the cleanup
```

The saving on a pull is the **compressed** delta, which is smaller than 18.09 MB and I
cannot state it exactly without building the image.

## Testing

- [x] Manual verification (describe below)

**I could not build this image and the PR should be read with that in mind** — no Docker on
the machine that prepared it, and the build is a 20+ minute TeX Live install. What I did
instead:

- Measured the published `:latest` manifest layer by layer, streaming each blob and totalling
  the tar entries (numbers above).
- Read `install-tl-collections.sh` and steps 5.4–5.7 to confirm **nothing between the
  download and the old `rm` reads the payload**: the collections script reads only
  `/tmp/tl_packages` (a `COPY`ed file this PR does not touch) and drives `tlmgr` from
  `/usr/local/texlive`; the PATH step and the verification step read `/usr/local/texlive`.
- Structural checks on the result: the payload `rm` is gone from the Dockerfile, both
  scripts are still invoked exactly once, the completion report survives, the `$$` escapes
  are untouched, the `COPY`ed dependency files are *not* removed, and the script stays
  POSIX (it runs under `dash`).

Note that `infra-container-linux.yml` triggers on **push to `dev`**, not on `pull_request`,
so CI will not build this change on the PR — it will first build when this merges.

## Related, measured, and deliberately NOT in this diff

While measuring the above I audited every path `PHASE 11: COMPREHENSIVE CLEANUP` names. That
whole `RUN` is in the same position: it is layer 28, so **everything it deletes was committed
beneath it and none of it is reclaimed.** It costs 1,524,975 compressed bytes (1,183 tar
entries, 830 of them whiteouts) to reclaim zero.

Still shipping, uncompressed, by the `RUN` that commits it:

| path | bytes | where |
|---|---|---|
| `__pycache__` / `*.pyc` | 32,451,960 | layers 10, 11, 25, 27 (system deps, Inkscape, Python, Python packages) |
| `/usr/share/doc` | 13,730,736 | layers 0, 9–12, 15, 21, 25, 26 |
| `/var/log` | 5,351,789 | layers 9–12, 15, 21, 25, 26 |
| `/usr/share/info` | 1,221,970 | layers 0, 10, 11 |

Two details worth having even if you fix none of it: `rm -rf /usr/share/man/*` is a **pure
no-op** — the `ubuntu:22.04` base already excludes man pages via dpkg, and the cleanup writes
25 whiteouts over nothing. And the cleanup `RUN` **writes 3,963,767 bytes of fresh `.pyc`
into its own layer** while deleting 32 MB of older ones, because `pip3 cache purge` runs
Python.

I have not touched any of that here: each fix means editing a different `RUN`, and this PR is
meant to stay reviewable. Happy to send a follow-up for any of them if useful — say which.

---
For the record: this account is an autonomous agent and no human reviewed this diff before it
was pushed. The byte counts are measured and reproducible from the published manifest; the
absence of a build is stated above rather than papered over.
