### PR TITLE
Link the BERT paper in Transformer further reading

### DIFF
--- a/tinytorch/milestones/05_2017_transformer/README.md
+++ b/tinytorch/milestones/05_2017_transformer/README.md
@@ -91,10 +91,10 @@ tito milestone run 05
 
 ## Further Reading
 
-- **The Paper**: Vaswani et al. (2017). "Attention Is All You Need"
+- **The Paper**: Vaswani et al. (2017). ["Attention Is All You Need"](https://arxiv.org/abs/1706.03762)
 - **Illustrated Transformer**: http://jalammar.github.io/illustrated-transformer/
-- **GPT Evolution**: Radford et al. (2018, 2019, 2020). GPT-1/2/3 papers
-- **BERT**: Devlin et al. (2018). ["BERT: Pre-training of Deep Bidirectional Transformers"](https://webeditions.page/works/bert-pre-training/) ([original paper](https://aclanthology.org/N19-1423/))
+- **GPT Evolution**: Radford et al. [GPT-1 (2018)](https://cdn.openai.com/research-covers/language-unsupervised/language_understanding_paper.pdf), [GPT-2 (2019)](https://cdn.openai.com/better-language-models/language_models_are_unsupervised_multitask_learners.pdf), and [GPT-3 (2020)](https://arxiv.org/abs/2005.14165)
+- **BERT**: Devlin et al. (2018). ["BERT: Pre-training of Deep Bidirectional Transformers"](https://arxiv.org/abs/1810.04805) ([read online](https://webeditions.page/works/bert-pre-training/))
 
 ## Achievement Unlocked
 

--- a/tinytorch/milestones/05_2017_transformer/README.md
+++ b/tinytorch/milestones/05_2017_transformer/README.md
@@ -94,7 +94,7 @@ tito milestone run 05
 - **The Paper**: Vaswani et al. (2017). "Attention Is All You Need"
 - **Illustrated Transformer**: http://jalammar.github.io/illustrated-transformer/
 - **GPT Evolution**: Radford et al. (2018, 2019, 2020). GPT-1/2/3 papers
-- **BERT**: Devlin et al. (2018). "BERT: Pre-training of Deep Bidirectional Transformers"
+- **BERT**: Devlin et al. (2018). ["BERT: Pre-training of Deep Bidirectional Transformers"](https://webeditions.page/works/bert-pre-training/) ([original paper](https://aclanthology.org/N19-1423/))
 
 ## Achievement Unlocked
 


### PR DESCRIPTION
## Summary

Completes the Transformer milestone's Further Reading block by linking each paper to its official source, while keeping the existing Illustrated Transformer resource. BERT also includes a readable Web Editions companion.

## Area

- [ ] Book (textbook content, figures, exercises)
- [x] TinyTorch (modules, tests, milestones)
- [ ] StaffML (interview questions, challenges)
- [ ] Kits (hardware labs)
- [ ] Infrastructure (CI/CD, scripts, config)

## Changes

- Link Attention Is All You Need and BERT to their arXiv records.
- Link GPT-1 and GPT-2 to the official OpenAI papers and GPT-3 to arXiv.
- Keep the BERT Web Editions reader as an optional read-online companion.

## Testing

- [ ] Rendered the book locally (`quarto render`)
- [ ] Ran tests (`pytest tests/`)
- [ ] Ran `tito module test NN` for affected module(s)
- [x] Manual verification (checked every URL and reviewed the Markdown diff)

## Related Issues

None.

---
*By submitting this PR, you agree to release your contribution under the project's license.*
